### PR TITLE
feat: add relay type

### DIFF
--- a/schemas/types.json
+++ b/schemas/types.json
@@ -8,7 +8,7 @@
     "SDKType" : {
       "type" : "string",
        "description" : "The primary deployment strategy for a LaunchDarkly SDK",
-       "enum" : ["client-side", "server-side", "edge"]
+       "enum" : ["client-side", "server-side", "edge", "relay"]
     }
   },
   "patternProperties" : {


### PR DESCRIPTION
Relay Proxy is a bit of an odd duck, since it's not an SDK, but it is managed by SDK team and we'd like to track its releases automatically in Docs.

I'm adding metadata for it, and a new "relay" type. It's pretty meaningless for now, but it'll allow us to import the metadata into Gatsby.