### PR TITLE
ci: verify releases schema

### DIFF
--- a/schemas/releases.json
+++ b/schemas/releases.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://launchdarkly.com/sdk-meta/releases.json",
+  "title": "SDK Releases",
+  "description": "List of SDK Releases",
+  "type": "object",
+  "$defs": {
+    "SDKReleases" : {
+      "type": "array",
+      "description": "A collection of releases",
+      "items" : {
+        "type" : "object",
+        "required" : ["major", "minor", "date", "eol"],
+        "properties": {
+          "major": {
+            "description": "Major version",
+            "type" : "integer",
+            "minimum" : 0
+          },
+          "minor": {
+            "description": "Minor version",
+            "type" : "integer",
+            "minimum" : 0
+          },
+          "date": {
+            "description": "Release date",
+            "type" : "string",
+            "format": "date-time"
+          },
+          "eol": {
+            "description": "End of life date",
+            "format": "date",
+            "anyOf": [
+              { "type": "string" },
+              { "type": "null" }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "patternProperties" : {
+    "^[a-z-]+$" : {
+      "$ref" : "#/$defs/SDKReleases"
+    }
+  }
+}

--- a/schemas/releases.json
+++ b/schemas/releases.json
@@ -29,9 +29,8 @@
           },
           "eol": {
             "description": "End of life date",
-            "format": "date",
             "anyOf": [
-              { "type": "string" },
+              { "type": "string", "format": "date" },
               { "type": "null" }
             ]
           }

--- a/scripts/ci/check-json-schemas.sh
+++ b/scripts/ci/check-json-schemas.sh
@@ -24,3 +24,4 @@ runTest ./schemas/types.json ./products/types.json
 runTest ./schemas/names.json ./products/names.json
 runTest ./schemas/languages.json ./products/languages.json
 runTest ./schemas/repos.json ./products/repos.json
+runTest ./schemas/releases.json ./products/releases.json

--- a/scripts/ci/check-json-schemas.sh
+++ b/scripts/ci/check-json-schemas.sh
@@ -17,7 +17,7 @@ function runTest() {
         fi
     done
 
-    npx --package=ajv-cli --package=ajv-formats ajv validate --spec=draft2020 -s "$primary" "${ajvFlags[@]}" -d "$2"
+    npx --package=ajv-cli --package=ajv-formats ajv validate -c ajv-formats --spec=draft2020 -s "$primary" "${ajvFlags[@]}" -d "$2"
 }
 
 runTest ./schemas/types.json ./products/types.json


### PR DESCRIPTION
Adds a schema for the releases data product. This way we can ensure the generated product doesn't unexpectedly break without CI failing. 