### PR TITLE
fix: don't filter out sdk-examples repos

### DIFF
--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -3,7 +3,7 @@
 gh api --paginate graphql -f query='{
   search(
     type: REPOSITORY
-    query: """topic:launchdarkly-sdk -topic:launchdarkly-sdk-component -topic:sdk-examples org:launchdarkly is:public"""
+    query: """topic:launchdarkly-sdk -topic:launchdarkly-sdk-component -topic:examples org:launchdarkly is:public"""
     first: 100
   ) {
     repositoryCount


### PR DESCRIPTION
I added `sdk-examples` to Lua because it contains examples. But the crawler filters these out (to avoid unecessary work.)

Turns out most standalone examples also have the `examples` tag, which could be used instead (and allow Lua to showup.)