### PR TITLE
feat: crawler generates PRs with diff in the body

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -33,6 +33,7 @@ jobs:
             echo "Changes detected!"
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "$changes"
+            { echo 'changes<<END'; echo "$changes"; echo 'END'; } >> $GITHUB_OUTPUT
           fi
 
       - name: Update data
@@ -60,5 +61,8 @@ jobs:
           title: "feat: update SDK metadata"
           commit-message: "feat: update SDK metadata"
           body: |
-            SDK metadata has changed. This PR updates the existing `metadata.sqlite3` database and associated
-            data products. 
+            This PR contains updates to SDK metadata.
+            It includes the following changes:
+            ```
+            ${{ steps.diff.outputs.changes }}
+            ``` 


### PR DESCRIPTION
The diff step already generates a human readable SQL diff. This ferries it along to the "create a PR step" and outputs it in the PR body. 

Now we can tell what is happening with a glance. 