### PR TITLE
ci: add id-token permission to manual-publish-npm.yml

### DIFF
--- a/.github/workflows/manual-publish-npm.yml
+++ b/.github/workflows/manual-publish-npm.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to obtain release secrets
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ci


### PR DESCRIPTION
https://github.com/launchdarkly/sdk-meta/actions/runs/11600051994