### PR TITLE
fix: ensure api-js changes are added to crawl PRs

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -58,6 +58,7 @@ jobs:
             ${{ env.METADATA_DIR }}
             products
             api/sdkmeta/data
+            api-js/src/data
           branch: "metadata-update"
           title: "fix(metadata): ingest new data and regenerate products"
           commit-message: "fix(metadata): ingest new data and regenerate products"


### PR DESCRIPTION
Noticed the latest auto-crawl didn't have any changes for the newly added `api-js`. That is because I forgot to add it to the commit created by `create-pull-request`. 

