### PR TITLE
chore: combine release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "include-component-in-tag" : true,
-  "bootstrap-sha": "b74079090a41680641db4599ec1d9584a0b1b982",
   "bump-minor-pre-major": true,
   "packages" : {
     "api" : {


### PR DESCRIPTION
Since both `api` and `api-js` will be modified at the same time by the Crawl script, we should just have them be combined into one PR.