### PR TITLE
ci: pin typescript dependency to 5.6.3

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Build JS API
       shell: bash
       run: |
-        cd api-js && npm install && npx publint
+        cd api-js && npm install && npx publint && npx --yes @arethetypeswrong/cli --pack .
 
     - name: Test JS API
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 20.18.0
+        node-version: 20.x
         registry-url: 'https://registry.npmjs.org'
 
     - name: Build JS API

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 20.18.0
         registry-url: 'https://registry.npmjs.org'
 
     - name: Build JS API

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "tsup": "8.3.4",
+    "tsup": "^8.3.5",
     "typescript": "5.6.3"
   },
   "type": "module",

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -14,8 +14,8 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@types/jest": "29.5.14",
-    "jest": "29.7.0",
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
     "ts-jest": "29.2.5",
     "tsup": "8.3.4",
     "typescript": "5.6.3"

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
-    "ts-jest": "29.2.5",
+    "ts-jest": "^29.2.5",
     "tsup": "8.3.4",
     "typescript": "5.6.3"
   },

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "tsup": "^8.3.5",
+    "tsup": "8.3.4",
     "typescript": "^5.6.3"
   },
   "type": "module",

--- a/api-js/package.json
+++ b/api-js/package.json
@@ -14,11 +14,11 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
+    "@types/jest": "29.5.14",
+    "jest": "29.7.0",
+    "ts-jest": "29.2.5",
     "tsup": "8.3.4",
-    "typescript": "^5.6.3"
+    "typescript": "5.6.3"
   },
   "type": "module",
   "main": "./dist/SDKMeta.cjs",


### PR DESCRIPTION
This is a temporary measure to restore CI builds for the JS API. It appears that the release related to https://github.com/microsoft/TypeScript/pull/60019 surfaced an issue in the way we're importing JSON files into the SDK. Despite it being a minor release, it was a breaking change for us.

But, I can't actually seem to fix it at the moment. Hopefully a subsequent release will allow us to do so. I'm not 100% following the conversation but it looks like a fix will be cherrypicked to Typescript 5.7: https://github.com/microsoft/TypeScript/pull/60673