### PR TITLE
fix: Deterministic repository ordering.

### DIFF
--- a/tool/cmd/ingest/main.go
+++ b/tool/cmd/ingest/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"time"
 
 	"github.com/launchdarkly/sdk-meta/tool/lib/releases"
@@ -184,9 +185,16 @@ func run(args *args) error {
 	}
 	defer tx.Rollback()
 
-	for sdkId, metadata := range metadata {
+	// Sort SDK IDs for consistent iteration order
+	sdkIds := make([]string, 0, len(metadata))
+	for sdkId := range metadata {
+		sdkIds = append(sdkIds, sdkId)
+	}
+	sort.Strings(sdkIds)
+
+	for _, sdkId := range sdkIds {
 		for column, insert := range inserters {
-			if err := insert(tx, sdkId, metadata); err != nil {
+			if err := insert(tx, sdkId, metadata[sdkId]); err != nil {
 				return fmt.Errorf("insert %s for %s: %v", column, sdkId, err)
 			}
 		}


### PR DESCRIPTION
This isn't ideal, but there isn't a primary key for userAgents and wrappers. Which means the primary key is the row id. The row IDs are non-detrministic if we don't iterate through the SDK metadata deterministically.

I would still like to research a better way. 

This change till prevent the constant changes in the diff, but will have changes when we add repos. 