### PR TITLE
fix: gh search hard limits to 1000 releases

### DIFF
--- a/tool/cmd/ingest/main.go
+++ b/tool/cmd/ingest/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/launchdarkly/sdk-meta/tool/lib/releases"
 	_ "github.com/mattn/go-sqlite3"
-	gh "github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
 
@@ -34,6 +33,7 @@ type metadataV1 struct {
 		TagPrefixes []string `json:"tag-prefixes"`
 	} `json:"releases"`
 }
+
 func (m *metadataV1) effectivePrefixes() []string {
 	var prefixes []string
 	prefixes = append(prefixes, m.Releases.TagPrefixes...)
@@ -170,9 +170,8 @@ func run(args *args) error {
 		src := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
 		)
-		httpClient := oauth2.NewClient(context.Background(), src)
+		client := oauth2.NewClient(context.Background(), src)
 
-		client := gh.NewClient(httpClient)
 		releaseCache := make(map[string][]releases.Raw)
 
 		inserters["releases"] = func(tx *sql.Tx, sdkId string, metadata *metadataV1) error {

--- a/tool/go.mod
+++ b/tool/go.mod
@@ -5,7 +5,6 @@ go 1.23.0
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/mattn/go-sqlite3 v1.14.22
-	github.com/shurcooL/githubv4 v0.0.0-20240120211514-18a1ae0e79dc
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.27.0
 )
@@ -13,6 +12,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tool/go.sum
+++ b/tool/go.sum
@@ -8,10 +8,6 @@ github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/shurcooL/githubv4 v0.0.0-20240120211514-18a1ae0e79dc h1:vH0NQbIDk+mJLvBliNGfcQgUmhlniWBDXC79oRxfZA0=
-github.com/shurcooL/githubv4 v0.0.0-20240120211514-18a1ae0e79dc/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
-github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
-github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=

--- a/tool/lib/releases/releases.go
+++ b/tool/lib/releases/releases.go
@@ -1,24 +1,24 @@
 package releases
 
 import (
-	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	gh "github.com/shurcooL/githubv4"
 )
 
 // How long we support the latest SDK version.
 const supportWindowYears = 1
 
-// Raw is the raw tag data returned from the github GraphQL releases query.
+// Raw is the raw tag data returned from the GitHub releases API.
 type Raw struct {
-	Tag     string `graphql:"tagName"`
-	Date    string `graphql:"publishedAt"`
-	IsDraft bool   `graphql:"isDraft"`
+	Tag     string
+	Date    string
+	IsDraft bool
 }
 
 // Parsed is the post-processed version of a Raw structure, with the version extracted and date
@@ -64,47 +64,52 @@ func (r WithEOL) MaybeEOL() *string {
 	return &formatted
 }
 
-type releasesQuery struct {
-	Repository struct {
-		Releases struct {
-			Nodes    []Raw
-			PageInfo struct {
-				EndCursor   gh.String
-				HasNextPage bool
-			}
-		} `graphql:"releases(first: 100, after: $cursor)"`
-	} `graphql:"repository(owner: $org, name: $repo)"`
+type restRelease struct {
+	TagName     string `json:"tag_name"`
+	PublishedAt string `json:"published_at"`
+	Draft       bool   `json:"draft"`
 }
 
-func Query(client *gh.Client,
-	repoPath string) ([]Raw, error) {
+func Query(client *http.Client, repoPath string) ([]Raw, error) {
 	parts := strings.Split(repoPath, "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid repo path: %s", repoPath)
 	}
 
-	org := parts[0]
-	repo := parts[1]
-
-	variables := map[string]interface{}{
-		"org":    gh.String(org),
-		"repo":   gh.String(repo),
-		"cursor": (*gh.String)(nil),
-	}
-
 	var releases []Raw
 
-	var query releasesQuery
-	for {
-		err := client.Query(context.Background(), &query, variables)
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=100&page=%d",
+			parts[0], parts[1], page)
+
+		resp, err := client.Get(url)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("fetching releases for %s: %w", repoPath, err)
 		}
-		releases = append(releases, query.Repository.Releases.Nodes...)
-		if !query.Repository.Releases.PageInfo.HasNextPage {
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("fetching releases for %s: HTTP %d", repoPath, resp.StatusCode)
+		}
+
+		var batch []restRelease
+		err = json.NewDecoder(resp.Body).Decode(&batch)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("decoding releases for %s: %w", repoPath, err)
+		}
+
+		if len(batch) == 0 {
 			break
 		}
-		variables["cursor"] = gh.NewString(query.Repository.Releases.PageInfo.EndCursor)
+
+		for _, r := range batch {
+			releases = append(releases, Raw{
+				Tag:     r.TagName,
+				Date:    r.PublishedAt,
+				IsDraft: r.Draft,
+			})
+		}
 	}
 
 	return releases, nil


### PR DESCRIPTION
This PR will:
- convert gh api graphql call to calling the gh api `/release` endpoint to fetch all releases
- remove the external `gh` go module in favor of builtin `http`


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/sdk-meta/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release data is fetched from GitHub (GraphQL to paginated REST), which can affect completeness and error handling of ingested release metadata; main risk is behavior differences/rate limiting rather than security.
> 
> **Overview**
> Fixes release ingestion to avoid GitHub GraphQL release query limits by switching `releases.Query` to call the paginated GitHub REST `GET /repos/{org}/{repo}/releases` endpoint until exhaustion.
> 
> Removes the `githubv4`/`graphql` dependencies and updates `ingest` to pass the OAuth2 `http.Client` directly into the new REST-based query implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e3644063c1322aaa2694269a90a759906d7b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->