### PR TITLE
fix: Skip goreleaser tag-validation step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -139,12 +139,18 @@ jobs:
       # goreleaser builds binaries + cosign-signs them into ./dist. It does
       # NOT touch GitHub releases (release.disable: true in the goreleaser
       # config).
+      #
+      # `--skip=validate` is required because goreleaser checks that
+      # `GORELEASER_CURRENT_TAG` (here `v0.1.0`) is a real git tag pointing
+      # at HEAD — but the actual tag pushed is `snippets/v0.1.0`. Validate
+      # also covers a dirty-worktree check, which is moot in CI on a
+      # fresh checkout.
       - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           distribution: goreleaser
           version: '~> v2'
           workdir: snippets
-          args: release --clean
+          args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ env.SEMVER_TAG }}


### PR DESCRIPTION
## Summary

The `snippets/v0.1.0` release in run [25187469780](https://github.com/launchdarkly/sdk-meta/actions/runs/25187469780) failed in goreleaser:

```
release failed after 0s   error=git tag v0.1.0 was not made against commit db90b9fc97a7ffa096c78fe522b173a957730ca6
```

Even when `GORELEASER_CURRENT_TAG=v0.1.0` is set, goreleaser still does a `git rev-parse v0.1.0` and asserts it equals HEAD. Since the actual git tag at HEAD is `snippets/v0.1.0` (not `v0.1.0`), the assertion fails. `--skip=validate` bypasses this check (and the dirty-worktree check, which is irrelevant in CI on a fresh checkout). Build, archive, sign, and checksum steps still run.

## Recovery for the orphaned v0.1.0 draft

The `snippets/v0.1.0` draft GitHub Release and `snippets/v0.1.0` git tag both already exist (created before the goreleaser failure). Two options after this lands:

1. **Bump-and-ship**: delete the orphan draft + tag, push a `fix(snippets): ...` commit, let release-please open a v0.1.1 rollup, merge it. Cleanest, accepts that v0.1.0 is a phantom.
2. **Re-cut v0.1.0 manually**: keep the tag, run goreleaser locally at the tag's SHA, `gh release upload` artifacts onto the existing draft, then `gh release edit snippets/v0.1.0 --draft=false`. Preserves the version number.

## Test plan

- [ ] Merge → next snippet release fires goreleaser with `--skip=validate`
- [ ] Confirm artifacts (tar.gz + sig + pem + checksums.txt + sigs) upload to the draft, then the release flips to non-draft

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it alters the CI release process by bypassing GoReleaser’s validation checks, which could allow mis-tagged releases if the tag/ref inputs are wrong.
> 
> **Overview**
> Fixes the `snippets` release workflow by running GoReleaser with `--skip=validate` so releases using prefixed tags like `snippets/vX.Y.Z` don’t fail GoReleaser’s tag-at-HEAD validation.
> 
> Adds inline documentation explaining why validation is skipped (prefixed tag vs `GORELEASER_CURRENT_TAG` and CI dirty-worktree check).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba746ab4e2ce0b8158b32157857306f880b2e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->