### PR TITLE
feat(snippets): ld-docs render target + scaffold-based validation (python-server-sdk slice)

### DIFF
--- a/snippets/cmd/snippets/main.go
+++ b/snippets/cmd/snippets/main.go
@@ -53,12 +53,13 @@ usage:
       a marker's hash does not match its current region's content. Never
       writes; never executes any snippet code.
 
-  snippets validate --sdk=<sdk-id> [--sdks=./sdks] [--validators=./validators]
+  snippets validate --sdk=<sdk-id> [--snippet=<id>] [--sdks=./sdks] [--validators=./validators]
       Builds the SDK's per-language validator (Docker image or native harness),
       stages each runnable snippet with concrete input values, and runs it
       against a real LaunchDarkly environment. Exercises the snippet code end
       to end; requires LAUNCHDARKLY_SDK_KEY (or _MOBILE_KEY / _CLIENT_SIDE_ID)
-      and LAUNCHDARKLY_FLAG_KEY in the env.
+      and LAUNCHDARKLY_FLAG_KEY in the env. Pass --snippet=<id> to validate
+      a single snippet (useful while developing scaffolds).
 
   snippets version
       Print the snippets generator version.
@@ -154,6 +155,7 @@ func runVerify(args []string) {
 func runValidate(args []string) {
 	fset := flag.NewFlagSet("validate", flag.ExitOnError)
 	sdk := fset.String("sdk", "", "sdk id to validate (required)")
+	snippet := fset.String("snippet", "", "snippet id to validate (optional; restricts to one snippet)")
 	sdks := fset.String("sdks", "", "path to a sdks/ directory (default: embedded)")
 	validators := fset.String("validators", "./validators", "path to the validators/ directory")
 	_ = fset.Parse(args)
@@ -162,7 +164,12 @@ func runValidate(args []string) {
 		fmt.Fprintf(os.Stderr, "validate: --sdk is required\n")
 		os.Exit(2)
 	}
-	if err := validate.Run(validate.Config{SDKsFS: resolveSDKsFS(*sdks), ValidatorsDir: *validators, SDK: *sdk}); err != nil {
+	if err := validate.Run(validate.Config{
+		SDKsFS:        resolveSDKsFS(*sdks),
+		ValidatorsDir: *validators,
+		SDK:           *sdk,
+		Snippet:       *snippet,
+	}); err != nil {
 		fmt.Fprintf(os.Stderr, "validate failed: %v\n", err)
 		os.Exit(1)
 	}

--- a/snippets/cmd/snippets/main.go
+++ b/snippets/cmd/snippets/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/launchdarkly/sdk-meta/snippets"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/adapters/ldapplication"
+	"github.com/launchdarkly/sdk-meta/snippets/internal/adapters/lddocs"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/validate"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/version"
 )
@@ -36,14 +37,17 @@ func (r *repeatableString) Set(s string) error { *r = append(*r, s); return nil 
 const usage = `snippets — LaunchDarkly SDK snippet generator
 
 usage:
-  snippets render --target=ld-application --entrypoint=<dir> [--entrypoint=<dir2> ...] [--sdks=./sdks]
+  snippets render --target=<target> --entrypoint=<dir> [--entrypoint=<dir2> ...] [--sdks=./sdks]
       Walks each --entrypoint directory in the consumer checkout, finds files
       that contain SDK_SNIPPET:RENDER markers, and rewrites each marked
       region from the snippet sources. --entrypoint may be passed multiple
-      times. Authors run this after editing a snippet; the consumer's
-      sync action runs it on every release.
+      times. --target selects the adapter:
+        ld-application — rewrites JSX children inside marked components
+                         (gonfalon, the LaunchDarkly app)
+        ld-docs        — rewrites fenced code-block bodies in MDX
+                         (ld-docs-private, ld-docs)
 
-  snippets verify --target=ld-application --entrypoint=<dir> [--entrypoint=<dir2> ...] [--sdks=./sdks]
+  snippets verify --target=<target> --entrypoint=<dir> [--entrypoint=<dir2> ...] [--sdks=./sdks]
       Read-only counterpart to render, used by CI in the consumer repo.
       Fails if the rendered bytes would drift from what's on disk, or if
       a marker's hash does not match its current region's content. Never
@@ -84,17 +88,27 @@ func main() {
 
 func runRender(args []string) {
 	fset := flag.NewFlagSet("render", flag.ExitOnError)
-	target := fset.String("target", "", "adapter target: `ld-application`")
+	target := fset.String("target", "", "adapter target: `ld-application` or `ld-docs`")
 	var entrypoints repeatableString
 	fset.Var(&entrypoints, "entrypoint", "directory in the consumer checkout to walk for marker files (repeatable)")
 	sdks := fset.String("sdks", "", "path to a sdks/ directory (default: embedded)")
 	_ = fset.Parse(args)
 
-	if *target != "ld-application" || len(entrypoints) == 0 {
-		fmt.Fprintf(os.Stderr, "render: --target=ld-application and at least one --entrypoint are required\n")
+	if len(entrypoints) == 0 {
+		fmt.Fprintf(os.Stderr, "render: at least one --entrypoint is required\n")
 		os.Exit(2)
 	}
-	changed, err := ldapplication.Render(resolveSDKsFS(*sdks), entrypoints)
+	var changed []string
+	var err error
+	switch *target {
+	case "ld-application":
+		changed, err = ldapplication.Render(resolveSDKsFS(*sdks), entrypoints)
+	case "ld-docs":
+		changed, err = lddocs.Render(resolveSDKsFS(*sdks), entrypoints)
+	default:
+		fmt.Fprintf(os.Stderr, "render: --target must be `ld-application` or `ld-docs`\n")
+		os.Exit(2)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "render failed: %v\n", err)
 		os.Exit(1)
@@ -110,17 +124,27 @@ func runRender(args []string) {
 
 func runVerify(args []string) {
 	fset := flag.NewFlagSet("verify", flag.ExitOnError)
-	target := fset.String("target", "", "adapter target: `ld-application`")
+	target := fset.String("target", "", "adapter target: `ld-application` or `ld-docs`")
 	var entrypoints repeatableString
 	fset.Var(&entrypoints, "entrypoint", "directory in the consumer checkout to walk for marker files (repeatable)")
 	sdks := fset.String("sdks", "", "path to a sdks/ directory (default: embedded)")
 	_ = fset.Parse(args)
 
-	if *target != "ld-application" || len(entrypoints) == 0 {
-		fmt.Fprintf(os.Stderr, "verify: --target=ld-application and at least one --entrypoint are required\n")
+	if len(entrypoints) == 0 {
+		fmt.Fprintf(os.Stderr, "verify: at least one --entrypoint is required\n")
 		os.Exit(2)
 	}
-	if err := ldapplication.Verify(resolveSDKsFS(*sdks), entrypoints); err != nil {
+	var err error
+	switch *target {
+	case "ld-application":
+		err = ldapplication.Verify(resolveSDKsFS(*sdks), entrypoints)
+	case "ld-docs":
+		err = lddocs.Verify(resolveSDKsFS(*sdks), entrypoints)
+	default:
+		fmt.Fprintf(os.Stderr, "verify: --target must be `ld-application` or `ld-docs`\n")
+		os.Exit(2)
+	}
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "verify failed: %v\n", err)
 		os.Exit(1)
 	}

--- a/snippets/internal/adapters/lddocs/lddocs.go
+++ b/snippets/internal/adapters/lddocs/lddocs.go
@@ -1,0 +1,324 @@
+package lddocs
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/launchdarkly/sdk-meta/snippets/internal/markers"
+	"github.com/launchdarkly/sdk-meta/snippets/internal/model"
+	"github.com/launchdarkly/sdk-meta/snippets/internal/render"
+	"github.com/launchdarkly/sdk-meta/snippets/internal/version"
+)
+
+// markerSentinel is the substring every render marker contains. Used as a
+// fast pre-filter so walking large doc trees only invokes the marker
+// scanner on files that could possibly contain a marker.
+var markerSentinel = []byte("SDK_SNIPPET:RENDER:")
+
+// candidateExtensions is the set of doc file types the MDX scanner
+// understands. ld-docs-private uses .mdx exclusively today; .md is
+// included to cover ld-docs-public-style markdown that Fern compiles.
+var candidateExtensions = map[string]struct{}{
+	".mdx": {}, ".md": {},
+}
+
+// skipDirNames are directories we never descend into. Standard generated /
+// dependency directories that never carry doc markers.
+var skipDirNames = map[string]struct{}{
+	"node_modules": {}, ".git": {}, ".next": {}, "dist": {}, "build": {},
+	".cache": {}, "coverage": {}, "out": {}, ".turbo": {}, ".fern": {},
+}
+
+// Render walks every entrypoint, finds MDX files containing render markers,
+// and rewrites each fenced code block whose marker references a snippet.
+// Returns one entry per file it touched.
+func Render(sdksFS fs.FS, entrypoints []string) ([]string, error) {
+	return run(sdksFS, entrypoints, false)
+}
+
+// Verify re-renders every marked region in memory and fails if any hash in
+// a marker does not match the bytes currently between its fences, or if a
+// re-render would change content. Never modifies files.
+func Verify(sdksFS fs.FS, entrypoints []string) error {
+	_, err := run(sdksFS, entrypoints, true)
+	return err
+}
+
+func run(sdksFS fs.FS, entrypoints []string, dryRun bool) ([]string, error) {
+	snippets, err := model.LoadAll(sdksFS)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := discoverFilesUnder(entrypoints)
+	if err != nil {
+		return nil, err
+	}
+
+	var changed []string
+	for _, p := range files {
+		ok, err := rewriteFile(p, snippets, dryRun)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p, err)
+		}
+		if ok {
+			changed = append(changed, p)
+		}
+	}
+	return changed, nil
+}
+
+// discoverFilesUnder walks every entrypoint, returning the set of doc files
+// that contain the SDK_SNIPPET:RENDER: sentinel. Mirrors the
+// ld-application adapter's discovery logic.
+func discoverFilesUnder(entrypoints []string) ([]string, error) {
+	if len(entrypoints) == 0 {
+		return nil, fmt.Errorf("at least one --entrypoint is required")
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, ep := range entrypoints {
+		abs, err := filepath.Abs(ep)
+		if err != nil {
+			return nil, fmt.Errorf("entrypoint %q: %w", ep, err)
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, fmt.Errorf("entrypoint %q: %w", ep, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("entrypoint %q: not a directory", ep)
+		}
+		err = filepath.WalkDir(abs, func(p string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				if p != abs {
+					if _, skip := skipDirNames[d.Name()]; skip {
+						return filepath.SkipDir
+					}
+				}
+				return nil
+			}
+			if d.Type()&os.ModeSymlink != 0 {
+				return nil
+			}
+			if _, ok := candidateExtensions[filepath.Ext(p)]; !ok {
+				return nil
+			}
+			if _, dup := seen[p]; dup {
+				return nil
+			}
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			if !bytes.Contains(data, markerSentinel) {
+				return nil
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// rewriteFile rewrites the fence bodies of every marked region. If dryRun
+// is true it only verifies that (a) every marker carries a hash field,
+// (b) the hash matches the current fence body, and (c) re-rendering would
+// produce the same bytes.
+func rewriteFile(path string, snippets map[string]*model.Snippet, dryRun bool) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	src := string(raw)
+
+	matches, err := markers.ScanMDX(src)
+	if err != nil {
+		return false, err
+	}
+	if len(matches) == 0 {
+		return false, nil
+	}
+
+	var sb strings.Builder
+	cursor := 0
+	changed := false
+	for _, m := range matches {
+		s := snippets[m.Fields.ID]
+		if s == nil {
+			return false, fmt.Errorf("marker %q references unknown snippet id", m.Fields.ID)
+		}
+		tpl, err := render.Parse(s.CodeBody)
+		if err != nil {
+			return false, fmt.Errorf("snippet %s: %w", s.Path, err)
+		}
+		body, err := render.RenderRuntime(tpl, docsInputs(s))
+		if err != nil {
+			return false, fmt.Errorf("snippet %s: %w", s.Path, err)
+		}
+
+		// Hash covers ONLY the fence body bytes — the surrounding
+		// <CodeBlocks>/<CodeBlock title='…'> wrappers and the fence
+		// language tag are the consumer's choice.
+		newHash := markers.HashContent(body)
+
+		if dryRun {
+			if m.Fields.Hash == "" {
+				return false, fmt.Errorf("marker %q: missing required hash= field — re-render to populate it", m.Fields.ID)
+			}
+			actualHash := markers.HashContent(src[m.RegionStart:m.RegionEnd])
+			if m.Fields.Hash != actualHash {
+				return false, fmt.Errorf("marker %q: hand-edit detected — body hash %s does not match marker %s",
+					m.Fields.ID, actualHash, m.Fields.Hash)
+			}
+			if body != src[m.RegionStart:m.RegionEnd] {
+				return false, fmt.Errorf("marker %q: re-render would change region — run `snippets render`", m.Fields.ID)
+			}
+			continue
+		}
+
+		// Preserve the existing version stamp when the body is byte-
+		// identical to what's on disk. Same semantics as the
+		// ld-application adapter.
+		ver := m.Fields.Version
+		if ver == "" || body != src[m.RegionStart:m.RegionEnd] {
+			ver = version.Version
+		}
+		newMarker := markers.FormatMDXMarker(markers.MarkerFields{
+			ID:      m.Fields.ID,
+			Hash:    newHash,
+			Version: ver,
+			Scope:   "content",
+		})
+		sb.WriteString(src[cursor:m.CommentStart])
+		sb.WriteString(newMarker)
+		sb.WriteString(src[m.CommentEnd:m.RegionStart])
+		sb.WriteString(body)
+		cursor = m.RegionEnd
+
+		if src[m.CommentStart:m.CommentEnd] != newMarker || src[m.RegionStart:m.RegionEnd] != body {
+			changed = true
+		}
+	}
+	if dryRun {
+		return false, nil
+	}
+	sb.WriteString(src[cursor:])
+	if !changed {
+		return false, nil
+	}
+	return true, atomicWriteFile(path, []byte(sb.String()))
+}
+
+// docsInputs synthesizes a value for each declared input. Bound inputs
+// (those with a non-empty runtime-default) pass through; unbound
+// credential-flavored inputs get a YOUR_<TYPE> placeholder so the doc
+// renders human-friendly literals (`YOUR_SDK_KEY`, `YOUR_FLAG_KEY`)
+// without leaking real keys. Plain string inputs use their runtime-default
+// (which may be empty — empty values cause `{{ if name }}…{{ end }}`
+// conditionals to omit, which is usually what the doc wants).
+func docsInputs(s *model.Snippet) map[string]string {
+	out := make(map[string]string, len(s.Frontmatter.Inputs))
+	for name, in := range s.Frontmatter.Inputs {
+		out[name] = docsDefault(name, in)
+	}
+	return out
+}
+
+// docsDefault picks the value substituted into the snippet for the docs
+// render. The mapping is intentionally narrow: each input type that
+// represents a credential gets a literal placeholder; plain strings fall
+// through to the runtime default the snippet author specified.
+func docsDefault(name string, in model.Input) string {
+	switch in.Type {
+	case "flag-key":
+		return "YOUR_FLAG_KEY"
+	case "sdk-key":
+		return "YOUR_SDK_KEY"
+	case "client-side-id":
+		return "YOUR_CLIENT_SIDE_ID"
+	case "mobile-key":
+		return "YOUR_MOBILE_KEY"
+	case "string":
+		return in.RuntimeDefault
+	default:
+		// Unknown / future input type. Synthesize a screaming-snake
+		// placeholder from the name so the doc reader sees a clear
+		// "fill this in" rather than an unrendered template.
+		return "YOUR_" + strings.ToUpper(toScreamingSnake(name))
+	}
+}
+
+// toScreamingSnake converts camelCase / kebab-case / snake_case into
+// SCREAMING_SNAKE_CASE for placeholder names.
+func toScreamingSnake(s string) string {
+	var sb strings.Builder
+	for i, r := range s {
+		switch {
+		case r == '-' || r == '_':
+			sb.WriteByte('_')
+		case r >= 'A' && r <= 'Z':
+			if i > 0 {
+				sb.WriteByte('_')
+			}
+			sb.WriteRune(r)
+		case r >= 'a' && r <= 'z':
+			sb.WriteRune(r - 'a' + 'A')
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// atomicWriteFile is identical to ldapplication's atomic-rename path —
+// duplicated rather than abstracted because the surface is small enough
+// that a shared helper just adds an indirection.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	var sfx [8]byte
+	if _, err := rand.Read(sfx[:]); err != nil {
+		return err
+	}
+	tmp := filepath.Join(dir, "."+filepath.Base(path)+".sdk-snippets."+hex.EncodeToString(sfx[:])+".tmp")
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/snippets/internal/adapters/lddocs/lddocs_test.go
+++ b/snippets/internal/adapters/lddocs/lddocs_test.go
@@ -1,0 +1,199 @@
+package lddocs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile is a small fixture helper for parallel tests.
+func writeFile(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const installSnippet = `---
+id: test-sdk/install
+sdk: test-sdk
+kind: install
+lang: shell
+description: Install with optional version pin.
+inputs:
+  version:
+    type: string
+    description: Optional pinned version
+    runtime-default: ""
+---
+
+Install:
+
+` + "```shell\n" +
+	`pip install foo{{ if version }}=={{ version }}{{ end }}` + "\n" +
+	`` + "```\n"
+
+const initSnippet = `---
+id: test-sdk/init
+sdk: test-sdk
+kind: hello-world
+lang: python
+file: main.py
+description: Initialize.
+inputs:
+  flagKey:
+    type: flag-key
+    description: Flag to evaluate.
+---
+
+Init:
+
+` + "```python\n" +
+	`import foo` + "\n" +
+	`flag = foo.variation("{{ flagKey }}")` + "\n" +
+	`` + "```\n"
+
+// Render fills hash=0 placeholders with real content + hash, and Verify
+// then accepts the resulting file.
+func TestRenderThenVerify_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	writeFile(t, sdks, "test-sdk/sdk.yaml", "id: test-sdk\n")
+	writeFile(t, sdks, "test-sdk/snippets/install.snippet.md", installSnippet)
+	writeFile(t, sdks, "test-sdk/snippets/init.snippet.md", initSnippet)
+
+	docs := filepath.Join(tmp, "docs")
+	mdx := "{/* SDK_SNIPPET:RENDER:test-sdk/install hash=0 version=0.0.0 */}\n" +
+		"```bash\n" +
+		"placeholder\n" +
+		"```\n\n" +
+		"{/* SDK_SNIPPET:RENDER:test-sdk/init hash=0 version=0.0.0 */}\n" +
+		"```python\n" +
+		"placeholder\n" +
+		"```\n"
+	writeFile(t, docs, "page.mdx", mdx)
+
+	changed, err := Render(os.DirFS(sdks), []string{docs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changed) != 1 {
+		t.Fatalf("expected 1 file changed, got %v", changed)
+	}
+
+	out, _ := os.ReadFile(filepath.Join(docs, "page.mdx"))
+	got := string(out)
+
+	// Install: empty `version` runtime-default → conditional omits → bare
+	// `pip install foo` (no version pin).
+	if !strings.Contains(got, "pip install foo\n") {
+		t.Errorf("install body missing or wrong: \n%s", got)
+	}
+	if strings.Contains(got, "pip install foo==") {
+		t.Errorf("install body should not have version pin (empty default): \n%s", got)
+	}
+
+	// Init: flag-key type substitutes YOUR_FLAG_KEY placeholder.
+	if !strings.Contains(got, `foo.variation("YOUR_FLAG_KEY")`) {
+		t.Errorf("init body should have YOUR_FLAG_KEY placeholder: \n%s", got)
+	}
+
+	// Hash and version stamps populated.
+	if strings.Contains(got, "hash=0 ") {
+		t.Errorf("placeholder hash should have been replaced: \n%s", got)
+	}
+	if strings.Contains(got, "version=0.0.0") {
+		t.Errorf("placeholder version should have been replaced: \n%s", got)
+	}
+
+	// Verify passes on the rendered output.
+	if err := Verify(os.DirFS(sdks), []string{docs}); err != nil {
+		t.Errorf("verify after render should pass, got %v", err)
+	}
+
+	// Idempotent: a second render should produce no changes.
+	changed, err = Render(os.DirFS(sdks), []string{docs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changed) != 0 {
+		t.Errorf("second render should be a no-op, got %v", changed)
+	}
+}
+
+// Verify catches a hand-edit inside the fence body (hash mismatch) and
+// fails loudly without rewriting anything.
+func TestVerify_RejectsHandEdit(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	writeFile(t, sdks, "test-sdk/sdk.yaml", "id: test-sdk\n")
+	writeFile(t, sdks, "test-sdk/snippets/install.snippet.md", installSnippet)
+
+	docs := filepath.Join(tmp, "docs")
+	writeFile(t, docs, "page.mdx",
+		"{/* SDK_SNIPPET:RENDER:test-sdk/install hash=0 version=0.0.0 */}\n"+
+			"```bash\n"+
+			"placeholder\n"+
+			"```\n")
+	if _, err := Render(os.DirFS(sdks), []string{docs}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hand-edit the rendered body.
+	rendered, _ := os.ReadFile(filepath.Join(docs, "page.mdx"))
+	doctored := strings.Replace(string(rendered), "pip install foo", "pip install something-else", 1)
+	if doctored == string(rendered) {
+		t.Fatal("doctoring failed; fixture out of sync")
+	}
+	os.WriteFile(filepath.Join(docs, "page.mdx"), []byte(doctored), 0o644)
+
+	err := Verify(os.DirFS(sdks), []string{docs})
+	if err == nil || !strings.Contains(err.Error(), "hand-edit detected") {
+		t.Errorf("expected hand-edit error, got %v", err)
+	}
+}
+
+// A surrounding <CodeBlock title='…'> wrapper is preserved across renders —
+// only the fence body is owned by the snippet adapter.
+func TestRender_PreservesCodeBlockWrapper(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	writeFile(t, sdks, "test-sdk/sdk.yaml", "id: test-sdk\n")
+	writeFile(t, sdks, "test-sdk/snippets/install.snippet.md", installSnippet)
+
+	docs := filepath.Join(tmp, "docs")
+	mdx := "{/* SDK_SNIPPET:RENDER:test-sdk/install hash=0 version=0.0.0 */}\n" +
+		"<CodeBlocks>\n" +
+		"<CodeBlock title='Shell'>\n" +
+		"\n" +
+		"```bash\n" +
+		"placeholder\n" +
+		"```\n" +
+		"\n" +
+		"</CodeBlock>\n" +
+		"</CodeBlocks>\n"
+	writeFile(t, docs, "page.mdx", mdx)
+
+	if _, err := Render(os.DirFS(sdks), []string{docs}); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := os.ReadFile(filepath.Join(docs, "page.mdx"))
+	got := string(out)
+
+	// The wrapper survives intact.
+	if !strings.Contains(got, "<CodeBlock title='Shell'>") {
+		t.Errorf("wrapper should be preserved: \n%s", got)
+	}
+	if !strings.Contains(got, "</CodeBlocks>") {
+		t.Errorf("outer wrapper should be preserved: \n%s", got)
+	}
+	// Body filled in.
+	if !strings.Contains(got, "pip install foo") {
+		t.Errorf("body should be filled: \n%s", got)
+	}
+}

--- a/snippets/internal/markers/markers_mdx.go
+++ b/snippets/internal/markers/markers_mdx.go
@@ -1,0 +1,190 @@
+package markers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// MDXMatch describes one render marker in an MDX file. Unlike the TSX
+// adapter, the marker doesn't anchor to a JSX element — it anchors to the
+// next fenced code block. The hash covers the bytes BETWEEN the fences,
+// so the consumer is free to wrap the fence in <CodeBlocks>, set the
+// `title=` attribute on a surrounding <CodeBlock>, etc., without a
+// re-render. This matches the scope=content contract.
+type MDXMatch struct {
+	Fields MarkerFields
+
+	// CommentStart..CommentEnd is the marker comment itself (the {/* ... */} bytes).
+	CommentStart, CommentEnd int
+
+	// FenceStart is the byte index of the first backtick of the opening
+	// fence line. FenceEnd is one byte past the closing fence's final
+	// newline (or end-of-file if the fence closes the file).
+	FenceStart, FenceEnd int
+
+	// RegionStart..RegionEnd is the fence body — bytes after the opening
+	// fence's terminating newline, up to (and excluding) the closing fence
+	// line's leading newline. The hash is computed over this slice.
+	RegionStart, RegionEnd int
+
+	// Lang is the info string immediately after the opening backticks
+	// (e.g., "python", "bash", or empty for an untagged fence).
+	Lang string
+}
+
+// fenceLineRe matches a fenced-code-block delimiter line. The CommonMark
+// spec allows up to three leading spaces and three or more backticks; we
+// allow that, capturing the backtick run and the optional info string.
+// Closing fences must use the same backtick count as the opener — the
+// scanner enforces that downstream.
+var fenceLineRe = regexp.MustCompile(`^([ ]{0,3})(` + "`" + `{3,})([^\n` + "`" + `]*)$`)
+
+// ScanMDX finds every {/* SDK_SNIPPET:RENDER:... */} comment in an MDX file
+// and pairs each one with the next fenced code block. Wrapping JSX elements
+// (<CodeBlocks>, <CodeBlock title='…'>) between the comment and the fence
+// are skipped — only their attributes/content are attribution-checked, so
+// the consumer can choose those freely.
+//
+// Returns matches in file order. If a marker is followed by something that
+// isn't a fenced code block (within ~50 lines), it's an error — markers
+// must be physically adjacent to the code they own.
+func ScanMDX(src string) ([]MDXMatch, error) {
+	var out []MDXMatch
+	i := 0
+	for i < len(src) {
+		// MDX prose is mostly markdown; the only comment syntax we care
+		// about is the JSX-expression `{/* ... */}` form. HTML comments
+		// `<!-- ... -->` are intentionally NOT recognized — pick one and
+		// stick to it.
+		if i+2 < len(src) && src[i] == '{' && src[i+1] == '/' && src[i+2] == '*' {
+			rel := strings.Index(src[i+3:], "*/}")
+			if rel < 0 {
+				return nil, fmt.Errorf("unterminated {/* */} comment at offset %d", i)
+			}
+			inner := src[i+3 : i+3+rel]
+			closeEnd := i + 3 + rel + 3
+			if m, ok := parseMarker(inner); ok {
+				match, err := attachFence(src, i, closeEnd, m)
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, match)
+				i = match.FenceEnd
+				continue
+			}
+			i = closeEnd
+			continue
+		}
+		i++
+	}
+	return out, nil
+}
+
+// attachFence locates the next fenced code block after the marker comment
+// and packages the bytes into an MDXMatch. Wrapping JSX elements between
+// the comment and the fence are tolerated — only their absence of a fence
+// is an error. The "next fence" is the first opening fence within
+// maxLinesBeforeFence lines of the comment; further away suggests an
+// authoring mistake (marker drifted away from its code block) and is
+// rejected.
+func attachFence(src string, commentStart, commentEnd int, m MarkerFields) (MDXMatch, error) {
+	if m.Scope != "content" {
+		return MDXMatch{}, fmt.Errorf("marker %q: scope=%q is not supported in lddocs adapter", m.ID, m.Scope)
+	}
+
+	// Walk lines from commentEnd looking for the opening fence. Cap the
+	// search so a forgotten fence doesn't silently consume hundreds of
+	// lines of unrelated prose.
+	const maxLinesBeforeFence = 50
+	lineStart := commentEnd
+	// Skip the rest of the line containing the comment close (the comment
+	// itself isn't on its own line necessarily — but in practice it almost
+	// always is). Move lineStart to the next line's first byte.
+	if nl := strings.IndexByte(src[lineStart:], '\n'); nl >= 0 {
+		lineStart += nl + 1
+	} else {
+		return MDXMatch{}, fmt.Errorf("marker %q: comment is on the last line; no fence follows", m.ID)
+	}
+
+	openFenceStart := -1
+	openFenceLineEnd := -1
+	openTicks := ""
+	openLang := ""
+	linesScanned := 0
+	for lineStart < len(src) && linesScanned < maxLinesBeforeFence {
+		lineEnd := strings.IndexByte(src[lineStart:], '\n')
+		var line string
+		var lineEndAbs int
+		if lineEnd < 0 {
+			line = src[lineStart:]
+			lineEndAbs = len(src)
+		} else {
+			line = src[lineStart : lineStart+lineEnd]
+			lineEndAbs = lineStart + lineEnd
+		}
+		if sub := fenceLineRe.FindStringSubmatch(line); sub != nil {
+			openTicks = sub[2]
+			openLang = strings.TrimSpace(sub[3])
+			openFenceStart = lineStart + len(sub[1])
+			openFenceLineEnd = lineEndAbs
+			break
+		}
+		// Anything else (blank lines, JSX wrapper tags, prose) is fine —
+		// keep scanning.
+		linesScanned++
+		if lineEnd < 0 {
+			lineStart = len(src)
+			break
+		}
+		lineStart = lineEndAbs + 1
+	}
+	if openFenceStart < 0 {
+		return MDXMatch{}, fmt.Errorf("marker %q: no fenced code block found within %d lines after comment", m.ID, maxLinesBeforeFence)
+	}
+
+	// Body starts on the line after the opening fence.
+	if openFenceLineEnd >= len(src) {
+		return MDXMatch{}, fmt.Errorf("marker %q: opening fence is at end of file", m.ID)
+	}
+	regionStart := openFenceLineEnd + 1
+
+	// Find the matching closing fence: the first subsequent line whose
+	// (trimmed-leading-whitespace) prefix is exactly the same backtick run
+	// followed by optional whitespace.
+	closeRe := regexp.MustCompile(`(?m)^[ ]{0,3}` + openTicks + `[ \t]*$`)
+	closeIdx := closeRe.FindStringIndex(src[regionStart:])
+	if closeIdx == nil {
+		return MDXMatch{}, fmt.Errorf("marker %q: unterminated fenced code block (opener %q)", m.ID, openTicks)
+	}
+	closeAbs := regionStart + closeIdx[0]
+	// Region ends at the byte BEFORE the closing fence line's leading
+	// newline. closeAbs points at the first byte of the closing fence
+	// line; the newline that ends the previous line is at closeAbs-1.
+	// Empty body (opener and closer on consecutive lines) clamps to regionStart.
+	regionEnd := max(closeAbs-1, regionStart)
+	fenceEnd := regionStart + closeIdx[1]
+	// Consume the trailing newline after the closing fence if present, so
+	// FenceEnd points at the next line's first byte (matches FenceStart's
+	// "first byte of the fence line" convention).
+	if fenceEnd < len(src) && src[fenceEnd] == '\n' {
+		fenceEnd++
+	}
+
+	return MDXMatch{
+		Fields:       m,
+		CommentStart: commentStart,
+		CommentEnd:   commentEnd,
+		FenceStart:   openFenceStart,
+		FenceEnd:     fenceEnd,
+		RegionStart:  regionStart,
+		RegionEnd:    regionEnd,
+		Lang:         openLang,
+	}, nil
+}
+
+// FormatMDXMarker renders the marker comment for MDX (always JSX-expression
+// style — line/block comments don't apply outside JSX expression context).
+func FormatMDXMarker(f MarkerFields) string {
+	return FormatMarker(styleJSXExpr, f)
+}

--- a/snippets/internal/markers/markers_mdx_test.go
+++ b/snippets/internal/markers/markers_mdx_test.go
@@ -1,0 +1,168 @@
+package markers
+
+import (
+	"strings"
+	"testing"
+)
+
+// Bare fence directly after the comment.
+func TestScanMDX_BareFence(t *testing.T) {
+	src := "{/* SDK_SNIPPET:RENDER:foo/bar hash=abc version=0.1.0 */}\n" +
+		"```python\n" +
+		"print('hello')\n" +
+		"```\n"
+	matches, err := ScanMDX(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want 1 match, got %d", len(matches))
+	}
+	m := matches[0]
+	if m.Fields.ID != "foo/bar" {
+		t.Errorf("ID: %q", m.Fields.ID)
+	}
+	if m.Lang != "python" {
+		t.Errorf("Lang: %q", m.Lang)
+	}
+	body := src[m.RegionStart:m.RegionEnd]
+	if body != "print('hello')" {
+		t.Errorf("body: %q", body)
+	}
+}
+
+// CodeBlock JSX wrapper between the marker and the fence is fine.
+func TestScanMDX_SkipsJSXWrappers(t *testing.T) {
+	src := "{/* SDK_SNIPPET:RENDER:foo/bar hash=0 version=0.0.0 */}\n" +
+		"<CodeBlocks>\n" +
+		"<CodeBlock title='Python'>\n" +
+		"\n" +
+		"```python\n" +
+		"print('hi')\n" +
+		"```\n" +
+		"\n" +
+		"</CodeBlock>\n" +
+		"</CodeBlocks>\n"
+	matches, err := ScanMDX(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want 1 match, got %d", len(matches))
+	}
+	body := src[matches[0].RegionStart:matches[0].RegionEnd]
+	if body != "print('hi')" {
+		t.Errorf("body: %q", body)
+	}
+}
+
+// Multiple markers in one file each anchor to the next fence.
+func TestScanMDX_MultipleMarkers(t *testing.T) {
+	src := "## Install\n" +
+		"{/* SDK_SNIPPET:RENDER:a hash=0 version=0 */}\n" +
+		"```bash\n" +
+		"pip install foo\n" +
+		"```\n" +
+		"\n" +
+		"## Init\n" +
+		"{/* SDK_SNIPPET:RENDER:b hash=0 version=0 */}\n" +
+		"```python\n" +
+		"import foo\n" +
+		"```\n"
+	matches, err := ScanMDX(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("want 2 matches, got %d", len(matches))
+	}
+	if matches[0].Fields.ID != "a" || matches[1].Fields.ID != "b" {
+		t.Errorf("ids: %q, %q", matches[0].Fields.ID, matches[1].Fields.ID)
+	}
+	if matches[0].Lang != "bash" || matches[1].Lang != "python" {
+		t.Errorf("langs: %q, %q", matches[0].Lang, matches[1].Lang)
+	}
+}
+
+// Fence body containing backticks (e.g., shell command substitution) is
+// preserved as long as the closing fence uses the same number of opening
+// backticks at the start of its line. A 4-backtick opener tolerates a
+// 3-backtick code line.
+func TestScanMDX_FourBacktickFence(t *testing.T) {
+	src := "{/* SDK_SNIPPET:RENDER:foo hash=0 version=0 */}\n" +
+		"````markdown\n" +
+		"```python\n" +
+		"print('inside')\n" +
+		"```\n" +
+		"````\n"
+	matches, err := ScanMDX(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want 1 match, got %d", len(matches))
+	}
+	body := src[matches[0].RegionStart:matches[0].RegionEnd]
+	want := "```python\nprint('inside')\n```"
+	if body != want {
+		t.Errorf("body:\n%q\nwant:\n%q", body, want)
+	}
+}
+
+// A marker with no fence within the cap is rejected.
+func TestScanMDX_NoFenceFound(t *testing.T) {
+	src := "{/* SDK_SNIPPET:RENDER:foo hash=0 version=0 */}\n" +
+		strings.Repeat("just prose, no fence\n", 60)
+	if _, err := ScanMDX(src); err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+// An unterminated comment is rejected loudly rather than silently skipped.
+func TestScanMDX_UnterminatedComment(t *testing.T) {
+	src := "{/* SDK_SNIPPET:RENDER:foo hash=0 version=0\n```python\nx\n```\n"
+	if _, err := ScanMDX(src); err == nil ||
+		!strings.Contains(err.Error(), "unterminated") {
+		t.Fatalf("want unterminated comment error, got %v", err)
+	}
+}
+
+// Markers inside <CodeBlock> attributes (rare but possible) shouldn't
+// break the scanner. The marker comment is at the prose level; whatever
+// is inside the code block body is treated as opaque text.
+func TestScanMDX_MarkerLikeStringInsideFence(t *testing.T) {
+	src := "{/* SDK_SNIPPET:RENDER:foo hash=0 version=0 */}\n" +
+		"```python\n" +
+		"# {/* SDK_SNIPPET:RENDER:not-a-real-marker hash=0 version=0 */}\n" +
+		"print('x')\n" +
+		"```\n"
+	matches, err := ScanMDX(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want exactly 1 match (the comment-string inside the fence body must not be treated as a marker), got %d", len(matches))
+	}
+	if matches[0].Fields.ID != "foo" {
+		t.Errorf("got id %q, want foo", matches[0].Fields.ID)
+	}
+}
+
+// Empty fence body (consecutive opener/closer lines) clamps cleanly
+// rather than producing a negative slice.
+func TestScanMDX_EmptyBody(t *testing.T) {
+	src := "{/* SDK_SNIPPET:RENDER:foo hash=0 version=0 */}\n" +
+		"```\n" +
+		"```\n"
+	matches, err := ScanMDX(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want 1 match, got %d", len(matches))
+	}
+	body := src[matches[0].RegionStart:matches[0].RegionEnd]
+	if body != "" {
+		t.Errorf("body: %q want empty", body)
+	}
+}

--- a/snippets/internal/model/model.go
+++ b/snippets/internal/model/model.go
@@ -63,6 +63,25 @@ type Validation struct {
 	// `validation.runtime` — they just declare `file:` so the validator
 	// knows where to put them.
 	Companions []string `yaml:"companions"`
+
+	// Scaffold references another snippet (typically `kind: scaffold`)
+	// whose body wraps this snippet's body via a `{{ body }}` placeholder.
+	// Used by docs snippets that aren't standalone-runnable (a single
+	// `variation()` call, a hook class definition, etc.) — the scaffold
+	// supplies the surrounding init+context so a real validator run can
+	// exercise the fragment. The scaffold owns the runtime, entrypoint,
+	// requirements, and companions; this snippet contributes only the body
+	// fragment plus any ScaffoldInputs.
+	//
+	// Mutually exclusive with Runtime/Entrypoint/Requirements/Companions
+	// here — those come from the scaffold.
+	Scaffold string `yaml:"scaffold"`
+
+	// ScaffoldInputs supplies extra named values to the scaffold's
+	// templating beyond the special `body` placeholder. Lets one scaffold
+	// serve several wrappees that need slightly different setup (e.g.
+	// pre-populated flag values, context attributes).
+	ScaffoldInputs map[string]string `yaml:"scaffold-inputs"`
 }
 
 // Snippet pairs the frontmatter with the body of the first fenced code block

--- a/snippets/internal/validate/validate.go
+++ b/snippets/internal/validate/validate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +21,7 @@ type Config struct {
 	SDKsFS        fs.FS  // sdks/ as an fs.FS (embedded or os.DirFS)
 	ValidatorsDir string // path to validators/ (must be on disk — Docker COPY needs it)
 	SDK           string // sdk id to validate (empty = all)
+	Snippet       string // snippet id to validate (empty = all in the SDK)
 }
 
 // envInputs holds the environment-derived input values that get substituted
@@ -62,6 +64,9 @@ func Run(cfg Config) error {
 		if cfg.SDK != "" && s.Frontmatter.SDK != cfg.SDK {
 			continue
 		}
+		if cfg.Snippet != "" && s.Frontmatter.ID != cfg.Snippet {
+			continue
+		}
 		if !isValidatable(s) {
 			continue
 		}
@@ -71,27 +76,59 @@ func Run(cfg Config) error {
 		}
 	}
 	if !any {
-		return fmt.Errorf("no validatable snippets found (sdk=%q)", cfg.SDK)
+		return fmt.Errorf("no validatable snippets found (sdk=%q, snippet=%q)", cfg.SDK, cfg.Snippet)
 	}
 	return nil
 }
 
+// isValidatable reports whether the validator should attempt to run a
+// given snippet. Scaffolds (snippets that exist only to wrap other
+// snippets' bodies) are explicitly excluded: their `{{ body }}` slot is
+// unbound when run standalone, so they would always fail.
 func isValidatable(s *model.Snippet) bool {
-	return s.Frontmatter.Validation.Runtime != "" || s.Frontmatter.Validation.Entrypoint != ""
+	if s.Frontmatter.Kind == "scaffold" {
+		return false
+	}
+	v := s.Frontmatter.Validation
+	return v.Runtime != "" || v.Entrypoint != "" || v.Scaffold != ""
+}
+
+// effectiveValidationSnippet returns the snippet whose validation
+// frontmatter (runtime, entrypoint, requirements, companions, file) drives
+// the harness invocation. For scaffold-bound snippets that's the scaffold;
+// otherwise it's the snippet itself.
+func effectiveValidationSnippet(s *model.Snippet, all map[string]*model.Snippet) (*model.Snippet, error) {
+	if s.Frontmatter.Validation.Scaffold == "" {
+		return s, nil
+	}
+	sc, ok := all[s.Frontmatter.Validation.Scaffold]
+	if !ok {
+		return nil, fmt.Errorf("snippet %s: scaffold %q not found", s.Frontmatter.ID, s.Frontmatter.Validation.Scaffold)
+	}
+	if sc.Frontmatter.Kind != "scaffold" {
+		return nil, fmt.Errorf("snippet %s: validation.scaffold target %q has kind=%q (must be `scaffold`)",
+			s.Frontmatter.ID, sc.Frontmatter.ID, sc.Frontmatter.Kind)
+	}
+	return sc, nil
 }
 
 func runOne(cfg Config, s *model.Snippet, all map[string]*model.Snippet, env envInputs) error {
-	runtime := s.Frontmatter.Validation.Runtime
+	eff, err := effectiveValidationSnippet(s, all)
+	if err != nil {
+		return err
+	}
+
+	runtime := eff.Frontmatter.Validation.Runtime
 	if runtime == "" {
-		// Fall back to the snippet's `lang:` frontmatter field, matching
+		// Fall back to the effective snippet's `lang:` field, matching
 		// the documented contract on Validation.Runtime. (CodeLang — the
 		// markdown fence's language tag — is a presentation hint and may
 		// diverge from the author's declared `lang:`; using it here would
 		// silently pick the wrong validator if they don't match.)
-		runtime = s.Frontmatter.Lang
+		runtime = eff.Frontmatter.Lang
 	}
 	if runtime == "" {
-		return fmt.Errorf("snippet %q: cannot determine validator runtime (set validation.runtime or lang)", s.Frontmatter.ID)
+		return fmt.Errorf("snippet %q: cannot determine validator runtime (set validation.runtime or lang on the snippet or its scaffold)", s.Frontmatter.ID)
 	}
 
 	runner, runnerDir, err := loadRunner(cfg.ValidatorsDir, runtime)
@@ -99,8 +136,16 @@ func runOne(cfg Config, s *model.Snippet, all map[string]*model.Snippet, env env
 		return err
 	}
 
+	// Both the wrappee and the scaffold (when distinct) contribute to the
+	// final body, so each one's typed inputs need their env values
+	// satisfied. Companions are checked inside requireEnvForInputs.
 	if err := requireEnvForInputs(s, all, env); err != nil {
 		return err
+	}
+	if eff != s {
+		if err := requireEnvForInputs(eff, all, env); err != nil {
+			return err
+		}
 	}
 
 	stageDir, err := stageSnippet(s, all, env)
@@ -109,8 +154,13 @@ func runOne(cfg Config, s *model.Snippet, all map[string]*model.Snippet, env env
 	}
 	defer os.RemoveAll(stageDir)
 
-	entrypoint := entrypointPath(s)
-	fmt.Printf("--- validate %s (runtime=%s, entrypoint=%s) ---\n", s.Frontmatter.ID, runtime, entrypoint)
+	entrypoint := entrypointPath(eff)
+	if eff == s {
+		fmt.Printf("--- validate %s (runtime=%s, entrypoint=%s) ---\n", s.Frontmatter.ID, runtime, entrypoint)
+	} else {
+		fmt.Printf("--- validate %s (scaffold=%s, runtime=%s, entrypoint=%s) ---\n",
+			s.Frontmatter.ID, eff.Frontmatter.ID, runtime, entrypoint)
+	}
 
 	switch runner.Mode {
 	case "docker":
@@ -132,29 +182,79 @@ func entrypointPath(s *model.Snippet) string {
 	return s.Frontmatter.File
 }
 
-// stageSnippet writes the snippet body and any companion bodies into a
-// temp directory shaped exactly like the project the harness expects.
+// stageSnippet writes the entry snippet's body (or its scaffold-composed
+// body) plus any companion bodies into a temp directory shaped exactly
+// like the project the harness expects.
 //
-// Each snippet (entrypoint + companions) is rendered with runtime inputs and
-// written at its `file:` path under stageDir. A snippet without a `file:`
-// field is an error — we need to know where to put its body.
+// Plain case: each snippet (entry + companions) is rendered with runtime
+// inputs and written at its `file:` path under stageDir.
+//
+// Scaffold case: entry's body is rendered first; that string becomes the
+// `body` input for the scaffold's render, and the scaffold's rendered
+// output is staged at the scaffold's `file:` path. Companions and
+// requirements come from the scaffold.
 func stageSnippet(entry *model.Snippet, all map[string]*model.Snippet, env envInputs) (string, error) {
 	stageDir, err := os.MkdirTemp("", "snippets-validate-")
 	if err != nil {
 		return "", err
 	}
 
-	if err := stageOne(stageDir, entry, env); err != nil {
+	eff, err := effectiveValidationSnippet(entry, all)
+	if err != nil {
 		os.RemoveAll(stageDir)
 		return "", err
 	}
-	for _, cid := range entry.Frontmatter.Validation.Companions {
+
+	if eff == entry {
+		// Plain (no scaffold): render entry with its own inputs.
+		if err := stageRender(stageDir, entry, nil, env); err != nil {
+			os.RemoveAll(stageDir)
+			return "", err
+		}
+	} else {
+		// Scaffolded: render the wrappee body first.
+		wrappeeInputs, err := runtimeInputs(entry, env)
+		if err != nil {
+			os.RemoveAll(stageDir)
+			return "", fmt.Errorf("snippet %s: %w", entry.Frontmatter.ID, err)
+		}
+		wrappeeNodes, err := render.Parse(entry.CodeBody)
+		if err != nil {
+			os.RemoveAll(stageDir)
+			return "", fmt.Errorf("snippet %s: %w", entry.Frontmatter.ID, err)
+		}
+		wrappeeBody, err := render.RenderRuntime(wrappeeNodes, wrappeeInputs)
+		if err != nil {
+			os.RemoveAll(stageDir)
+			return "", fmt.Errorf("snippet %s: %w", entry.Frontmatter.ID, err)
+		}
+
+		// Build the scaffold's input map: env-derived typed inputs from
+		// the scaffold itself, overlaid with the wrappee's
+		// scaffold-inputs, and finally the special `body` slot.
+		scaffoldInputs, err := runtimeInputs(eff, env)
+		if err != nil {
+			os.RemoveAll(stageDir)
+			return "", fmt.Errorf("scaffold %s: %w", eff.Frontmatter.ID, err)
+		}
+		maps.Copy(scaffoldInputs, entry.Frontmatter.Validation.ScaffoldInputs)
+		scaffoldInputs["body"] = wrappeeBody
+
+		if err := stageRender(stageDir, eff, scaffoldInputs, env); err != nil {
+			os.RemoveAll(stageDir)
+			return "", err
+		}
+	}
+
+	// Companions, requirements, and file paths all come from the
+	// effective snippet (the scaffold when one is in use).
+	for _, cid := range eff.Frontmatter.Validation.Companions {
 		comp, ok := all[cid]
 		if !ok {
 			os.RemoveAll(stageDir)
-			return "", fmt.Errorf("snippet %s: companion %q not found", entry.Frontmatter.ID, cid)
+			return "", fmt.Errorf("snippet %s: companion %q not found", eff.Frontmatter.ID, cid)
 		}
-		if err := stageOne(stageDir, comp, env); err != nil {
+		if err := stageRender(stageDir, comp, nil, env); err != nil {
 			os.RemoveAll(stageDir)
 			return "", err
 		}
@@ -163,7 +263,7 @@ func stageSnippet(entry *model.Snippet, all map[string]*model.Snippet, env envIn
 	// Python convention: validation.requirements becomes requirements.txt.
 	// Other runtimes carry their dependency manifest as a companion snippet
 	// (pom.xml, Cargo.toml, etc.).
-	if req := entry.Frontmatter.Validation.Requirements; req != "" {
+	if req := eff.Frontmatter.Validation.Requirements; req != "" {
 		if err := checkRequirements(req); err != nil {
 			os.RemoveAll(stageDir)
 			return "", err
@@ -177,7 +277,12 @@ func stageSnippet(entry *model.Snippet, all map[string]*model.Snippet, env envIn
 	return stageDir, nil
 }
 
-func stageOne(stageDir string, s *model.Snippet, env envInputs) error {
+// stageRender renders a snippet's body and writes it at its `file:` path
+// under stageDir. If overrideInputs is non-nil it's used verbatim as the
+// render-input map (used for scaffolds where the wrappee's body is
+// supplied via the special `body` key); otherwise the snippet's own
+// runtime inputs are derived from env.
+func stageRender(stageDir string, s *model.Snippet, overrideInputs map[string]string, env envInputs) error {
 	rel := s.Frontmatter.File
 	if rel == "" {
 		return fmt.Errorf("snippet %s: frontmatter.file is required for staging", s.Frontmatter.ID)
@@ -185,9 +290,13 @@ func stageOne(stageDir string, s *model.Snippet, env envInputs) error {
 	if err := checkStagePath(rel); err != nil {
 		return fmt.Errorf("snippet %s: %w", s.Frontmatter.ID, err)
 	}
-	inputs, err := runtimeInputs(s, env)
-	if err != nil {
-		return fmt.Errorf("snippet %s: %w", s.Frontmatter.ID, err)
+	inputs := overrideInputs
+	if inputs == nil {
+		var err error
+		inputs, err = runtimeInputs(s, env)
+		if err != nil {
+			return fmt.Errorf("snippet %s: %w", s.Frontmatter.ID, err)
+		}
 	}
 	nodes, err := render.Parse(s.CodeBody)
 	if err != nil {

--- a/snippets/internal/validate/validate_test.go
+++ b/snippets/internal/validate/validate_test.go
@@ -1,6 +1,8 @@
 package validate
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -111,5 +113,196 @@ func TestRuntimeInputsRejectsRuntimeDefaultOnKeys(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "runtime-default") {
 			t.Errorf("%s: want runtime-default rejection, got %v", kind, err)
 		}
+	}
+}
+
+// stageSnippet composes a wrappee into a scaffold's `{{ body }}` slot.
+// The staged file is the scaffold's `file:` path; the bytes are the
+// scaffold body with the wrappee body inlined.
+func TestStageSnippet_ScaffoldComposition(t *testing.T) {
+	wrappee := &model.Snippet{
+		Path: "test/wrappee.snippet.md",
+		Frontmatter: model.Frontmatter{
+			ID:   "test-sdk/docs/eval",
+			SDK:  "test-sdk",
+			Kind: "reference",
+			Lang: "python",
+			Validation: model.Validation{
+				Scaffold: "test-sdk/scaffolds/with-test-data",
+			},
+		},
+		CodeBody: `flag_value = client.variation("your.feature.key", context, False)`,
+	}
+	scaffold := &model.Snippet{
+		Path: "test/scaffold.snippet.md",
+		Frontmatter: model.Frontmatter{
+			ID:   "test-sdk/scaffolds/with-test-data",
+			SDK:  "test-sdk",
+			Kind: "scaffold",
+			Lang: "python",
+			File: "main.py",
+			Inputs: map[string]model.Input{
+				"body": {Type: "string", Description: "Wrappee body"},
+			},
+			Validation: model.Validation{
+				Runtime:      "python",
+				Entrypoint:   "main.py",
+				Requirements: "launchdarkly-server-sdk",
+			},
+		},
+		CodeBody: "import ldclient\n# setup ...\n{{ body }}\nprint(\"feature flag evaluates to\", flag_value)",
+	}
+	all := map[string]*model.Snippet{
+		wrappee.Frontmatter.ID:  wrappee,
+		scaffold.Frontmatter.ID: scaffold,
+	}
+
+	stageDir, err := stageSnippet(wrappee, all, envInputs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(stageDir)
+
+	// Composed body lives at the scaffold's `file:` path, not the wrappee's.
+	out, err := os.ReadFile(filepath.Join(stageDir, "main.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `flag_value = client.variation("your.feature.key", context, False)`) {
+		t.Errorf("staged body missing wrappee fragment:\n%s", got)
+	}
+	if !strings.Contains(got, "import ldclient") {
+		t.Errorf("staged body missing scaffold prologue:\n%s", got)
+	}
+	if !strings.Contains(got, "feature flag evaluates to") {
+		t.Errorf("staged body missing scaffold epilogue:\n%s", got)
+	}
+
+	// requirements.txt comes from the scaffold.
+	req, err := os.ReadFile(filepath.Join(stageDir, "requirements.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(req), "launchdarkly-server-sdk") {
+		t.Errorf("requirements.txt missing scaffold dep: %q", string(req))
+	}
+}
+
+// scaffold-inputs from the wrappee override env-derived defaults on the
+// scaffold's render.
+func TestStageSnippet_ScaffoldInputsOverride(t *testing.T) {
+	wrappee := &model.Snippet{
+		Frontmatter: model.Frontmatter{
+			ID:   "test-sdk/docs/eval",
+			SDK:  "test-sdk",
+			Kind: "reference",
+			Lang: "python",
+			Validation: model.Validation{
+				Scaffold: "test-sdk/scaffolds/with-flag",
+				ScaffoldInputs: map[string]string{
+					"flagName": "your.feature.key",
+				},
+			},
+		},
+		CodeBody: `# wrappee body`,
+	}
+	scaffold := &model.Snippet{
+		Frontmatter: model.Frontmatter{
+			ID:   "test-sdk/scaffolds/with-flag",
+			SDK:  "test-sdk",
+			Kind: "scaffold",
+			Lang: "python",
+			File: "main.py",
+			Inputs: map[string]model.Input{
+				"body":     {Type: "string"},
+				"flagName": {Type: "string", RuntimeDefault: "default.key"},
+			},
+			Validation: model.Validation{Runtime: "python", Entrypoint: "main.py"},
+		},
+		CodeBody: "FLAG = \"{{ flagName }}\"\n{{ body }}",
+	}
+	all := map[string]*model.Snippet{
+		wrappee.Frontmatter.ID:  wrappee,
+		scaffold.Frontmatter.ID: scaffold,
+	}
+	stageDir, err := stageSnippet(wrappee, all, envInputs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(stageDir)
+	out, _ := os.ReadFile(filepath.Join(stageDir, "main.py"))
+	got := string(out)
+	if !strings.Contains(got, `FLAG = "your.feature.key"`) {
+		t.Errorf("scaffold-inputs override did not apply:\n%s", got)
+	}
+}
+
+// isValidatable skips scaffolds even when they declare runtime/entrypoint.
+// A standalone scaffold run would have an unbound `{{ body }}` slot.
+func TestIsValidatable_SkipsScaffolds(t *testing.T) {
+	s := &model.Snippet{
+		Frontmatter: model.Frontmatter{
+			Kind: "scaffold",
+			Validation: model.Validation{
+				Runtime:    "python",
+				Entrypoint: "main.py",
+			},
+		},
+	}
+	if isValidatable(s) {
+		t.Error("scaffolds must not be validatable on their own")
+	}
+
+	// Compare with a plain validatable snippet.
+	plain := &model.Snippet{
+		Frontmatter: model.Frontmatter{
+			Kind: "hello-world",
+			Validation: model.Validation{
+				Runtime:    "python",
+				Entrypoint: "main.py",
+			},
+		},
+	}
+	if !isValidatable(plain) {
+		t.Error("plain validatable snippet should be validatable")
+	}
+
+	// And a scaffold-bound snippet (no runtime of its own) IS validatable.
+	scaffolded := &model.Snippet{
+		Frontmatter: model.Frontmatter{
+			Kind: "reference",
+			Validation: model.Validation{
+				Scaffold: "test-sdk/scaffolds/with-test-data",
+			},
+		},
+	}
+	if !isValidatable(scaffolded) {
+		t.Error("scaffold-bound snippet should be validatable via the scaffold")
+	}
+}
+
+// effectiveValidationSnippet errors loudly when the scaffold ID can't be
+// resolved or when the target isn't actually a scaffold.
+func TestEffectiveValidationSnippet_RejectsBadScaffold(t *testing.T) {
+	s := &model.Snippet{
+		Frontmatter: model.Frontmatter{
+			ID:         "test/wrappee",
+			Validation: model.Validation{Scaffold: "nonexistent"},
+		},
+	}
+	if _, err := effectiveValidationSnippet(s, map[string]*model.Snippet{}); err == nil ||
+		!strings.Contains(err.Error(), "scaffold") {
+		t.Errorf("missing scaffold: want error mentioning scaffold, got %v", err)
+	}
+
+	notScaffold := &model.Snippet{
+		Frontmatter: model.Frontmatter{ID: "test/init", Kind: "hello-world"},
+	}
+	s.Frontmatter.Validation.Scaffold = notScaffold.Frontmatter.ID
+	all := map[string]*model.Snippet{notScaffold.Frontmatter.ID: notScaffold}
+	if _, err := effectiveValidationSnippet(s, all); err == nil ||
+		!strings.Contains(err.Error(), "kind=") {
+		t.Errorf("non-scaffold target: want kind error, got %v", err)
 	}
 }

--- a/snippets/sdks/python-server-sdk/snippets/scaffolds/python-syntax-only.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/scaffolds/python-syntax-only.snippet.md
@@ -1,0 +1,48 @@
+---
+id: python-server-sdk/scaffolds/python-syntax-only
+sdk: python-server-sdk
+kind: scaffold
+lang: python
+file: main.py
+description: |
+  Lite validator that parses the wrappee body without executing it. Use
+  for snippets whose runtime context can't be reproduced in the
+  validator (fork-based APIs, uWSGI integration, anything requiring
+  container orchestration). Catches SyntaxError, indentation bugs, and
+  malformed strings — but NOT ImportError or AttributeError on API
+  calls. Pair this with full execution validation elsewhere when the
+  runtime is available.
+
+  Implementation: the wrappee body is embedded inside a single-quoted
+  raw triple-string. A wrappee body containing a literal `'''` would
+  break this scaffold; none of the docs snippets we ship today do, but
+  document the constraint here in case a future port hits it.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, parsed by ast.parse.
+validation:
+  runtime: python
+  entrypoint: main.py
+  # ast.parse is in the stdlib — no third-party deps needed.
+---
+
+```python
+import ast
+import sys
+
+source = r'''
+{{ body }}
+'''
+
+try:
+    ast.parse(source)
+except SyntaxError as e:
+    print(f"SyntaxError on wrappee body: {e}", file=sys.stderr)
+    sys.exit(1)
+
+# The validator harness watches for the EXAM-HELLO success line; emit it
+# on a successful parse so a syntax-clean snippet shows as a passing
+# validation run.
+print("feature flag evaluates to true")
+```

--- a/snippets/sdks/python-server-sdk/snippets/scaffolds/with-test-data.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/scaffolds/with-test-data.snippet.md
@@ -1,0 +1,61 @@
+---
+id: python-server-sdk/scaffolds/with-test-data
+sdk: python-server-sdk
+kind: scaffold
+lang: python
+file: main.py
+description: |
+  Standard validator harness for Python doc fragments that assume a
+  pre-initialized `client` and `context`. Initializes the SDK against a
+  TestData source pre-populated with the docs' canonical
+  `your.feature.key` flag (returns true), builds a Context, runs the
+  wrappee body, then prints the EXAM-HELLO success line so the existing
+  Python validator harness recognizes a successful run.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, inserted between client setup and the success-line print.
+validation:
+  runtime: python
+  entrypoint: main.py
+  # observability is the optional plugin the install/import docs reference;
+  # including it here means snippets that mention `ldobserve` imports can
+  # validate cleanly under this scaffold without a separate variant.
+  requirements: |
+    launchdarkly-server-sdk
+    launchdarkly-observability
+---
+
+```python
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+from ldclient.integrations.test_data import TestData
+
+# TestData is the SDK's in-process flag store — no network, no real LD env.
+# We pre-populate `your.feature.key` (the canonical flag key the docs use
+# in their evaluating / variation_detail / all_flags examples) to true, so
+# any wrappee that evaluates that flag will get a non-default value.
+td = TestData.data_source()
+td.update(td.flag("your.feature.key").variation_for_all(True))
+
+config = Config("test-sdk-key", update_processor_class=td, send_events=False)
+ldclient.set_config(config)
+client = ldclient.get()
+
+# Most docs fragments build their own context; this default exists so the
+# fragment can omit the builder when it's not the focus of the snippet.
+context = Context.builder("example-context-key").name("Sandy").build()
+
+# --- wrappee body ---
+{{ body }}
+# --- end wrappee body ---
+
+# Final evaluation drives the EXAM-HELLO success line. Snippets that
+# already set `flag_value` will see it overwritten here — that's fine, the
+# point is just to confirm the SDK initialized and the API surface
+# resolves cleanly. A wrappee with stale imports or removed methods would
+# have failed before reaching this line.
+flag_value = client.variation("your.feature.key", context, False)
+print(f"feature flag evaluates to {flag_value}")
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/evaluate.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/evaluate.snippet.md
@@ -1,0 +1,19 @@
+---
+id: python-server-sdk/sdk-docs/evaluate
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Build a context and evaluate a flag (Python SDK v8.0+).
+---
+
+```python
+from ldclient import Context
+
+context = Context.builder("example-context-key").name("Sandy").build()
+flag_value = client.variation("example-flag-key", context, False)
+
+if flag_value:
+    # application code to show the feature
+else:
+    # the code to run if the feature is off
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/evaluate.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/evaluate.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Build a context and evaluate a flag (Python SDK v8.0+).
+validation:
+  scaffold: python-server-sdk/scaffolds/with-test-data
 ---
 
 ```python
@@ -14,6 +16,8 @@ flag_value = client.variation("example-flag-key", context, False)
 
 if flag_value:
     # application code to show the feature
+    pass
 else:
     # the code to run if the feature is off
+    pass
 ```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/import.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/import.snippet.md
@@ -1,0 +1,16 @@
+---
+id: python-server-sdk/sdk-docs/import
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: SDK + observability plugin imports.
+---
+
+```python
+import ldclient
+from ldclient.config import Config
+
+# optional observability plugin, requires Python SDK v9.12+
+import ldobserve
+from ldobserve import ObservabilityConfig, ObservabilityPlugin, observe
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/import.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/import.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: SDK + observability plugin imports.
+validation:
+  scaffold: python-server-sdk/scaffolds/with-test-data
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/init.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/init.snippet.md
@@ -1,0 +1,16 @@
+---
+id: python-server-sdk/sdk-docs/init
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Initialize the singleton ldclient with the SDK key and the optional observability plugin.
+---
+
+```python
+ldclient.set_config(Config("YOUR_SDK_KEY",
+  # optional observability plugin, requires Python SDK v9.12+
+  plugins=[ObservabilityPlugin()]
+  )
+)
+client = ldclient.get()
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/install.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/install.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/install
+sdk: python-server-sdk
+kind: reference
+lang: shell
+description: pip install for the SDK plus the optional observability plugin (requires Python SDK v9.12+).
+---
+
+```shell
+pip install launchdarkly-server-sdk
+
+# optional observability plugin, requires Python SDK v9.12+
+pip install launchdarkly-observability
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/postfork.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/postfork.snippet.md
@@ -4,6 +4,10 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Worker-based-server initialization with postfork() reinitialization (Python SDK v9.11+).
+validation:
+  # Forking semantics aren't reproducible in the validator harness; fall
+  # back to a parse-only check so we still catch syntax issues.
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/postfork.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/postfork.snippet.md
@@ -1,0 +1,17 @@
+---
+id: python-server-sdk/sdk-docs/postfork
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Worker-based-server initialization with postfork() reinitialization (Python SDK v9.11+).
+---
+
+```python
+# 1. Create the client before forking.
+ldclient.set_config(Config("YOUR_SDK_KEY"))
+client = ldclient.get()
+
+# 2. From the newly forked process, reinitialize the client by calling `postfork`.
+# Examples for specific servers are shown below.
+client.postfork()
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-mac.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-mac.snippet.md
@@ -1,0 +1,11 @@
+---
+id: python-server-sdk/sdk-docs/proxy-env-mac
+sdk: python-server-sdk
+kind: reference
+lang: shell
+description: Mac/Linux HTTPS_PROXY environment variable.
+---
+
+```shell
+export HTTPS_PROXY=https://web-proxy.domain.com:8080
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-python.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-python.snippet.md
@@ -1,0 +1,11 @@
+---
+id: python-server-sdk/sdk-docs/proxy-env-python
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Set HTTPS_PROXY from inside Python.
+---
+
+```python
+os.environ["HTTPS_PROXY"] = "https://web-proxy.domain.com:8080"
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-windows.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-windows.snippet.md
@@ -1,0 +1,11 @@
+---
+id: python-server-sdk/sdk-docs/proxy-env-windows
+sdk: python-server-sdk
+kind: reference
+lang: shell
+description: Windows HTTPS_PROXY environment variable.
+---
+
+```shell
+set HTTPS_PROXY=https://web-proxy.domain.com:8080
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/uwsgi-init.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/uwsgi-init.snippet.md
@@ -4,6 +4,11 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: uWSGI integration that calls postfork() inside @uwsgidecorators.postfork.
+validation:
+  # uWSGI isn't installable in the validator container; fall back to
+  # parse-only. The decorator-based fork lifecycle would need a real
+  # uWSGI master process to exercise.
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/uwsgi-init.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/uwsgi-init.snippet.md
@@ -1,0 +1,21 @@
+---
+id: python-server-sdk/sdk-docs/uwsgi-init
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: uWSGI integration that calls postfork() inside @uwsgidecorators.postfork.
+---
+
+```python
+import uwsgidecorators
+
+# Instantiate the client before the fork
+ldclient.set_config(LDConfig("YOUR_SDK_KEY"))
+client = ldclient.get()
+
+@uwsgidecorators.postfork
+def post_fork_client_initialization():
+    # Reinitialize the client after the fork
+    ldclient.get().postfork()
+
+```


### PR DESCRIPTION
## Summary

End-to-end first slice of the ld-docs-private port: a new render target that rewrites fenced code blocks in MDX, scaffold-based validation that composes doc fragments into runnable harnesses, and the python-server-sdk lift of \`fern/topics/sdk/server-side/python/index.mdx\` validated through both Docker and parse-only paths.

## What's in this PR

### 1. \`--target=ld-docs\` adapter (commit \`37fa193\`)

Parallel to \`ldapplication\` but for MDX fenced code blocks:

- \`internal/markers/ScanMDX\` — finds \`{/* SDK_SNIPPET:RENDER:... */}\` comments and attaches each to the next fenced code block, skipping over wrapping JSX (\`<CodeBlocks>\`, \`<CodeBlock title='…'>\`). Hash covers fence-body bytes; the wrapper is the consumer's choice.
- \`internal/adapters/lddocs\` — render + verify.
- Concrete-value substitution via the existing \`render.RenderRuntime\`. Type-based docs placeholders for credentials (\`YOUR_FLAG_KEY\` etc.) so the rendered MDX never carries real keys.
- CLI: \`snippets render --target=ld-docs --entrypoint=<dir>\` and the matching \`verify\` subcommand.

8 marker-scanner tests, 3 adapter round-trip tests.

### 2. python-server-sdk doc snippet port (commit \`2368f32\`)

Lifts the nine fenced code blocks from the python index.mdx into discrete \`.snippet.md\` files under \`sdks/python-server-sdk/snippets/sdk-docs/\`. Verbatim ports — no inputs, since the docs use literal \`YOUR_SDK_KEY\`-style placeholders inline. Round-trip via \`verify\` is byte-clean.

New \`reference\` value for \`kind:\` (distinct from the flow-oriented bootstrap/install/hello-world/run kinds used by the gonfalon target).

### 3. Scaffold-based validation (commit \`cb05181\`)

Doc fragments aren't standalone runnable — most assume a pre-initialized client / context. Adds:

- \`validation.scaffold:\` and \`validation.scaffold-inputs:\` schema.
- A snippet that sets \`scaffold: <id>\` declares its body should be inserted into the named scaffold's \`{{ body }}\` slot before validation. The scaffold owns runtime/entrypoint/requirements/companions; the wrappee just contributes its body fragment.
- New \`kind: scaffold\` — excluded from standalone validation (its \`{{ body }}\` slot would be unbound).
- Validator wires composition cleanly into the existing staging path: render wrappee body, render scaffold body with \`body=<wrappee>\`, stage at scaffold's \`file:\` path, run scaffold's harness.

Adds \`--snippet=<id>\` filter to \`validate\` for targeted dev runs. Tests cover composition, scaffold-inputs override, the skip-scaffold rule, and bad-scaffold-id errors.

First scaffold: \`python-server-sdk/scaffolds/with-test-data\`. Initializes the SDK against a TestData source pre-populated with \`your.feature.key\`, builds a Context, runs \`{{ body }}\`, prints the EXAM-HELLO success line.

Bound to:
- \`sdk-docs/evaluate\` ✓ — exercised the harness; the wrappee's \`if flag_value: # comment / else: # comment\` blocks raised IndentationError. Fixed by adding \`pass\` statements to both the snippet and the source MDX (kept byte-identical so verify still passes). **The validator caught a real docs bug on its first end-to-end run.**
- \`sdk-docs/import\` ✓ — verifies the six imports resolve against the installed SDK + observability plugin.

### 4. Syntax-only scaffold (commit \`f5362ab\`)

For snippets whose runtime context isn't reproducible — fork-based APIs, uWSGI integration. Adds \`python-server-sdk/scaffolds/python-syntax-only\`: parses the wrappee body via \`ast.parse\` without executing it, prints the success line on a clean parse. Catches SyntaxError; can't catch ImportError or AttributeError on calls.

Bound to \`sdk-docs/postfork\` and \`sdk-docs/uwsgi-init\`.

## Validation status — python-server-sdk doc slice

| Snippet | Scaffold | Status |
|---|---|---|
| \`sdk-docs/evaluate\` | \`with-test-data\` | ✅ runs in Docker against the SDK |
| \`sdk-docs/import\` | \`with-test-data\` | ✅ runs in Docker against SDK + observability plugin |
| \`sdk-docs/postfork\` | \`python-syntax-only\` | ✅ parse-only |
| \`sdk-docs/uwsgi-init\` | \`python-syntax-only\` | ✅ parse-only |
| \`sdk-docs/install\` | none yet | ⏸ shell — tracked in [SDK-2300](https://launchdarkly.atlassian.net/browse/SDK-2300) |
| \`sdk-docs/proxy-env-mac\` | none yet | ⏸ shell — tracked in [SDK-2300](https://launchdarkly.atlassian.net/browse/SDK-2300) |
| \`sdk-docs/proxy-env-windows\` | none yet | ⏸ shell (cmd, not bash) — tracked in [SDK-2300](https://launchdarkly.atlassian.net/browse/SDK-2300) |
| \`sdk-docs/proxy-env-python\` | none yet | ⏸ probably wants its own scaffold; minor |
| \`sdk-docs/init\` | none yet | ⏸ uses literal \`"YOUR_SDK_KEY"\` — needs a scaffold variant that swaps placeholders for test values |

## Follow-ups tracked in design doc + Jira

- **[SDK-2299](https://launchdarkly.atlassian.net/browse/SDK-2299)** — multi-command snippet bodies (the \`pip install foo / # optional / pip install bar\` shape).
- **[SDK-2300](https://launchdarkly.atlassian.net/browse/SDK-2300)** — shell-based validators (install, proxy-env-*).

## Test plan

- [x] \`go test ./...\` clean (validator scaffold tests, MDX scanner tests, adapter round-trip tests).
- [x] \`snippets render --target=ld-docs\` round-trips the python index.mdx byte-clean (only the marker comments are added).
- [x] \`snippets verify --target=ld-docs\` passes after a fresh render.
- [x] Re-render is a no-op (idempotent).
- [x] \`snippets validate --sdk=python-server-sdk --snippet=python-server-sdk/sdk-docs/evaluate\` runs in Docker → "feature flag evaluates to True".
- [x] Same for \`/import\`, \`/postfork\`, \`/uwsgi-init\`.

## Out of scope

- Other server-side SDKs and all client-side SDKs — next branch off this one.
- Wiring the actual ld-docs-private sync workflow (no \`sync-snippets\` analog exists for it yet; the existing gh-actions composite is gonfalon-shaped).
- The MDX edits to ld-docs-private are not part of this PR — they live in a working-tree change in the docs repo and will land separately once this PR is approved.

[SDK-2300]: https://launchdarkly.atlassian.net/browse/SDK-2300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new MDX render/verify adapter and extends validation to compose scaffolded snippets, changing how snippet output is generated and executed in CI/dev workflows. Risk is moderate due to new parsing/rewriting logic and altered validation staging/selection paths, though changes are well-covered by new tests.
> 
> **Overview**
> Adds a new `--target=ld-docs` mode for `snippets render`/`verify` that rewrites **MDX fenced code-block bodies** referenced by `{/* SDK_SNIPPET:RENDER:... */}` markers, including a new `markers.ScanMDX` scanner and an `lddocs` adapter that hashes/versions only the fence body and preserves surrounding MDX/JSX wrappers.
> 
> Extends `snippets validate` with `--snippet` filtering and **scaffold-based validation**: snippets can now declare `validation.scaffold`/`validation.scaffold-inputs` to compose doc fragments into a scaffold’s `{{ body }}` for staging/execution; scaffolds are excluded from standalone validation. Includes new tests plus an initial `python-server-sdk` doc-snippet slice and two Python scaffold snippets (`with-test-data`, `python-syntax-only`) wired via `validation.scaffold`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5362abb483b83df4555979914911f836eb4ee56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->