### PR TITLE
feat: Port "sdk-info" snippets.

### DIFF
--- a/snippets/cmd/snippets/main.go
+++ b/snippets/cmd/snippets/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/launchdarkly/sdk-meta/snippets"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/adapters/ldapplication"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/adapters/lddocs"
+	"github.com/launchdarkly/sdk-meta/snippets/internal/adapters/rawfiles"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/validate"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/version"
 )
@@ -46,6 +47,13 @@ usage:
                          (gonfalon, the LaunchDarkly app)
         ld-docs        — rewrites fenced code-block bodies in MDX
                          (ld-docs-private, ld-docs)
+
+  snippets render --target=raw-files --manifest=<path> [--consumer=<dir>] [--sdks=./sdks]
+      Reads a YAML manifest enumerating (snippet-id, output-path) pairs and
+      writes each rendered body to <consumer>/<manifest.out>/<entry.path>.
+      Used by consumers that import snippet text via Vite's "?raw" import
+      pattern (e.g. gonfalon's packages/sdk-info/) where the marker-driven
+      flow doesn't apply. --consumer defaults to the manifest's directory.
 
   snippets verify --target=<target> --entrypoint=<dir> [--entrypoint=<dir2> ...] [--sdks=./sdks]
       Read-only counterpart to render, used by CI in the consumer repo.
@@ -89,31 +97,61 @@ func main() {
 
 func runRender(args []string) {
 	fset := flag.NewFlagSet("render", flag.ExitOnError)
-	target := fset.String("target", "", "adapter target: `ld-application` or `ld-docs`")
+	target := fset.String("target", "", "adapter target: `ld-application`, `ld-docs`, or `raw-files`")
 	var entrypoints repeatableString
-	fset.Var(&entrypoints, "entrypoint", "directory in the consumer checkout to walk for marker files (repeatable)")
+	fset.Var(&entrypoints, "entrypoint", "directory in the consumer checkout to walk for marker files (repeatable; ld-application and ld-docs only)")
+	manifest := fset.String("manifest", "", "path to a raw-files manifest YAML (raw-files only)")
+	consumer := fset.String("consumer", "", "consumer-checkout root that the manifest's `out:` resolves against (default: manifest's directory)")
 	sdks := fset.String("sdks", "", "path to a sdks/ directory (default: embedded)")
 	_ = fset.Parse(args)
 
-	if len(entrypoints) == 0 {
-		fmt.Fprintf(os.Stderr, "render: at least one --entrypoint is required\n")
-		os.Exit(2)
-	}
-	var changed []string
-	var err error
 	switch *target {
 	case "ld-application":
-		changed, err = ldapplication.Render(resolveSDKsFS(*sdks), entrypoints)
+		if len(entrypoints) == 0 {
+			fmt.Fprintf(os.Stderr, "render: --target=ld-application requires at least one --entrypoint\n")
+			os.Exit(2)
+		}
+		changed, err := ldapplication.Render(resolveSDKsFS(*sdks), entrypoints)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "render failed: %v\n", err)
+			os.Exit(1)
+		}
+		printRenderResult(changed)
 	case "ld-docs":
-		changed, err = lddocs.Render(resolveSDKsFS(*sdks), entrypoints)
+		if len(entrypoints) == 0 {
+			fmt.Fprintf(os.Stderr, "render: --target=ld-docs requires at least one --entrypoint\n")
+			os.Exit(2)
+		}
+		changed, err := lddocs.Render(resolveSDKsFS(*sdks), entrypoints)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "render failed: %v\n", err)
+			os.Exit(1)
+		}
+		printRenderResult(changed)
+	case "raw-files":
+		if *manifest == "" {
+			fmt.Fprintf(os.Stderr, "render: --target=raw-files requires --manifest\n")
+			os.Exit(2)
+		}
+		written, err := rawfiles.Render(resolveSDKsFS(*sdks), *manifest, *consumer)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "render failed: %v\n", err)
+			os.Exit(1)
+		}
+		if len(written) == 0 {
+			fmt.Println("no files written")
+			return
+		}
+		for _, p := range written {
+			fmt.Println("wrote", p)
+		}
 	default:
-		fmt.Fprintf(os.Stderr, "render: --target must be `ld-application` or `ld-docs`\n")
+		fmt.Fprintf(os.Stderr, "render: --target must be `ld-application`, `ld-docs`, or `raw-files` (got %q)\n", *target)
 		os.Exit(2)
 	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "render failed: %v\n", err)
-		os.Exit(1)
-	}
+}
+
+func printRenderResult(changed []string) {
 	if len(changed) == 0 {
 		fmt.Println("no changes")
 		return

--- a/snippets/embedded_test.go
+++ b/snippets/embedded_test.go
@@ -24,9 +24,15 @@ func TestSDKsFS_BundlesEverySDK(t *testing.T) {
 
 	// Every SDK directory must carry an sdk.yaml; without it the
 	// ld-application adapter's discoverTargetFiles would skip it.
+	// Underscore-prefixed directories (e.g. _shared) hold cross-SDK
+	// snippets that aren't tied to a specific SDK and have no
+	// `sdk.yaml`; they're skipped.
 	missing := []string{}
 	for _, e := range entries {
 		if !e.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(e.Name(), "_") {
 			continue
 		}
 		if _, err := fs.Stat(fsys, e.Name()+"/sdk.yaml"); err != nil {

--- a/snippets/internal/adapters/ldapplication/ldapplication.go
+++ b/snippets/internal/adapters/ldapplication/ldapplication.go
@@ -2,14 +2,13 @@ package ldapplication
 
 import (
 	"bytes"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/launchdarkly/sdk-meta/snippets/internal/atomicfile"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/markers"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/model"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/render"
@@ -246,49 +245,7 @@ func rewriteFile(path string, snippets map[string]*model.Snippet, dryRun bool) (
 	if !changed {
 		return false, nil
 	}
-	return true, atomicWriteFile(path, []byte(sb.String()))
-}
-
-// atomicWriteFile writes to a same-directory tempfile, fsyncs, and renames
-// over the destination. The destination's permission bits are preserved so
-// running `snippets render` on a checkout that has tightened permissions
-// (e.g. read-only mode for a CODEOWNER-protected file) doesn't quietly
-// reset them to 0644.
-func atomicWriteFile(path string, data []byte) error {
-	dir := filepath.Dir(path)
-	mode := os.FileMode(0o644)
-	if info, err := os.Stat(path); err == nil {
-		mode = info.Mode().Perm()
-	}
-	// Random suffix avoids colliding with parallel renders.
-	var sfx [8]byte
-	if _, err := rand.Read(sfx[:]); err != nil {
-		return err
-	}
-	tmp := filepath.Join(dir, "."+filepath.Base(path)+".sdk-snippets."+hex.EncodeToString(sfx[:])+".tmp")
-	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return true, atomicfile.Write(path, []byte(sb.String()))
 }
 
 // renderForJSXChild produces the bytes that go between <Tag> and </Tag>.

--- a/snippets/internal/adapters/rawfiles/rawfiles.go
+++ b/snippets/internal/adapters/rawfiles/rawfiles.go
@@ -1,0 +1,275 @@
+// Package rawfiles renders snippet bodies to plain text files outside any
+// JSX/MDX context. It exists to back the gonfalon `packages/sdk-info/`
+// surface, where the existing consumer pattern is `import x from
+// './foo.txt?raw'` rather than the marker-driven `<Snippet>{...}</Snippet>`
+// rewrite the ldapplication adapter performs.
+//
+// Unlike ldapplication and lddocs, this adapter does NOT scan consumer
+// files for SDK_SNIPPET:RENDER markers. Marker-based discovery doesn't
+// fit the `?raw` import pattern (the consumer references a path, not an
+// inline marker), so the adapter is driven by a manifest the consumer
+// commits next to the output directory. The manifest enumerates every
+// snippet ID it wants extracted and the relative output path it should
+// land at.
+//
+// There is no `verify` counterpart for this target: with no marker on the
+// consumer side there's no contract to verify against. CI in the consumer
+// repo runs the renderer and diffs the resulting tree.
+package rawfiles
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/launchdarkly/sdk-meta/snippets/internal/model"
+	"github.com/launchdarkly/sdk-meta/snippets/internal/render"
+	"gopkg.in/yaml.v3"
+)
+
+// Manifest describes which snippets to extract and where to write them.
+// It's authored by the consumer and committed alongside the output
+// directory so the mapping from canonical snippet IDs to consumer paths
+// is reviewable and version-controlled.
+type Manifest struct {
+	// Out is the output root, relative to the manifest's directory or
+	// (less commonly) absolute. Each Files entry's Path is taken
+	// relative to Out.
+	Out string `yaml:"out"`
+
+	// Files lists the (snippet-id, output-path) pairs to render. Order
+	// in the source manifest is preserved; duplicate IDs and duplicate
+	// output paths are both errors caught by Validate.
+	Files []ManifestEntry `yaml:"files"`
+}
+
+// ManifestEntry is one line in the manifest. Both fields are required.
+type ManifestEntry struct {
+	// ID matches a snippet's frontmatter `id:` exactly. Mismatches are
+	// rejected with a list of close-match suggestions so a typo doesn't
+	// silently get skipped.
+	ID string `yaml:"id"`
+
+	// Path is the file location relative to Manifest.Out. The renderer
+	// creates parent directories as needed.
+	Path string `yaml:"path"`
+}
+
+// LoadManifest reads and parses a manifest file. Returns the parsed
+// Manifest and the directory containing the manifest (used to resolve a
+// relative `out:` path against).
+func LoadManifest(manifestPath string) (*Manifest, string, error) {
+	abs, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("manifest %q: %w", manifestPath, err)
+	}
+	raw, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, "", fmt.Errorf("manifest %q: %w", manifestPath, err)
+	}
+	var m Manifest
+	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&m); err != nil {
+		return nil, "", fmt.Errorf("manifest %q: %w", manifestPath, err)
+	}
+	if err := m.validate(); err != nil {
+		return nil, "", fmt.Errorf("manifest %q: %w", manifestPath, err)
+	}
+	return &m, filepath.Dir(abs), nil
+}
+
+// validate enforces structural invariants on a parsed manifest:
+//   - `out:` is required (otherwise the renderer wouldn't know where to write);
+//   - every entry has both `id:` and `path:`;
+//   - no duplicate ids (the consumer would silently shadow one);
+//   - no duplicate output paths (two snippets racing to the same file is
+//     either a copy-paste mistake or deliberate aliasing — neither is OK
+//     in a generated tree).
+func (m *Manifest) validate() error {
+	if strings.TrimSpace(m.Out) == "" {
+		return fmt.Errorf("`out:` is required")
+	}
+	if len(m.Files) == 0 {
+		return fmt.Errorf("`files:` is empty")
+	}
+	seenID := map[string]struct{}{}
+	seenPath := map[string]struct{}{}
+	for i, e := range m.Files {
+		if strings.TrimSpace(e.ID) == "" {
+			return fmt.Errorf("files[%d]: `id:` is required", i)
+		}
+		if strings.TrimSpace(e.Path) == "" {
+			return fmt.Errorf("files[%d] (id=%q): `path:` is required", i, e.ID)
+		}
+		// Output paths are always relative to `out:`. An absolute or
+		// `..`-traversing path would let a manifest write outside the
+		// declared output root, which defeats the point of having one.
+		if filepath.IsAbs(e.Path) {
+			return fmt.Errorf("files[%d] (id=%q): `path:` must be relative, got %q", i, e.ID, e.Path)
+		}
+		clean := filepath.Clean(e.Path)
+		if strings.HasPrefix(clean, "..") || strings.Contains(clean, string(filepath.Separator)+"..") {
+			return fmt.Errorf("files[%d] (id=%q): `path:` must not escape `out:`, got %q", i, e.ID, e.Path)
+		}
+		if _, dup := seenID[e.ID]; dup {
+			return fmt.Errorf("duplicate id %q in manifest", e.ID)
+		}
+		seenID[e.ID] = struct{}{}
+		if _, dup := seenPath[clean]; dup {
+			return fmt.Errorf("duplicate output path %q in manifest", e.Path)
+		}
+		seenPath[clean] = struct{}{}
+	}
+	return nil
+}
+
+// Render extracts every snippet listed in the manifest at manifestPath
+// and writes its rendered body to <consumerDir>/<manifest.out>/<entry.path>.
+// `consumerDir` is the consumer-checkout root that `out:` is resolved
+// against; passing the empty string defaults to the manifest's own
+// directory (the common case where the manifest sits next to the output
+// directory).
+//
+// Returns the absolute paths of every file written, sorted lexically.
+// Files whose content is byte-identical to what's already on disk are
+// still listed — atomic writes mean the inode changes regardless, and
+// the caller (CI's `git diff`) is the right place to detect no-op runs.
+func Render(sdksFS fs.FS, manifestPath, consumerDir string) ([]string, error) {
+	m, manifestDir, err := LoadManifest(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	snippets, err := model.LoadAll(sdksFS)
+	if err != nil {
+		return nil, err
+	}
+
+	root := consumerDir
+	if root == "" {
+		root = manifestDir
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("consumer dir %q: %w", root, err)
+	}
+	outRoot := m.Out
+	if !filepath.IsAbs(outRoot) {
+		outRoot = filepath.Join(absRoot, outRoot)
+	}
+
+	var written []string
+	for _, e := range m.Files {
+		s, ok := snippets[e.ID]
+		if !ok {
+			return nil, fmt.Errorf("manifest references unknown snippet id %q (suggestions: %s)",
+				e.ID, suggestSimilarIDs(e.ID, snippets))
+		}
+		body, err := renderBody(s)
+		if err != nil {
+			return nil, fmt.Errorf("snippet %s: %w", s.Path, err)
+		}
+		dest := filepath.Join(outRoot, filepath.FromSlash(e.Path))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return nil, fmt.Errorf("create %s: %w", filepath.Dir(dest), err)
+		}
+		if err := atomicWriteFile(dest, []byte(body)); err != nil {
+			return nil, fmt.Errorf("write %s: %w", dest, err)
+		}
+		written = append(written, dest)
+	}
+	return written, nil
+}
+
+// renderBody runs the snippet's body through the runtime renderer with
+// no inputs. Most sdk-info bodies have no template inputs at all, so
+// this is a near-passthrough; declared inputs would render as empty
+// strings here, and undeclared `{{ name }}` syntax (e.g. the cursor
+// prompt's `{{SDK_NAME}}` runtime placeholders) round-trips as literal
+// `{{ name }}` per the renderer's foreign-template contract.
+//
+// The output always ends with a trailing newline so the written file
+// matches the POSIX-friendly convention the source `.txt` files used.
+// The .snippet.md fence syntax strips the trailing newline before the
+// closing fence; we add one back here.
+func renderBody(s *model.Snippet) (string, error) {
+	tpl, err := render.Parse(s.CodeBody)
+	if err != nil {
+		return "", err
+	}
+	body, err := render.RenderRuntime(tpl, nil)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return body, nil
+}
+
+// suggestSimilarIDs returns a short comma-joined list of candidate IDs
+// that look similar to the missing one. Used in the manifest-mismatch
+// error so a typo is easy to fix without paging through a 300-line
+// list of every loaded snippet.
+func suggestSimilarIDs(missing string, snippets map[string]*model.Snippet) string {
+	const max = 5
+	var hits []string
+	parts := strings.Split(missing, "/")
+	tail := parts[len(parts)-1]
+	for id := range snippets {
+		if strings.Contains(id, tail) {
+			hits = append(hits, id)
+			if len(hits) >= max {
+				break
+			}
+		}
+	}
+	if len(hits) == 0 {
+		return "(none)"
+	}
+	return strings.Join(hits, ", ")
+}
+
+// atomicWriteFile mirrors ldapplication.atomicWriteFile: write to a
+// same-directory tempfile, fsync, rename. Crash-safe and concurrent-safe
+// across parallel renders that target distinct destinations.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	var sfx [8]byte
+	if _, err := rand.Read(sfx[:]); err != nil {
+		return err
+	}
+	tmp := filepath.Join(dir, "."+filepath.Base(path)+".sdk-snippets."+hex.EncodeToString(sfx[:])+".tmp")
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/snippets/internal/adapters/rawfiles/rawfiles.go
+++ b/snippets/internal/adapters/rawfiles/rawfiles.go
@@ -18,14 +18,14 @@
 package rawfiles
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/launchdarkly/sdk-meta/snippets/internal/atomicfile"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/model"
 	"github.com/launchdarkly/sdk-meta/snippets/internal/render"
 	"gopkg.in/yaml.v3"
@@ -135,10 +135,11 @@ func (m *Manifest) validate() error {
 // directory (the common case where the manifest sits next to the output
 // directory).
 //
-// Returns the absolute paths of every file written, sorted lexically.
-// Files whose content is byte-identical to what's already on disk are
-// still listed — atomic writes mean the inode changes regardless, and
-// the caller (CI's `git diff`) is the right place to detect no-op runs.
+// Returns the absolute paths of every file written, sorted lexically
+// regardless of manifest entry order. Files whose content is
+// byte-identical to what's already on disk are still listed — atomic
+// writes mean the inode changes regardless, and the caller (CI's
+// `git diff`) is the right place to detect no-op runs.
 func Render(sdksFS fs.FS, manifestPath, consumerDir string) ([]string, error) {
 	m, manifestDir, err := LoadManifest(manifestPath)
 	if err != nil {
@@ -178,11 +179,12 @@ func Render(sdksFS fs.FS, manifestPath, consumerDir string) ([]string, error) {
 		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 			return nil, fmt.Errorf("create %s: %w", filepath.Dir(dest), err)
 		}
-		if err := atomicWriteFile(dest, []byte(body)); err != nil {
+		if err := atomicfile.Write(dest, []byte(body)); err != nil {
 			return nil, fmt.Errorf("write %s: %w", dest, err)
 		}
 		written = append(written, dest)
 	}
+	sort.Strings(written)
 	return written, nil
 }
 
@@ -235,41 +237,3 @@ func suggestSimilarIDs(missing string, snippets map[string]*model.Snippet) strin
 	return strings.Join(hits, ", ")
 }
 
-// atomicWriteFile mirrors ldapplication.atomicWriteFile: write to a
-// same-directory tempfile, fsync, rename. Crash-safe and concurrent-safe
-// across parallel renders that target distinct destinations.
-func atomicWriteFile(path string, data []byte) error {
-	dir := filepath.Dir(path)
-	mode := os.FileMode(0o644)
-	if info, err := os.Stat(path); err == nil {
-		mode = info.Mode().Perm()
-	}
-	var sfx [8]byte
-	if _, err := rand.Read(sfx[:]); err != nil {
-		return err
-	}
-	tmp := filepath.Join(dir, "."+filepath.Base(path)+".sdk-snippets."+hex.EncodeToString(sfx[:])+".tmp")
-	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
-}

--- a/snippets/internal/adapters/rawfiles/rawfiles_test.go
+++ b/snippets/internal/adapters/rawfiles/rawfiles_test.go
@@ -177,31 +177,7 @@ func TestLoadManifest_RejectsMissingOut(t *testing.T) {
 	}
 }
 
-// atomicWriteFile preserves the destination's permission bits when
-// overwriting. Mirrors the contract of ldapplication.atomicWriteFile.
-func TestAtomicWriteFile_PreservesMode(t *testing.T) {
-	tmp := t.TempDir()
-	dest := filepath.Join(tmp, "f.txt")
-	if err := os.WriteFile(dest, []byte("first"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := atomicWriteFile(dest, []byte("second")); err != nil {
-		t.Fatal(err)
-	}
-	info, err := os.Stat(dest)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("expected mode 0600 preserved, got %o", info.Mode().Perm())
-	}
-	got, _ := os.ReadFile(dest)
-	if string(got) != "second" {
-		t.Fatalf("body mismatch: %q", got)
-	}
-}
-
-// atomicWriteFile creates intermediate directories when called from
+// atomicfile.Write creates intermediate directories when called from
 // Render — exercises that the Render path mkdir-p's.
 func TestRender_CreatesIntermediateDirs(t *testing.T) {
 	tmp := t.TempDir()

--- a/snippets/internal/adapters/rawfiles/rawfiles_test.go
+++ b/snippets/internal/adapters/rawfiles/rawfiles_test.go
@@ -1,0 +1,252 @@
+package rawfiles
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSDK seeds a one-snippet sdks/<id>/ tree at sdksDir. The body is
+// plain text so the no-input render path is exercised.
+func writeSDK(t *testing.T, sdksDir, sdkID, snippetID, lang, body string) {
+	t.Helper()
+	d := filepath.Join(sdksDir, sdkID)
+	if err := os.MkdirAll(filepath.Join(d, "snippets", "sdk-info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "sdk.yaml"),
+		[]byte("id: "+sdkID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	md := "---\n" +
+		"id: " + snippetID + "\n" +
+		"sdk: " + sdkID + "\n" +
+		"kind: install\n" +
+		"lang: " + lang + "\n" +
+		"file: out/" + filepath.Base(snippetID) + ".txt\n" +
+		"---\n\n" +
+		"```" + lang + "\n" + body + "\n```\n"
+	if err := os.WriteFile(filepath.Join(d, "snippets", "sdk-info", filepath.Base(snippetID)+".snippet.md"),
+		[]byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFile(t *testing.T, p, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Round-trip: a manifest pointing at a registered snippet writes the body
+// (plus a trailing newline) to the configured output path.
+func TestRender_WritesSnippetBodiesToManifestPaths(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	consumer := filepath.Join(tmp, "consumer")
+	writeSDK(t, sdks, "x-sdk", "x-sdk/sdk-info/install", "shell", "npm i x")
+
+	manifest := filepath.Join(consumer, "extract.yaml")
+	writeFile(t, manifest, "out: snippets\nfiles:\n  - id: x-sdk/sdk-info/install\n    path: x-sdk/install.txt\n")
+
+	written, err := Render(os.DirFS(sdks), manifest, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 1 {
+		t.Fatalf("expected 1 file written, got %d: %v", len(written), written)
+	}
+	got, err := os.ReadFile(filepath.Join(consumer, "snippets", "x-sdk", "install.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The .snippet.md fence syntax strips the trailing newline before the
+	// closing fence; the adapter adds one back so the on-disk file ends
+	// with a newline (matches the source .txt POSIX convention).
+	if string(got) != "npm i x\n" {
+		t.Fatalf("body mismatch: %q", got)
+	}
+}
+
+// The --consumer override resolves the manifest's `out:` against the
+// supplied root rather than the manifest's directory. This is the path
+// gonfalon's CI uses to render into a checkout that's separate from the
+// repo where the manifest lives.
+func TestRender_ConsumerOverrideResolvesOut(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	manifestDir := filepath.Join(tmp, "manifests")
+	consumer := filepath.Join(tmp, "elsewhere")
+	writeSDK(t, sdks, "x-sdk", "x-sdk/sdk-info/install", "shell", "npm i x")
+
+	manifest := filepath.Join(manifestDir, "extract.yaml")
+	writeFile(t, manifest, "out: snippets\nfiles:\n  - id: x-sdk/sdk-info/install\n    path: a.txt\n")
+
+	if _, err := Render(os.DirFS(sdks), manifest, consumer); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(consumer, "snippets", "a.txt")); err != nil {
+		t.Fatalf("expected file under consumer/snippets: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(manifestDir, "snippets", "a.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected NO file under manifest dir, got err=%v", err)
+	}
+}
+
+// A manifest referencing an unknown snippet ID fails with a useful
+// suggestions list rather than silently emitting an empty file.
+func TestRender_RejectsUnknownID(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	consumer := filepath.Join(tmp, "consumer")
+	writeSDK(t, sdks, "x-sdk", "x-sdk/sdk-info/install", "shell", "npm i x")
+
+	manifest := filepath.Join(consumer, "extract.yaml")
+	writeFile(t, manifest, "out: snippets\nfiles:\n  - id: x-sdk/sdk-info/innstall\n    path: x.txt\n")
+
+	_, err := Render(os.DirFS(sdks), manifest, "")
+	if err == nil {
+		t.Fatal("expected error for unknown id")
+	}
+	if !strings.Contains(err.Error(), "unknown snippet id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Manifest validation rejects duplicate IDs (would silently shadow a
+// previous render entry).
+func TestLoadManifest_RejectsDuplicateID(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := filepath.Join(tmp, "extract.yaml")
+	writeFile(t, manifest, "out: out\nfiles:\n  - id: a/sdk-info/x\n    path: a.txt\n  - id: a/sdk-info/x\n    path: b.txt\n")
+	if _, _, err := LoadManifest(manifest); err == nil ||
+		!strings.Contains(err.Error(), "duplicate id") {
+		t.Fatalf("want duplicate-id error, got %v", err)
+	}
+}
+
+// Manifest validation rejects duplicate output paths (two snippets racing
+// to the same file).
+func TestLoadManifest_RejectsDuplicatePath(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := filepath.Join(tmp, "extract.yaml")
+	writeFile(t, manifest, "out: out\nfiles:\n  - id: a/sdk-info/x\n    path: a.txt\n  - id: a/sdk-info/y\n    path: a.txt\n")
+	if _, _, err := LoadManifest(manifest); err == nil ||
+		!strings.Contains(err.Error(), "duplicate output path") {
+		t.Fatalf("want duplicate-path error, got %v", err)
+	}
+}
+
+// Manifest validation rejects entries whose `path:` would write outside
+// the declared `out:` root.
+func TestLoadManifest_RejectsTraversingPath(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := filepath.Join(tmp, "extract.yaml")
+	writeFile(t, manifest, "out: snippets\nfiles:\n  - id: a/sdk-info/x\n    path: ../escape.txt\n")
+	if _, _, err := LoadManifest(manifest); err == nil ||
+		!strings.Contains(err.Error(), "must not escape") {
+		t.Fatalf("want escape error, got %v", err)
+	}
+}
+
+// An unknown frontmatter key in the manifest is rejected at parse time
+// (KnownFields is on). Catches typos like `output:` instead of `out:`.
+func TestLoadManifest_RejectsUnknownKey(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := filepath.Join(tmp, "extract.yaml")
+	writeFile(t, manifest, "out: out\noutput: something\nfiles:\n  - id: a/sdk-info/x\n    path: a.txt\n")
+	if _, _, err := LoadManifest(manifest); err == nil ||
+		!strings.Contains(err.Error(), "field output") {
+		t.Fatalf("want unknown-field error, got %v", err)
+	}
+}
+
+// Missing `out:` is rejected — the renderer wouldn't know where to write.
+func TestLoadManifest_RejectsMissingOut(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := filepath.Join(tmp, "extract.yaml")
+	writeFile(t, manifest, "files:\n  - id: a/sdk-info/x\n    path: a.txt\n")
+	if _, _, err := LoadManifest(manifest); err == nil ||
+		!strings.Contains(err.Error(), "out:") {
+		t.Fatalf("want missing-out error, got %v", err)
+	}
+}
+
+// atomicWriteFile preserves the destination's permission bits when
+// overwriting. Mirrors the contract of ldapplication.atomicWriteFile.
+func TestAtomicWriteFile_PreservesMode(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "f.txt")
+	if err := os.WriteFile(dest, []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(dest, []byte("second")); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected mode 0600 preserved, got %o", info.Mode().Perm())
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != "second" {
+		t.Fatalf("body mismatch: %q", got)
+	}
+}
+
+// atomicWriteFile creates intermediate directories when called from
+// Render — exercises that the Render path mkdir-p's.
+func TestRender_CreatesIntermediateDirs(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	consumer := filepath.Join(tmp, "consumer")
+	writeSDK(t, sdks, "x-sdk", "x-sdk/sdk-info/install", "shell", "npm i x")
+
+	manifest := filepath.Join(consumer, "extract.yaml")
+	writeFile(t, manifest, "out: out\nfiles:\n  - id: x-sdk/sdk-info/install\n    path: deep/nested/path/install.txt\n")
+
+	if _, err := Render(os.DirFS(sdks), manifest, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(consumer, "out", "deep", "nested", "path", "install.txt")); err != nil {
+		t.Fatalf("expected nested file: %v", err)
+	}
+}
+
+// Bodies that have a foreign-template `{{ name }}` (not declared as an
+// input) round-trip verbatim through the renderer when called with no
+// inputs. Important for the cursor prompt's `{{SDK_NAME}}` placeholders
+// — they should land in the rendered file unchanged so gonfalon's
+// runtime substitution sees the same source it always has.
+//
+// Caveat documented in the inconsistency log: `{{SDK_NAME}}` (no inner
+// whitespace) round-trips as `{{ SDK_NAME }}` (with whitespace) because
+// the renderer normalizes Var formatting.
+func TestRender_PreservesForeignTemplateMarkers(t *testing.T) {
+	tmp := t.TempDir()
+	sdks := filepath.Join(tmp, "sdks")
+	consumer := filepath.Join(tmp, "consumer")
+	// Body holds a `{{ NAME }}` that's not in any inputs map.
+	writeSDK(t, sdks, "x-sdk", "x-sdk/sdk-info/install", "text", "Hello {{ NAME }}")
+
+	manifest := filepath.Join(consumer, "extract.yaml")
+	writeFile(t, manifest, "out: out\nfiles:\n  - id: x-sdk/sdk-info/install\n    path: hello.txt\n")
+
+	if _, err := Render(os.DirFS(sdks), manifest, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(consumer, "out", "hello.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Hello {{ NAME }}\n" {
+		t.Fatalf("expected foreign-template preserved, got %q", got)
+	}
+}

--- a/snippets/internal/atomicfile/atomicfile.go
+++ b/snippets/internal/atomicfile/atomicfile.go
@@ -1,0 +1,52 @@
+// Package atomicfile writes a file by way of a same-directory tempfile,
+// fsync, and rename. Crash-safe and concurrent-safe across parallel
+// renders that target distinct destinations. Used by every render
+// adapter that emits files into the consumer checkout.
+package atomicfile
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+)
+
+// Write atomically replaces path with data. Preserves the destination's
+// existing permission bits (so a checkout that has tightened a file to
+// read-only mode for CODEOWNER reasons doesn't quietly get reset to
+// 0644). New files are created with mode 0644.
+func Write(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	var sfx [8]byte
+	if _, err := rand.Read(sfx[:]); err != nil {
+		return err
+	}
+	tmp := filepath.Join(dir, "."+filepath.Base(path)+".sdk-snippets."+hex.EncodeToString(sfx[:])+".tmp")
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/snippets/internal/atomicfile/atomicfile_test.go
+++ b/snippets/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,69 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Write preserves the destination's permission bits when overwriting,
+// so a checkout that has tightened a file (e.g. read-only mode for a
+// CODEOWNER-protected file) doesn't quietly get reset to 0644.
+func TestWrite_PreservesMode(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "f.txt")
+	if err := os.WriteFile(dest, []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(dest, []byte("second")); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected mode 0600 preserved, got %o", info.Mode().Perm())
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != "second" {
+		t.Fatalf("body mismatch: %q", got)
+	}
+}
+
+// Write to a non-existing destination uses 0644 as the default mode.
+func TestWrite_NewFileDefaultMode(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "new.txt")
+	if err := Write(dest, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("expected mode 0644 for new file, got %o", info.Mode().Perm())
+	}
+}
+
+// Write leaves no .tmp turds behind in the destination directory after
+// a successful write.
+func TestWrite_NoTempfileLeftover(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "f.txt")
+	if err := Write(dest, []byte("body")); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "f.txt" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected only f.txt in dir, got %v", names)
+	}
+}

--- a/snippets/internal/render/render.go
+++ b/snippets/internal/render/render.go
@@ -149,10 +149,16 @@ func escapeTL(s string) string {
 	return s
 }
 
-// literalVar formats a Var node back to its source `{{ name }}` /
-// `{{ name | filter }}` form. Used when emitting an undeclared name
-// verbatim so foreign-template syntax round-trips intact.
+// literalVar formats a Var node back to its source form. Used when
+// emitting an undeclared name verbatim so foreign-template syntax
+// round-trips intact. Prefers the Raw form captured at parse time so
+// templates like the cursor-prompt's `{{SDK_NAME}}` (no inner whitespace)
+// don't get whitespace-normalized into a form gonfalon's runtime regex
+// won't match.
 func literalVar(v *Var) string {
+	if v.Raw != "" {
+		return v.Raw
+	}
 	if v.Filter == "" {
 		return "{{ " + v.Name + " }}"
 	}

--- a/snippets/internal/render/template.go
+++ b/snippets/internal/render/template.go
@@ -23,6 +23,13 @@ type Literal struct{ Text string }
 type Var struct {
 	Name   string
 	Filter string // empty if no filter; e.g. "camelCase"
+	// Raw is the source-text form including outer braces and any inner
+	// whitespace, e.g. "{{SDK_NAME}}" or "{{ flag | camelCase }}". Set by
+	// Parse; consumed by literalVar so foreign-template Vars round-trip
+	// byte-identically (the cursor-prompt template uses {{NAME}} with no
+	// surrounding whitespace and gonfalon's runtime regex requires that
+	// exact form).
+	Raw string
 }
 type Cond struct {
 	Var  string
@@ -78,7 +85,7 @@ func Parse(src string) ([]Node, error) {
 			append_(closed)
 		case m[6] >= 0: // "NAME" optionally followed by "| FILTER"
 			name := src[m[6]:m[7]]
-			v := &Var{Name: name}
+			v := &Var{Name: name, Raw: token}
 			if m[8] >= 0 {
 				filter := src[m[8]:m[9]]
 				if filter != "camelCase" {

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -1,0 +1,164 @@
+# sdk-info port notes
+
+Issues observed while lifting `gonfalon/packages/sdk-info/src/snippets/`
+into sdk-meta during Phase 1 of [SDK-2316][].
+Bodies were copied verbatim; nothing here was fixed in this PR — each
+entry is a flag for triage during Phase 2 (consumer refactor) or for a
+follow-up content pass.
+
+[SDK-2316]: https://launchdarkly.atlassian.net/browse/SDK-2316
+
+## Cursor prompt template uses an unsupported placeholder syntax
+
+**Severity**: medium
+
+**SDKs affected**: cursor-prompt (root)
+
+**What we observed**: `prompt.txt` uses `{{SDK_NAME}}`, `{{SDK_DOCS_URL}}`,
+`{{SDK_EVENT_DOC_URL}}` placeholders that gonfalon's
+`CursorSdkInstall.tsx` substitutes at runtime via a string-replace.
+sdk-meta's templating DSL parses any `{{ NAME }}` token (with or without
+inner whitespace) into a Var node and round-trips it as `{{ NAME }}`
+(with whitespace) when no input is declared. The lifted body therefore
+renders byte-different from the source file: `{{SDK_NAME}}` becomes
+`{{ SDK_NAME }}`. This is the only file in the 52-file set that does not
+round-trip byte-identical.
+
+**Recommended action**: Phase 2 (consumer refactor) replaces the
+runtime string-replace with the canonical DSL. Two paths to consider:
+either teach the DSL a "passthrough" mode that emits Var nodes verbatim
+(preserving original whitespace), or migrate the cursor template to use
+the DSL's own input contract and let the `<Snippet>` component supply
+the values. Until then, gonfalon's runtime substitution must continue
+to accept both `{{SDK_NAME}}` and `{{ SDK_NAME }}` so the canonical
+sdk-meta body stays usable.
+
+## Inconsistent npm install package-name conventions
+
+**Severity**: low
+
+**SDKs affected**: js-client-sdk, react-client-sdk, vue-client-sdk,
+node-client-sdk (all use `launchdarkly-<x>-sdk`); node-server-sdk,
+react-native-client-sdk (use `@launchdarkly/<x>-sdk`)
+
+**What we observed**: Newer SDK packages have moved to the
+`@launchdarkly/` npm scope, but the older packages haven't, so the
+install snippets diverge along package-name lines. This isn't a bug —
+each command is correct for its SDK — but a Phase 2 consumer would
+notice that the install-npm.txt files are nearly-but-not-quite a single
+template parameterized by package name.
+
+**Recommended action**: When migrating consumers, consider whether
+these can be expressed as a single `install-<pm>` snippet shared across
+SDKs with a `package` input. Tracked under the larger
+"deduplicate sdk-info with getting-started" effort in the design doc;
+not urgent.
+
+## flagEval snippets only exist for 6 of 13 SDKs
+
+**Severity**: low
+
+**SDKs affected**: missing for android-client-sdk, dotnet-server-sdk,
+go-server-sdk, ios-client-sdk, node-client-sdk, react-native-client-sdk,
+vue-client-sdk
+
+**What we observed**: Only 6 of the 13 SDKs ship a `flagEval.txt`.
+Gonfalon's FlagAddToCode UI presumably has a fallback for the missing
+ones (or just hides the step). Backfilling these is a content question,
+not a structural one.
+
+**Recommended action**: Hold off on backfilling in this PR (verbatim
+lift only). When Phase 2 lands the consumers, file a content-team
+ticket to source flagEval examples for the 7 missing SDKs from
+each SDK's reference docs.
+
+## init.txt fragments aren't standalone runnable
+
+**Severity**: medium
+
+**SDKs affected**: all 13
+
+**What we observed**: Every `init.txt` assumes a surrounding scaffold —
+e.g. java-server-sdk's body has a `Main` class and a `main` method but
+no package declaration; android-client-sdk's body uses `this@BaseApplication`
+with no Activity context; react-client-sdk's body uses a JSX `<App>`
+function with no module-level imports for `App`. The SDK-2316 design
+defers validation to "reuse the scaffold model from SDK-2308," meaning
+Phase 1 deliberately doesn't add `validation:` blocks to these
+snippets. They're documentation fragments, not runnable units.
+
+**Recommended action**: When the scaffold work from SDK-2308 lands,
+revisit each sdk-info `init` and `flagEval` snippet and decide whether
+to (a) add a scaffold-companion that wraps the fragment in a runnable
+shell, or (b) leave them documentation-only and rely on the existing
+`getting-started/` snippets for runnable coverage.
+
+## Cross-source drift between sdk-info and getting-started
+
+**Severity**: medium
+
+**SDKs affected**: js-client-sdk, others likely
+
+**What we observed**: js-client-sdk's `sdk-info/init.txt` uses
+`createClient('YOUR_CLIENT_SIDE_ID', context)` (the v4 API), while
+sdk-meta's existing `js-client-sdk/snippets/getting-started/app-ts.snippet.md`
+and gonfalon's older Connect-an-SDK content reference different API
+generations. The design doc flags this as the canonical
+"v3 vs v4 vs docs" cross-source drift.
+
+**Recommended action**: Phase 1 keeps the two sources side-by-side
+under separate snippet groups (`sdk-info/` and `getting-started/`). The
+drift is real and pre-existing; deduplication is explicitly Phase 2
+scope per SDK-2316. Flag the divergence in the Phase 2 ticket so the
+consumer-refactor PR resolves both consumers onto a single canonical
+snippet rather than silently picking one and breaking the other.
+
+## .NET install-csharp snippet uses a PowerShell command
+
+**Severity**: low
+
+**SDKs affected**: dotnet-server-sdk
+
+**What we observed**: `install-csharp.txt` contains
+`Install-Package LaunchDarkly.ServerSdk` — a NuGet PowerShell cmdlet,
+not a `dotnet` CLI invocation. The `lang:` field on the lifted snippet
+is therefore set to `powershell` (not `csharp`). The filename
+`install-csharp.txt` is misleading.
+
+**Recommended action**: Verbatim-lift kept the original filename so
+gonfalon's existing `?raw` import keeps working. When Phase 2 migrates
+the consumers, consider renaming to `install-nuget` and/or adding a
+`install-dotnet-cli` companion (`dotnet add package LaunchDarkly.ServerSdk`)
+for projects on the modern CLI workflow.
+
+## install-package-swift.txt is a fragment, not a standalone Package.swift
+
+**Severity**: low
+
+**SDKs affected**: ios-client-sdk
+
+**What we observed**: The body opens with `//...` and ends with `//...`,
+i.e. it's intended to be pasted inside an existing `Package.swift`
+manifest. Validation as-is would fail; gonfalon shows it as a
+copy-paste hint.
+
+**Recommended action**: When scaffold validation lands, mark this
+snippet as documentation-only (no `validation:` block) and rely on a
+separate runnable `Package.swift` companion under `getting-started/`
+for end-to-end coverage.
+
+## Rendered files always end with a trailing newline
+
+**Severity**: informational
+
+**SDKs affected**: all
+
+**What we observed**: The `.snippet.md` fence syntax strips the trailing
+newline before the closing fence, so the rawfiles renderer adds one
+back to match the POSIX-friendly convention the source `.txt` files
+followed (every source file ends with a single `\n`). This is documented
+in `internal/adapters/rawfiles/rawfiles.go` (`renderBody`).
+
+**Recommended action**: None. Documented here so future readers don't
+chase a phantom drift if a `.snippet.md` body ends with multiple blank
+lines and the rendered output normalizes to one.

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -8,30 +8,27 @@ follow-up content pass.
 
 [SDK-2316]: https://launchdarkly.atlassian.net/browse/SDK-2316
 
-## Cursor prompt template uses an unsupported placeholder syntax
+## Cursor prompt template uses an unsupported placeholder syntax (fixed)
 
-**Severity**: medium
+**Severity**: ~~medium~~ resolved
 
 **SDKs affected**: cursor-prompt (root)
 
 **What we observed**: `prompt.txt` uses `{{SDK_NAME}}`, `{{SDK_DOCS_URL}}`,
 `{{SDK_EVENT_DOC_URL}}` placeholders that gonfalon's
-`CursorSdkInstall.tsx` substitutes at runtime via a string-replace.
-sdk-meta's templating DSL parses any `{{ NAME }}` token (with or without
-inner whitespace) into a Var node and round-trips it as `{{ NAME }}`
-(with whitespace) when no input is declared. The lifted body therefore
-renders byte-different from the source file: `{{SDK_NAME}}` becomes
-`{{ SDK_NAME }}`. This is the only file in the 52-file set that does not
-round-trip byte-identical.
+`CursorSdkInstall.tsx` substitutes at runtime via a regex
+(`/{{SDK_NAME}}/g`) that matches the no-whitespace form only. Originally
+the DSL parsed any `{{ NAME }}` token (with or without inner whitespace)
+into a Var node and round-tripped it as `{{ NAME }}` (with whitespace),
+so the lifted body rendered byte-different from the source — gonfalon's
+regex would not have matched the rendered output.
 
-**Recommended action**: Phase 2 (consumer refactor) replaces the
-runtime string-replace with the canonical DSL. Two paths to consider:
-either teach the DSL a "passthrough" mode that emits Var nodes verbatim
-(preserving original whitespace), or migrate the cursor template to use
-the DSL's own input contract and let the `<Snippet>` component supply
-the values. Until then, gonfalon's runtime substitution must continue
-to accept both `{{SDK_NAME}}` and `{{ SDK_NAME }}` so the canonical
-sdk-meta body stays usable.
+**Resolution**: The DSL now captures the original source-text form on
+the `Var` node (`Raw` field) and `literalVar` emits that verbatim for
+undeclared (foreign-template) names. All 52 sdk-info files now round-trip
+byte-identical to the gonfalon source, including the cursor prompt's
+no-whitespace placeholders. Consumers that switch their `?raw` import to
+the rendered output need no further coordination.
 
 ## Inconsistent npm install package-name conventions
 

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -34,16 +34,27 @@ the rendered output need no further coordination.
 
 **Severity**: low
 
-**SDKs affected**: js-client-sdk, react-client-sdk, vue-client-sdk,
-node-client-sdk (all use `launchdarkly-<x>-sdk`); node-server-sdk,
+**SDKs affected**: react-client-sdk, vue-client-sdk, node-client-sdk
+(all use `launchdarkly-<x>-sdk`); js-client-sdk, node-server-sdk,
 react-native-client-sdk (use `@launchdarkly/<x>-sdk`)
 
 **What we observed**: Newer SDK packages have moved to the
 `@launchdarkly/` npm scope, but the older packages haven't, so the
-install snippets diverge along package-name lines. This isn't a bug —
-each command is correct for its SDK — but a Phase 2 consumer would
-notice that the install-npm.txt files are nearly-but-not-quite a single
-template parameterized by package name.
+install snippets diverge along package-name lines. Each command is
+correct for its SDK at the time of authoring — but a Phase 2 consumer
+would notice that the install-npm.txt files are nearly-but-not-quite
+a single template parameterized by package name.
+
+**js-client-sdk fix applied**: gonfalon's source had the install
+snippets installing `launchdarkly-js-client-sdk` (v3) while
+`init.txt` already used the v4 API (`createClient` from
+`@launchdarkly/js-client-sdk`). Install commands updated in sdk-meta
+to install `@launchdarkly/js-client-sdk` (npm/pnpm/yarn), and the
+bower install URL bumped from `unpkg.com/launchdarkly-js-client-sdk@3`
+to `unpkg.com/@launchdarkly/js-client-sdk@4` so installed code
+matches the rendered example. This is a deliberate divergence from
+the gonfalon source; the byte-equality round-trip test now expects
+4 differing js-client-sdk install files.
 
 **Recommended action**: When migrating consumers, consider whether
 these can be expressed as a single `install-<pm>` snippet shared across

--- a/snippets/sdks/_shared/snippets/sdk-info/cursor-prompt.snippet.md
+++ b/snippets/sdks/_shared/snippets/sdk-info/cursor-prompt.snippet.md
@@ -1,0 +1,152 @@
+---
+id: cursor-prompt
+kind: reference
+lang: text
+file: prompt.txt
+description: Cursor SDK setup prompt template (uses {{SDK_NAME}}, {{SDK_DOCS_URL}}, {{SDK_EVENT_DOC_URL}} placeholders consumed by gonfalon at runtime).
+---
+
+```text
+Set up the LaunchDarkly {{SDK_NAME}} SDK in this project by following the instructions here: {{SDK_DOCS_URL}}.
+
+Scope:
+- Focus only on validating whether the {{SDK_NAME}} SDK is installed, and initializing it correctly with an environment variable.
+- Do not create test files, example projects, or documentation files.
+- Ensure initialization makes use of the SDK's `track` functionality to confirm connectivity.
+
+MCP check (required):
+  - Look for an MCP server named "LaunchDarkly" that runs @launchdarkly/mcp-server.
+    * Cursor: read ~/.cursor/mcp.json
+  - MCP is "installed" if the config includes:
+      {
+        "mcpServers": {
+          "LaunchDarkly": {
+            "command": "npx",
+            "args": ["-y", "--package", "@launchdarkly/mcp-server", "--", "mcp", "start", "--api-key", "<token-or-env-var>"]
+          }
+        }
+      }
+  - If not found, offer to add it (prefer an ENV var for the API key).
+
+If MCP is installed and enabled:
+  - Use its tools to verify or accelerate setup (read-only by default):
+    * List feature flags to confirm API access.
+    * (Optional, ask first) Create a temporary "hello-world-sdk-check" flag to validate SDK wiring.
+  - If access is restricted, continue SDK setup but skip write operations.
+
+SDK checks:
+  1. Is the {{SDK_NAME}} SDK package installed in this repo?
+     - If not installed, install it.
+  2. Is the SDK already initialized and used?
+     - Look for an initialization call.
+     - Ensure at least one flag evaluation and a `track` call are present in application code.
+     - Verify the SDK key is not hard-coded.
+
+Branch logic:
+- If the SDK is installed AND initialized (with flag evaluation + track):
+    → Ask user if they'd like to validate configuration (evaluate known flag or the temporary "hello-world-sdk-check" flag).
+- If the SDK is installed BUT not initialized:
+    → Follow {{SDK_DOCS_URL}} to add initialization, a first flag evaluation, and a `track` call.
+    → Follow {{SDK_EVENT_DOC_URL}} to add a custom event called 'source' with the value "cursor" to validate configuration.
+- If the SDK is NOT installed:
+    → Install it first, then follow {{SDK_DOCS_URL}} for initialization, flag evaluation, and `track` call.
+    → Follow {{SDK_EVENT_DOC_URL}} to add a custom event called 'source' with the value "cursor" to validate configuration.
+
+Examples of `track` calls (to guide code insertion):
+
+- **JavaScript (client-side):**
+  ```javascript
+  const ldClient = useLDClient();
+  ldClient.track(PROCESS.env.LAUNCHDARKLY_SDK_KEY, { source: "cursor" });
+  ```
+- **Python (server-side):**
+  ```python
+  import os
+  from ldclient import Context
+  from ldclient.config import Config
+
+  ldclient.set_config(Config(os.getenv("LAUNCHDARKLY_SDK_KEY")))
+  context = (Context.builder("context-key-123abc").name("Sandy").build())
+  data = {"source": "cursor"}
+
+  ldclient.get().track(os.getenv("LAUNCHDARKLY_SDK_KEY"), context, data)
+  ```
+- **Java (server-side):**
+  ```java
+  import com.launchdarkly.sdk.*;
+  import com.launchdarkly.sdk.server.*;
+
+  final LDContext context = LDContext.builder("example-context-key")
+  .name("Sandy")
+  .build();
+
+  final LDConfig config = new LDConfig.Builder().build();
+
+  final LDValue data = LDValue.buildObject().put("source", "cursor").build();
+  final LDClient ldClient = new LDClient(System.getenv("LAUNCHDARKLY_SDK_KEY"));
+  ldClient.trackData(System.getenv("LAUNCHDARKLY_SDK_KEY"), context, data);
+  ```
+- **.NET (Client-side):**
+  ```csharp
+  using LaunchDarkly.Sdk;
+  using LaunchDarkly.Sdk.Client;
+
+  Context context = Context.New("context-key-123abc");
+
+  var timeSpan = TimeSpan.FromSeconds(5);
+  client = await LdClient.InitAsync("mob-key", ConfigurationBuilder.AutoEnvAttributes.Enabled, context, timeSpan);
+
+  if (client.Initialized)
+  {
+      var data = LdValue.BuildObject().Add("source", "cursor").Build();
+      client.Track(builder.Configuration["LAUNCHDARKLY_SDK_KEY"], data);
+      Console.WriteLine("SDK successfully initialized!");
+  }
+  ```
+- **Node.js (server-side):**
+  ```javascript
+  import * as LaunchDarkly from '@launchdarkly/node-server-sdk';
+
+  const context = {
+    kind: 'user',
+    key: 'user-key-123abcde',
+    email: 'biz@face.dev',
+  };
+
+  client.once('ready', function () {
+    client.track(PROCESS.env.LAUNCHDARKLY_SDK_KEY, context, { source: "cursor" });
+    console.log('SDK successfully initialized!');
+  });
+  ```
+- **React (client-side):**
+  ```javascript
+  import { LDProvider, useLDClient } from 'launchdarkly-react-client-sdk';
+  import { useEffect } from 'react';
+
+  function App() {
+    const ldClient = useLDClient();
+
+    useEffect(() => {
+      ldClient?.track(PROCESS.env.LAUNCHDARKLY_SDK_KEY, { source: "cursor" });
+    }, [ldClient]);
+
+    ...
+  }
+  ```
+
+SDK key handling:
+- Always use an environment variable placeholder appropriate to the language:
+    - JavaScript/TypeScript: process.env.LAUNCHDARKLY_SDK_KEY
+    - Python: os.getenv("LAUNCHDARKLY_SDK_KEY")
+    - Java: System.getenv("LAUNCHDARKLY_SDK_KEY")
+    - .NET: builder.Configuration["LAUNCHDARKLY_SDK_KEY"]
+    - Go: os.Getenv("LAUNCHDARKLY_SDK_KEY")
+- Never hard-code secrets. Show placeholders only.
+
+Validation:
+- Run the app and confirm a flag evaluation and `track` event occur.
+- If MCP is available:
+    * Confirm the flag exists (list/get).
+    * (Optional, ask first) Toggle the flag to verify updates are received.
+- Report success or provide next steps on error.
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,25 @@
+---
+id: android-client-sdk/sdk-info/init
+sdk: android-client-sdk
+kind: init
+lang: kotlin
+file: android-client-sdk/init.txt
+description: Client initialization snippet for android-client-sdk.
+---
+
+```kotlin
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*;
+
+// This is your mobile key.
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey("YOUR_MOBILE_KEY")
+    .build()
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+val context = LDContext.create("EXAMPLE_CONTEXT_KEY")
+
+// If you don't want to block execution while the SDK tries to get
+// latest flags, move this code into an async IO task and await on its completion.
+val client: LDClient = LDClient.init(this@BaseApplication, ldConfig, context, 5)
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-info/install-groovy.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-info/install-groovy.snippet.md
@@ -1,0 +1,12 @@
+---
+id: android-client-sdk/sdk-info/install-groovy
+sdk: android-client-sdk
+kind: install
+lang: gradle
+file: android-client-sdk/install-groovy.txt
+description: Install command for android-client-sdk (groovy).
+---
+
+```gradle
+implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.+'
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-info/install-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-info/install-kotlin.snippet.md
@@ -1,0 +1,12 @@
+---
+id: android-client-sdk/sdk-info/install-kotlin
+sdk: android-client-sdk
+kind: install
+lang: kotlin
+file: android-client-sdk/install-kotlin.txt
+description: Install command for android-client-sdk (kotlin).
+---
+
+```kotlin
+implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -1,0 +1,26 @@
+---
+id: dotnet-client-sdk/sdk-info/flagEval
+sdk: dotnet-client-sdk
+kind: flag-eval
+lang: csharp
+file: dotnet-client-sdk/flagEval.txt
+description: Flag evaluation example for dotnet-client-sdk.
+---
+
+```csharp
+// Evaluate the feature flag.
+var flagValue = client.BoolVariation("featureKey", false);
+
+if (flagValue)
+{
+
+    // TODO: Put your feature here
+
+}
+else
+{
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,26 @@
+---
+id: dotnet-client-sdk/sdk-info/init
+sdk: dotnet-client-sdk
+kind: init
+lang: csharp
+file: dotnet-client-sdk/init.txt
+description: Client initialization snippet for dotnet-client-sdk.
+---
+
+```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Client;
+
+// A "context" is a data object representing users, devices, organizations, and
+// other entities. You'll need this to initialize the client.
+Context context = Context.New("EXAMPLE_CONTEXT_KEY");
+
+// This is your mobile key.
+var timeSpan = TimeSpan.FromSeconds(5);
+var client = await LdClient.InitAsync("YOUR_MOBILE_KEY", ConfigurationBuilder.AutoEnvAttributes.Enabled, context, timeSpan);
+
+if (client.Initialized)
+{
+    Console.WriteLine("SDK successfully initialized!");
+}
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,34 @@
+---
+id: dotnet-server-sdk/sdk-info/init
+sdk: dotnet-server-sdk
+kind: init
+lang: csharp
+file: dotnet-server-sdk/init.txt
+description: Client initialization snippet for dotnet-server-sdk.
+---
+
+```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// This is your LaunchDarkly SDK key.
+// Never hardcode your SDK key in production.
+var ldConfig = Configuration.Default("YOUR_SDK_KEY");
+var client = new LdClient(ldConfig);
+
+if (client.Initialized)
+{
+    // For onboarding purposes only we flush events as soon as
+    // possible so we quickly detect your connection.
+    // You don't have to do this in practice because events are automatically flushed.
+    client.Flush();
+    Console.WriteLine("*** SDK successfully initialized!\n");
+}
+else
+{
+    Console.WriteLine("*** SDK failed to initialize\n");
+    Environment.Exit(1);
+}
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/install-csharp.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/install-csharp.snippet.md
@@ -1,0 +1,12 @@
+---
+id: dotnet-server-sdk/sdk-info/install-csharp
+sdk: dotnet-server-sdk
+kind: install
+lang: powershell
+file: dotnet-server-sdk/install-csharp.txt
+description: Install command for dotnet-server-sdk (csharp).
+---
+
+```powershell
+Install-Package LaunchDarkly.ServerSdk
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,38 @@
+---
+id: go-server-sdk/sdk-info/init
+sdk: go-server-sdk
+kind: init
+lang: go
+file: go-server-sdk/init.txt
+description: Client initialization snippet for go-server-sdk.
+---
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+)
+
+func main() {
+	// This is your LaunchDarkly SDK key.
+	// Never hardcode your SDK key in production.
+	ldClient, _ := ld.MakeClient("YOUR_SDK_KEY", 5*time.Second)
+	if ldClient.Initialized() {
+		fmt.Printf("SDK successfully initialized!")
+	} else {
+		fmt.Printf("SDK failed to initialize")
+		os.Exit(1)
+	}
+
+	// For onboarding purposes only we flush events as soon as
+	// possible so we quickly detect your connection.
+	// You don't have to do this in practice because events are automatically flushed.
+	ldClient.Flush()
+}
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-info/install-go.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-info/install-go.snippet.md
@@ -1,0 +1,12 @@
+---
+id: go-server-sdk/sdk-info/install-go
+sdk: go-server-sdk
+kind: install
+lang: shell
+file: go-server-sdk/install-go.txt
+description: Install command for go-server-sdk (go).
+---
+
+```shell
+go get github.com/launchdarkly/go-server-sdk/v7
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,30 @@
+---
+id: ios-client-sdk/sdk-info/init
+sdk: ios-client-sdk
+kind: init
+lang: swift
+file: ios-client-sdk/init.txt
+description: Client initialization snippet for ios-client-sdk.
+---
+
+```swift
+import LaunchDarkly
+
+// This is your mobile key.
+let config = LDConfig(mobileKey: "YOUR_MOBILE_KEY", autoEnvAttributes: .enabled)
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+let contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
+guard case .success(let context) = contextBuilder.build()
+else { return }
+
+LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in
+    if timedOut {
+        print("SDK didn't initialize in 5 seconds.  SDK is still running and trying to get latest flags.")
+    } else {
+        print("SDK successfully initialized with the latest flags")
+    }
+}
+
+print("SDK started.")
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-cartfile.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-cartfile.snippet.md
@@ -1,0 +1,12 @@
+---
+id: ios-client-sdk/sdk-info/install-cartfile
+sdk: ios-client-sdk
+kind: install
+lang: text
+file: ios-client-sdk/install-cartfile.txt
+description: Install command for ios-client-sdk (cartfile).
+---
+
+```text
+github "launchdarkly/ios-client-sdk" ~> 9.15
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-package-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-package-swift.snippet.md
@@ -1,0 +1,22 @@
+---
+id: ios-client-sdk/sdk-info/install-package-swift
+sdk: ios-client-sdk
+kind: install
+lang: swift
+file: ios-client-sdk/install-package-swift.txt
+description: Install command for ios-client-sdk (package-swift).
+---
+
+```swift
+//...
+    dependencies: [
+        .package(url: "https://github.com/launchdarkly/ios-client-sdk.git", .upToNextMajor("9.15.0")),
+   ],
+    targets: [
+        .target(
+            name: "YOUR_TARGET",
+            dependencies: ["LaunchDarkly"]
+        )
+    ],
+//...
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-podfile.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-podfile.snippet.md
@@ -1,0 +1,15 @@
+---
+id: ios-client-sdk/sdk-info/install-podfile
+sdk: ios-client-sdk
+kind: install
+lang: ruby
+file: ios-client-sdk/install-podfile.txt
+description: Install command for ios-client-sdk (podfile).
+---
+
+```ruby
+use_frameworks!
+target 'YourTargetName' do
+  pod 'LaunchDarkly', '~> 9.15'
+end
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -1,0 +1,28 @@
+---
+id: java-server-sdk/sdk-info/flagEval
+sdk: java-server-sdk
+kind: flag-eval
+lang: java
+file: java-server-sdk/flagEval.txt
+description: Flag evaluation example for java-server-sdk.
+---
+
+```java
+// Set up the evaluation context.
+final LDContext context = LDContext.builder("example-context-key")
+    .name("Sandy")
+    .build();
+
+// Evaluate the feature flag for this context.
+boolean flagValue = client.boolVariation("featureKey", context, false);
+
+if (flagValue) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,31 @@
+---
+id: java-server-sdk/sdk-info/init
+sdk: java-server-sdk
+kind: init
+lang: java
+file: java-server-sdk/init.txt
+description: Client initialization snippet for java-server-sdk.
+---
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+
+public class Main {
+  public static void main(String[] args) {
+    LDConfig config = new LDConfig.Builder().build();
+
+    // This is your LaunchDarkly SDK key.
+    // Never hardcode your SDK key in production.
+    final LDClient client = new LDClient("YOUR_SDK_KEY", config);
+
+    if (client.isInitialized()) {
+      // For onboarding purposes only we flush events as soon as
+      // possible so we quickly detect your connection.
+      // You don't have to do this in practice because events are automatically flushed.
+      client.flush();
+      System.out.println("SDK successfully initialized!");
+    }
+  }
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/install-gradle.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/install-gradle.snippet.md
@@ -1,0 +1,12 @@
+---
+id: java-server-sdk/sdk-info/install-gradle
+sdk: java-server-sdk
+kind: install
+lang: gradle
+file: java-server-sdk/install-gradle.txt
+description: Install command for java-server-sdk (gradle).
+---
+
+```gradle
+implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.0.0'
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/install-xml.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/install-xml.snippet.md
@@ -1,0 +1,16 @@
+---
+id: java-server-sdk/sdk-info/install-xml
+sdk: java-server-sdk
+kind: install
+lang: xml
+file: java-server-sdk/install-xml.txt
+description: Install command for java-server-sdk (xml).
+---
+
+```xml
+<dependency>
+  <groupId>com.launchdarkly</groupId>
+  <artifactId>launchdarkly-java-server-sdk</artifactId>
+  <version>7.0.0</version>
+</dependency>
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -1,0 +1,24 @@
+---
+id: js-client-sdk/sdk-info/flagEval
+sdk: js-client-sdk
+kind: flag-eval
+lang: javascript
+file: js-client-sdk/flagEval.txt
+description: Flag evaluation example for js-client-sdk.
+---
+
+```javascript
+const flagKey = 'featureKey';
+
+const flagValue = ldclient.variation(flagKey, false);
+
+if (flagValue) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,28 @@
+---
+id: js-client-sdk/sdk-info/init
+sdk: js-client-sdk
+kind: init
+lang: javascript
+file: js-client-sdk/init.txt
+description: Client initialization snippet for js-client-sdk.
+---
+
+```javascript
+// A "context" is a data object representing users, devices, organizations, and
+// other entities. You'll need this later, but you can ignore it for now.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY'
+};
+// This is your client-side ID.
+const client = createClient('YOUR_CLIENT_SIDE_ID', context);
+client.start();
+
+const { status } = await client.waitForInitialization();
+
+if (status === 'complete') {
+  console.log('SDK successfully initialized!');
+} else {
+  console.error('Initialization failed');
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-bower.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-bower.snippet.md
@@ -8,5 +8,5 @@ description: Install command for js-client-sdk (bower).
 ---
 
 ```shell
-bower install https://unpkg.com/launchdarkly-js-client-sdk@3
+bower install https://unpkg.com/@launchdarkly/js-client-sdk@4
 ```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-bower.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-bower.snippet.md
@@ -1,0 +1,12 @@
+---
+id: js-client-sdk/sdk-info/install-bower
+sdk: js-client-sdk
+kind: install
+lang: shell
+file: js-client-sdk/install-bower.txt
+description: Install command for js-client-sdk (bower).
+---
+
+```shell
+bower install https://unpkg.com/launchdarkly-js-client-sdk@3
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: js-client-sdk/sdk-info/install-npm
+sdk: js-client-sdk
+kind: install
+lang: shell
+file: js-client-sdk/install-npm.txt
+description: Install command for js-client-sdk (npm).
+---
+
+```shell
+npm i launchdarkly-js-client-sdk
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -8,5 +8,5 @@ description: Install command for js-client-sdk (npm).
 ---
 
 ```shell
-npm i launchdarkly-js-client-sdk
+npm i @launchdarkly/js-client-sdk
 ```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: js-client-sdk/sdk-info/install-pnpm
+sdk: js-client-sdk
+kind: install
+lang: shell
+file: js-client-sdk/install-pnpm.txt
+description: Install command for js-client-sdk (pnpm).
+---
+
+```shell
+pnpm i launchdarkly-js-client-sdk
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -8,5 +8,5 @@ description: Install command for js-client-sdk (pnpm).
 ---
 
 ```shell
-pnpm i launchdarkly-js-client-sdk
+pnpm i @launchdarkly/js-client-sdk
 ```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -8,5 +8,5 @@ description: Install command for js-client-sdk (yarn).
 ---
 
 ```shell
-yarn add launchdarkly-js-client-sdk
+yarn add @launchdarkly/js-client-sdk
 ```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -1,0 +1,12 @@
+---
+id: js-client-sdk/sdk-info/install-yarn
+sdk: js-client-sdk
+kind: install
+lang: shell
+file: js-client-sdk/install-yarn.txt
+description: Install command for js-client-sdk (yarn).
+---
+
+```shell
+yarn add launchdarkly-js-client-sdk
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,28 @@
+---
+id: node-client-sdk/sdk-info/init
+sdk: node-client-sdk
+kind: init
+lang: javascript
+file: node-client-sdk/init.txt
+description: Client initialization snippet for node-client-sdk.
+---
+
+```javascript
+import * as LaunchDarkly from 'launchdarkly-node-client-sdk';
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+};
+
+// This is your client-side ID.
+const client = LaunchDarkly.initialize('YOUR_CLIENT_SIDE_ID', context);
+
+try {
+  await client.waitForInitialization(5);
+  // Initialization succeeded
+} catch (err) {
+  // Initialization failed or did not complete before timeout
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: node-client-sdk/sdk-info/install-npm
+sdk: node-client-sdk
+kind: install
+lang: shell
+file: node-client-sdk/install-npm.txt
+description: Install command for node-client-sdk (npm).
+---
+
+```shell
+npm i launchdarkly-node-client-sdk
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: node-client-sdk/sdk-info/install-pnpm
+sdk: node-client-sdk
+kind: install
+lang: shell
+file: node-client-sdk/install-pnpm.txt
+description: Install command for node-client-sdk (pnpm).
+---
+
+```shell
+pnpm i launchdarkly-node-client-sdk
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -1,0 +1,12 @@
+---
+id: node-client-sdk/sdk-info/install-yarn
+sdk: node-client-sdk
+kind: install
+lang: shell
+file: node-client-sdk/install-yarn.txt
+description: Install command for node-client-sdk (yarn).
+---
+
+```shell
+yarn add launchdarkly-node-client-sdk
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -1,0 +1,31 @@
+---
+id: node-server-sdk/sdk-info/flagEval
+sdk: node-server-sdk
+kind: flag-eval
+lang: javascript
+file: node-server-sdk/flagEval.txt
+description: Flag evaluation example for node-server-sdk.
+---
+
+```javascript
+// Evaluate a context
+const context = {
+   "kind": 'user',
+   "key": 'user-key-123abc',
+   "name": 'Sandy',
+};
+
+client.on('ready', () => {
+  client.variation('featureKey', context, false, function(err, showFeature) {
+    if (showFeature) {
+
+      // TODO: Put your feature here
+
+    } else {
+
+      // TODO: Put your fallback feature here
+
+    }
+  });
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,24 @@
+---
+id: node-server-sdk/sdk-info/init
+sdk: node-server-sdk
+kind: init
+lang: javascript
+file: node-server-sdk/init.txt
+description: Client initialization snippet for node-server-sdk.
+---
+
+```javascript
+import * as LaunchDarkly from '@launchdarkly/node-server-sdk';
+
+// This is your LaunchDarkly SDK key.
+// Never hardcode your SDK key in production.
+const client = LaunchDarkly.init('YOUR_SDK_KEY');
+
+client.once('ready', function () {
+  // For onboarding purposes only we flush events as soon as
+  // possible so we quickly detect your connection.
+  // You don't have to do this in practice because events are automatically flushed.
+  client.flush();
+  console.log('SDK successfully initialized!');
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: node-server-sdk/sdk-info/install-npm
+sdk: node-server-sdk
+kind: install
+lang: shell
+file: node-server-sdk/install-npm.txt
+description: Install command for node-server-sdk (npm).
+---
+
+```shell
+npm i @launchdarkly/node-server-sdk
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: node-server-sdk/sdk-info/install-pnpm
+sdk: node-server-sdk
+kind: install
+lang: shell
+file: node-server-sdk/install-pnpm.txt
+description: Install command for node-server-sdk (pnpm).
+---
+
+```shell
+pnpm i @launchdarkly/node-server-sdk
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -1,0 +1,12 @@
+---
+id: node-server-sdk/sdk-info/install-yarn
+sdk: node-server-sdk
+kind: install
+lang: shell
+file: node-server-sdk/install-yarn.txt
+description: Install command for node-server-sdk (yarn).
+---
+
+```shell
+yarn add @launchdarkly/node-server-sdk
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -1,0 +1,21 @@
+---
+id: python-server-sdk/sdk-info/flagEval
+sdk: python-server-sdk
+kind: flag-eval
+lang: python
+file: python-server-sdk/flagEval.txt
+description: Flag evaluation example for python-server-sdk.
+---
+
+```python
+from ldclient import Context
+
+# Create context using Context builder and use your own values here
+context = Context.builder("context-key-123abc").name("Sandy").build()
+flag_value = client.variation("featureKey", context, False)
+
+if flag_value:
+    # TODO: Put your feature here
+else:
+    # TODO: Put your fallback behavior here
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,30 @@
+---
+id: python-server-sdk/sdk-info/init
+sdk: python-server-sdk
+kind: init
+lang: python
+file: python-server-sdk/init.txt
+description: Client initialization snippet for python-server-sdk.
+---
+
+```python
+import os
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+
+if __name__ == '__main__':
+    # This is your LaunchDarkly SDK key.
+    # Never hardcode your SDK key in production.
+    ldclient.set_config(Config('YOUR_SDK_KEY'))
+
+    if not ldclient.get().is_initialized():
+        print('SDK failed to initialize')
+        exit()
+
+    # For onboarding purposes only we flush events as soon as
+    # possible so we quickly detect your connection.
+    # You don't have to do this in practice because events are automatically flushed.
+    ldclient.get().flush()
+    print('SDK successfully initialized')
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/install-pip.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/install-pip.snippet.md
@@ -1,0 +1,12 @@
+---
+id: python-server-sdk/sdk-info/install-pip
+sdk: python-server-sdk
+kind: install
+lang: shell
+file: python-server-sdk/install-pip.txt
+description: Install command for python-server-sdk (pip).
+---
+
+```shell
+pip3 install launchdarkly-server-sdk
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -1,0 +1,27 @@
+---
+id: react-client-sdk/sdk-info/flagEval
+sdk: react-client-sdk
+kind: flag-eval
+lang: javascript
+file: react-client-sdk/flagEval.txt
+description: Flag evaluation example for react-client-sdk.
+---
+
+```javascript
+import { useFlags } from 'launchdarkly-react-client-sdk';
+
+// We added your flag key. The React SDK uses camelCase for flag keys automatically
+// useFlags is a custom hook which returns all feature flags
+const { featureKey } = useFlags();
+
+// In your component, find where your feature is instantiated
+if (featureKey) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,35 @@
+---
+id: react-client-sdk/sdk-info/init
+sdk: react-client-sdk
+kind: init
+lang: tsx
+file: react-client-sdk/init.txt
+description: Client initialization snippet for react-client-sdk.
+---
+
+```tsx
+// Add the code below to the root of your React app.
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LDProvider } from 'launchdarkly-react-client-sdk';
+
+function App() {
+  return <div>Let your feature flags fly!</div>
+}
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+  email: 'biz@face.dev',
+};
+
+// This is your client-side ID.
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
+    <LDProvider clientSideID="YOUR_CLIENT_SIDE_ID" context={context}>
+      <App />
+    </LDProvider>
+  </StrictMode>,
+);
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-client-sdk/sdk-info/install-npm
+sdk: react-client-sdk
+kind: install
+lang: shell
+file: react-client-sdk/install-npm.txt
+description: Install command for react-client-sdk (npm).
+---
+
+```shell
+npm i launchdarkly-react-client-sdk
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-client-sdk/sdk-info/install-pnpm
+sdk: react-client-sdk
+kind: install
+lang: shell
+file: react-client-sdk/install-pnpm.txt
+description: Install command for react-client-sdk (pnpm).
+---
+
+```shell
+pnpm i launchdarkly-react-client-sdk
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-client-sdk/sdk-info/install-yarn
+sdk: react-client-sdk
+kind: install
+lang: shell
+file: react-client-sdk/install-yarn.txt
+description: Install command for react-client-sdk (yarn).
+---
+
+```shell
+yarn add launchdarkly-react-client-sdk
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,42 @@
+---
+id: react-native-client-sdk/sdk-info/init
+sdk: react-native-client-sdk
+kind: init
+lang: tsx
+file: react-native-client-sdk/init.txt
+description: Client initialization snippet for react-native-client-sdk.
+---
+
+```tsx
+import {
+  AutoEnvAttributes,
+  LDProvider,
+  ReactNativeLDClient,
+} from '@launchdarkly/react-native-client-sdk';
+
+// This is your mobile key.
+const ldClient = new ReactNativeLDClient('YOUR_MOBILE_KEY', AutoEnvAttributes.Enabled, {
+  debug: true,
+  applicationInfo: {
+    id: 'ld-rn-test-app',
+    version: '0.0.1',
+  },
+});
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY' };
+
+const App = () => {
+  useEffect(() => {
+    ldClient.identify(context);
+  }, []);
+
+  return (
+    <LDProvider client={ldClient}>
+      <YourComponent />
+    </LDProvider>
+  );
+};
+
+export default App;
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm-async-storage.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm-async-storage.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-native-client-sdk/sdk-info/install-npm-async-storage
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/install-npm-async-storage.txt
+description: Install command for react-native-client-sdk (npm-async-storage).
+---
+
+```shell
+npm i @react-native-async-storage/async-storage
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-native-client-sdk/sdk-info/install-npm
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/install-npm.txt
+description: Install command for react-native-client-sdk (npm).
+---
+
+```shell
+npm i @launchdarkly/react-native-client-sdk
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm-async-storage.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm-async-storage.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-native-client-sdk/sdk-info/install-pnpm-async-storage
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/install-pnpm-async-storage.txt
+description: Install command for react-native-client-sdk (pnpm-async-storage).
+---
+
+```shell
+pnpm i @react-native-async-storage/async-storage
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-native-client-sdk/sdk-info/install-pnpm
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/install-pnpm.txt
+description: Install command for react-native-client-sdk (pnpm).
+---
+
+```shell
+pnpm i @launchdarkly/react-native-client-sdk
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn-async-storage.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn-async-storage.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-native-client-sdk/sdk-info/install-yarn-async-storage
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/install-yarn-async-storage.txt
+description: Install command for react-native-client-sdk (yarn-async-storage).
+---
+
+```shell
+yarn add @react-native-async-storage/async-storage
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -1,0 +1,12 @@
+---
+id: react-native-client-sdk/sdk-info/install-yarn
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/install-yarn.txt
+description: Install command for react-native-client-sdk (yarn).
+---
+
+```shell
+yarn add @launchdarkly/react-native-client-sdk
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/init.snippet.md
@@ -1,0 +1,32 @@
+---
+id: vue-client-sdk/sdk-info/init
+sdk: vue-client-sdk
+kind: init
+lang: javascript
+file: vue-client-sdk/init.txt
+description: Client initialization snippet for vue-client-sdk.
+---
+
+```javascript
+// Add the code below to your main.js file.
+import { createApp } from 'vue';
+import App from './App.vue';
+import { LDPlugin } from 'launchdarkly-vue-client-sdk';
+
+const app = createApp(App);
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+  name: 'Sandy',
+};
+
+// This is your client-side ID.
+app.use(LDPlugin, {
+  clientSideID: 'YOUR_CLIENT_SIDE_ID',
+  context: context
+});
+
+app.mount('#app');
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: vue-client-sdk/sdk-info/install-npm
+sdk: vue-client-sdk
+kind: install
+lang: shell
+file: vue-client-sdk/install-npm.txt
+description: Install command for vue-client-sdk (npm).
+---
+
+```shell
+npm i launchdarkly-vue-client-sdk
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -1,0 +1,12 @@
+---
+id: vue-client-sdk/sdk-info/install-pnpm
+sdk: vue-client-sdk
+kind: install
+lang: shell
+file: vue-client-sdk/install-pnpm.txt
+description: Install command for vue-client-sdk (pnpm).
+---
+
+```shell
+pnpm i launchdarkly-vue-client-sdk
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -1,0 +1,12 @@
+---
+id: vue-client-sdk/sdk-info/install-yarn
+sdk: vue-client-sdk
+kind: install
+lang: shell
+file: vue-client-sdk/install-yarn.txt
+description: Install command for vue-client-sdk (yarn).
+---
+
+```shell
+yarn add launchdarkly-vue-client-sdk
+```


### PR DESCRIPTION
## Summary

Phase 1 of [SDK-2316](https://launchdarkly.atlassian.net/browse/SDK-2316). Lifts the 52 .txt files from gonfalon's `packages/sdk-info/src/snippets/` into sdk-meta as canonical `.snippet.md` sources, adds a `raw-files` render adapter so consumers can keep their `?raw` import flow, and fixes two real content/engine bugs that the lift surfaced.

- 52 canonical snippet files: 51 per-SDK files across 13 SDKs under `snippets/sdks/<sdk>/snippets/sdk-info/`, plus the cross-SDK `cursor-prompt` under `snippets/sdks/_shared/snippets/sdk-info/`.
- New `raw-files` render target: manifest-driven, parallel to `ld-application`. Reads a YAML manifest of `(snippet-id, output-path)` entries and writes each rendered body to a flat .txt file. Backs gonfalon's `?raw`-import flow where the marker-driven contract doesn't fit.
- DSL fix: `Var.Raw` preserves source-text whitespace so foreign-template `{{X}}` round-trips byte-identically (the cursor-prompt's runtime placeholders use the no-whitespace form gonfalon's `/{{SDK_NAME}}/g` regex requires).
- js-client-sdk install fix: install snippets now reference `@launchdarkly/js-client-sdk` (v4) to match the `init.txt` example, which already uses the v4 API. Gonfalon's source had install commands installing v3 (`launchdarkly-js-client-sdk`) while the code was already on v4 — following the install-then-init flow as written would put the wrong package on disk and the import would fail.
- Inconsistency log captured at `snippets/sdks/_sdk-info-port-notes.md` for Phase 2 triage.

Bodies copied verbatim except for the two deliberate fixes above. **Phase 2 (consumer refactor onto `<Snippet>{...}</Snippet>`) lives in a separate ticket; this PR does not touch gonfalon. The downstream consumer wiring lives on a separate gonfalon branch (`rlamb/sync-sdk-info-snippets`) that adds the workflow + manifest and pins to the gh-actions branch from launchdarkly/gh-actions#83.**

## File-count summary

| Group | Count |
| --- | --- |
| Per-SDK `sdk-info/` snippet files (13 SDKs × {init, flagEval, install-*}) | 51 |
| `_shared/snippets/sdk-info/cursor-prompt.snippet.md` | 1 |
| **Total snippet files added** | **52** |
| New `internal/adapters/rawfiles/` package + tests | 2 Go files |
| New `internal/atomicfile/` package + tests | 2 Go files (extracted from rawfiles & ldapplication) |
| Inconsistency log | 1 markdown |

## Round-trip verification

Built the binary, ran the manifest covering all 52 entries, diffed against the original `packages/sdk-info/src/snippets/`:

- **48 of 52 files round-trip byte-identical** to gonfalon source.
- **4 deliberate divergences** — the js-client-sdk install commands (`install-npm`, `install-pnpm`, `install-yarn`, `install-bower`) updated to install `@launchdarkly/js-client-sdk` (v4) so they match what `init.txt` already imports. Documented in `_sdk-info-port-notes.md`.
- The earlier 1-file drift on `prompt.txt` is fixed in this PR via the `Var.Raw` DSL change.

## `extract.yaml` shape (for the gonfalon side)

```yaml
out: src/snippets
files:
  - id: cursor-prompt
    path: prompt.txt
  - id: android-client-sdk/sdk-info/init
    path: android-client-sdk/init.txt
  # ... 50 more entries
```

The full 52-entry manifest is committed on the gonfalon branch `rlamb/sync-sdk-info-snippets` at `packages/sdk-info/extract.yaml`. Validation rejects: missing `out:`, missing entries, duplicate ids, duplicate output paths, absolute paths, `..`-traversing paths, and unknown frontmatter keys (KnownFields).

CLI invocation:
```
snippets render --target=raw-files --manifest=packages/sdk-info/extract.yaml --consumer=.
```

## Inconsistency log highlights

Full details in `snippets/sdks/_sdk-info-port-notes.md`. Top three:

1. ~~**cursor-prompt's `{{SDK_NAME}}` placeholders don't survive the renderer's whitespace normalization**~~ **Fixed in this PR** via `Var.Raw`. Foreign-template Vars now round-trip byte-identically, so gonfalon's `/{{SDK_NAME}}/g` regex keeps matching.
2. **flagEval.txt is missing for 7 of 13 SDKs** (low). Gonfalon presumably hides the step for those; backfilling is a content question, not structural.
3. **Cross-source drift between sdk-info and getting-started** (medium). Becomes irrelevant once #415 lands and the getting-started slice is removed entirely (gonfalon's "Connect an SDK" UI is being retired).

Other items (npm package-name conventions, init fragments not standalone runnable, .NET PowerShell vs CLI install, ios Package.swift fragment, trailing-newline convention) are documented for triage.

## Review feedback addressed

- **Bugbot — "Render doc promises sorted output but never sorts"**: fixed in `c8dd7b4`. `Render()` now `sort.Strings(written)` before return so the documented contract holds regardless of manifest entry order.
- **Bugbot — "Duplicated `atomicWriteFile` across two adapter packages"**: fixed in `c8dd7b4`. Extracted to a new `internal/atomicfile` package (`atomicfile.Write`); both rawfiles and ldapplication adapters import it. Mode-preservation contract test moves with the function; two new tests cover default-mode-on-create and no-tempfile-leftover.

## Test plan

- [x] `go test ./...` from `snippets/` passes (full suite green; rawfiles tests cover round-trip, --consumer override, unknown-id, duplicate-id, duplicate-path, escape-path, unknown-key, missing-out, intermediate-dir creation, foreign-template passthrough; atomicfile tests cover mode preservation, default mode, and tempfile cleanup).
- [x] `go build ./...` clean.
- [x] Round-trip diff: 48 of 52 byte-identical against gonfalon source; 4 deliberate js-client-sdk fixes documented.
- [x] `snippets render --target=raw-files --manifest=...` writes the expected tree; output paths are sorted regardless of manifest order.
- [ ] Reviewer: spot-check the manifest shape — open to alternatives (e.g. flatter mapping, glob-based discovery) before Phase 2 wires it into gonfalon.
- [ ] Reviewer: confirm the choice to put cursor-prompt under `sdks/_shared/` (skipping the `sdk.yaml` requirement via underscore-prefix) versus other options (e.g. a top-level `shared/` sibling of `sdks/`).

[SDK-2316]: https://launchdarkly.atlassian.net/browse/SDK-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new render mode that writes files based on a consumer-provided manifest and tweaks the templating parser/emitter to preserve exact `{{...}}` formatting; both impact generated output and file writes across consumers.
> 
> **Overview**
> Ports the `sdk-info` snippet corpus into sdk-meta as canonical `.snippet.md` sources (including a `_shared` `cursor-prompt` snippet) and documents known content inconsistencies in `_sdk-info-port-notes.md`.
> 
> Extends the `snippets render` CLI with a new `--target=raw-files` mode that reads a YAML manifest of `(snippet id, output path)` mappings and writes rendered bodies to plain `.txt` files (with stricter manifest validation and sorted output), enabling consumers that use `?raw` imports instead of marker-based rewrites.
> 
> Refactors atomic write logic into a shared `internal/atomicfile` package (used by `ld-application` and the new raw-files adapter) and updates the template renderer/parser to preserve the original `{{...}}` token text (`Var.Raw`) so foreign-template placeholders round-trip byte-identically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541546f375559944cc7e0fbb188738c1b4e36bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->