### PR TITLE
feat(snippets): extended validation for sdk-info snippets

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -88,7 +88,7 @@ jobs:
           # Carthage is installed on-demand via `brew install
           # carthage` in the harness setup step, since macos-latest
           # doesn't ship it preinstalled.
-          - { sdk: ios-client-sdk,          runs-on: macos-latest,  key-type: mobile }
+          - { sdk: ios-client-sdk,          runs-on: macos-latest,  key-type: none }
     steps:
       - uses: actions/checkout@v4
 
@@ -116,6 +116,14 @@ jobs:
 
       - name: Validate
         id: validate
+        # SDKs whose only bound snippets are install fragments (e.g.
+        # ios-client-sdk: cartfile/package-swift/podfile) don't run any
+        # LaunchDarkly client code — they just run package managers in
+        # an empty dir. They don't need (and shouldn't pretend to need)
+        # the verify-hello-app wrapper, which assumes the validate
+        # output will contain "feature flag evaluates to true". Use a
+        # plain run for those; verify-hello-app for everything else.
+        if: matrix.key-type != 'none'
         uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.1
         with:
           use_server_key: ${{ matrix.key-type == 'server' }}
@@ -128,11 +136,26 @@ jobs:
             go run ./cmd/snippets validate --sdk=${{ matrix.sdk }} \
               --sdks=./sdks --validators=./validators 2>&1 | tee /tmp/validate.log
 
+      - name: Validate (no key)
+        if: matrix.key-type == 'none'
+        id: validate-no-key
+        run: |
+          set -o pipefail
+          cd snippets
+          go run ./cmd/snippets validate --sdk=${{ matrix.sdk }} \
+            --sdks=./sdks --validators=./validators 2>&1 | tee /tmp/validate.log
+
       - name: Record result
         if: always()
+        env:
+          OUTCOME_KEYED: ${{ steps.validate.outcome }}
+          OUTCOME_NOKEY: ${{ steps.validate-no-key.outcome }}
         run: |
+          # Exactly one of the two validate steps ran (selected by
+          # key-type); the other reports outcome == 'skipped'. Treat
+          # 'success' as ok, anything else as fail.
           mkdir -p /tmp/result
-          if [ "${{ steps.validate.outcome }}" = "success" ]; then
+          if [ "$OUTCOME_KEYED" = "success" ] || [ "$OUTCOME_NOKEY" = "success" ]; then
               echo "ok" > /tmp/result/status
           else
               echo "fail" > /tmp/result/status

--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -62,22 +62,57 @@ jobs:
           # Mobile-key SDKs.
           - { sdk: dotnet-client-sdk, runs-on: ubuntu-latest, key-type: mobile }
 
-          # Install-only matrix rows. The shell-install validator
-          # sniffs the body's leading token (npm/pnpm/yarn/pip/go/bower)
-          # and runs the real package manager in a clean working dir;
-          # no LaunchDarkly key is needed. We pass `key-type: server` so
-          # the verify-hello-app action injects an unused server key
-          # rather than failing on no-key-set.
-          - { sdk: node-client-sdk,         runs-on: ubuntu-latest, key-type: server }
-          - { sdk: react-client-sdk,        runs-on: ubuntu-latest, key-type: server }
-          - { sdk: react-native-client-sdk, runs-on: ubuntu-latest, key-type: server }
-          - { sdk: vue-client-sdk,          runs-on: ubuntu-latest, key-type: server }
+          # SDKs whose only validatable surface is the shell-install
+          # snippets — no init/flagEval bindings yet. The shell-install
+          # validator sniffs the body's leading token
+          # (npm/pnpm/yarn/pip/go/bower) and runs the real package
+          # manager in a clean working dir; no LaunchDarkly key is
+          # needed. We pass `key-type: server` so the verify-hello-app
+          # action injects an unused server key rather than failing on
+          # no-key-set.
+          - { sdk: dotnet-server-sdk,       runs-on: ubuntu-latest, key-type: server }
+
+          # Client/mobile-key SDKs with end-to-end init bindings.
+          - { sdk: node-client-sdk,         runs-on: ubuntu-latest, key-type: client }
+          - { sdk: react-client-sdk,        runs-on: ubuntu-latest, key-type: client }
+          - { sdk: vue-client-sdk,          runs-on: ubuntu-latest, key-type: client }
+
+          # React Native init runs under jest with the RN preset (no
+          # emulator). Mobile key.
+          - { sdk: react-native-client-sdk, runs-on: ubuntu-latest, key-type: mobile }
+
+          # iOS install fragments (Cartfile, Package.swift, Podfile)
+          # need real Apple toolchains; macos-latest has Swift +
+          # CocoaPods preinstalled. The validator runs in `native` mode
+          # because docker isn't available on macos runners.
+          # Carthage is installed on-demand via `brew install
+          # carthage` in the harness setup step, since macos-latest
+          # doesn't ship it preinstalled.
+          - { sdk: ios-client-sdk,          runs-on: macos-latest,  key-type: mobile }
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+
+      - name: Install iOS toolchain (macos only)
+        if: matrix.runs-on == 'macos-latest'
+        run: |
+          # macos-latest images ship Xcode + Swift + Ruby preinstalled.
+          # CocoaPods and the xcodeproj gem (used by the Podfile harness
+          # to synthesize a stub Xcode project) and Carthage are not
+          # always preinstalled — install both, gracefully no-oping if
+          # they're already there. Carthage installation can be slow on
+          # cold runners, so prefer brew's bottle when available.
+          set -e
+          if ! command -v carthage >/dev/null; then
+              brew install carthage
+          fi
+          if ! command -v pod >/dev/null; then
+              sudo gem install cocoapods --no-document
+          fi
+          sudo gem install xcodeproj --no-document
 
       - name: Validate
         id: validate

--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -43,22 +43,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # SDKs whose sdk-docs scaffold bindings pass today. The 17
-          # other SDKs ship Docker harnesses and syntax-only scaffolds
-          # under snippets/validators/ + snippets/sdks/<sdk>/snippets/
-          # scaffolds/, but no bound runnable snippets — they were
-          # validated end-to-end via the gonfalon-targeted
-          # getting-started/main-* programs, which were removed when
-          # gonfalon's "Connect an SDK" UI was retired. Bindings can be
-          # restored once the per-SDK scaffolds learn to splice
-          # top-level imports up to file scope and provide a
-          # client/context in the wrappee body's lexical scope; tracked
-          # as a follow-up.
+          # The first block — server-key SDKs — covers both the original
+          # sdk-docs scaffold bindings AND the newly-wired sdk-info
+          # install/init/flagEval bindings under each SDK's snippets/
+          # sdk-info/ group.
           - { sdk: python-server-sdk, runs-on: ubuntu-latest, key-type: server }
           - { sdk: node-server-sdk,   runs-on: ubuntu-latest, key-type: server }
+          - { sdk: go-server-sdk,     runs-on: ubuntu-latest, key-type: server }
+          - { sdk: java-server-sdk,   runs-on: ubuntu-latest, key-type: server }
           - { sdk: ruby-server-sdk,   runs-on: ubuntu-latest, key-type: server }
           - { sdk: php-server-sdk,    runs-on: ubuntu-latest, key-type: server }
           - { sdk: lua-server-sdk,    runs-on: ubuntu-latest, key-type: server }
+
+          # Client SDKs whose validators run a real bundle and assert
+          # a flag evaluation against the LD sandbox env.
+          - { sdk: js-client-sdk,     runs-on: ubuntu-latest, key-type: client }
+
+          # Mobile-key SDKs.
+          - { sdk: dotnet-client-sdk, runs-on: ubuntu-latest, key-type: mobile }
+
+          # Install-only matrix rows. The shell-install validator
+          # sniffs the body's leading token (npm/pnpm/yarn/pip/go/bower)
+          # and runs the real package manager in a clean working dir;
+          # no LaunchDarkly key is needed. We pass `key-type: server` so
+          # the verify-hello-app action injects an unused server key
+          # rather than failing on no-key-set.
+          - { sdk: node-client-sdk,         runs-on: ubuntu-latest, key-type: server }
+          - { sdk: react-client-sdk,        runs-on: ubuntu-latest, key-type: server }
+          - { sdk: react-native-client-sdk, runs-on: ubuntu-latest, key-type: server }
+          - { sdk: vue-client-sdk,          runs-on: ubuntu-latest, key-type: server }
     steps:
       - uses: actions/checkout@v4
 

--- a/snippets/internal/model/model.go
+++ b/snippets/internal/model/model.go
@@ -24,8 +24,8 @@ type Frontmatter struct {
 	Lang        string           `yaml:"lang"`
 	File        string           `yaml:"file"`
 	Description string           `yaml:"description"`
-	Inputs     map[string]Input `yaml:"inputs"`
-	Validation Validation       `yaml:"validation"`
+	Inputs      map[string]Input `yaml:"inputs"`
+	Validation  Validation       `yaml:"validation"`
 }
 
 type Input struct {
@@ -82,6 +82,27 @@ type Validation struct {
 	// serve several wrappees that need slightly different setup (e.g.
 	// pre-populated flag values, context attributes).
 	ScaffoldInputs map[string]string `yaml:"scaffold-inputs"`
+
+	// Placeholders maps literal source-text fragments inside the snippet
+	// body to environment-variable names. After the body is rendered (and
+	// after any scaffold composition), the dispatcher does a literal
+	// string-replace: every occurrence of the key is replaced with the
+	// value of the named env var.
+	//
+	// Use case: gonfalon's sdk-info init snippets carry literal
+	// `'YOUR_SDK_KEY'` / `'YOUR_MOBILE_KEY'` / `'YOUR_CLIENT_SIDE_ID'`
+	// placeholders that the user is expected to swap manually. Validating
+	// the snippet end-to-end against a real LaunchDarkly env requires
+	// substituting a real key — but rewriting the body to use a
+	// `{{ sdk_key }}` template marker would make the rendered output
+	// (consumed by gonfalon) lose the human-readable placeholder.
+	// Placeholders keep the snippet body unchanged at render time and
+	// only swap at validate time.
+	//
+	// Only a small allow-list of env var names is honored:
+	// LAUNCHDARKLY_SDK_KEY, LAUNCHDARKLY_FLAG_KEY, LAUNCHDARKLY_MOBILE_KEY,
+	// LAUNCHDARKLY_CLIENT_SIDE_ID. The dispatcher rejects any other name.
+	Placeholders map[string]string `yaml:"placeholders"`
 }
 
 // Snippet pairs the frontmatter with the body of the first fenced code block
@@ -95,6 +116,7 @@ type Snippet struct {
 }
 
 var frontmatterRe = regexp.MustCompile(`(?s)\A---\n(.*?)\n---\n`)
+
 // `[ \t]*` (not `\s*`) for the trailing horizontal whitespace because
 // `\s` includes `\n`: a greedy `\s*$` will consume the line-terminating
 // newline, and then the `after = after[1:]` step in firstCodeBlock skips

--- a/snippets/internal/model/model.go
+++ b/snippets/internal/model/model.go
@@ -83,6 +83,17 @@ type Validation struct {
 	// pre-populated flag values, context attributes).
 	ScaffoldInputs map[string]string `yaml:"scaffold-inputs"`
 
+	// Env maps validator-specific env-var names to literal values that
+	// the dispatcher forwards into the harness's process environment.
+	// Used by per-snippet binding metadata that the harness reads at
+	// run time — e.g. ios-install's `INSTALL_KIND` discriminator that
+	// picks `swift-package` vs `podfile` vs `cartfile`.
+	//
+	// Keys are restricted to a snippet-author-defined set; the
+	// dispatcher does not touch the value (no env lookup, no template
+	// substitution). Use Placeholders for the env-derived case.
+	Env map[string]string `yaml:"env"`
+
 	// Placeholders maps literal source-text fragments inside the snippet
 	// body to environment-variable names. After the body is rendered (and
 	// after any scaffold composition), the dispatcher does a literal

--- a/snippets/internal/validate/validate.go
+++ b/snippets/internal/validate/validate.go
@@ -162,11 +162,24 @@ func runOne(cfg Config, s *model.Snippet, all map[string]*model.Snippet, env env
 			s.Frontmatter.ID, eff.Frontmatter.ID, runtime, entrypoint)
 	}
 
+	// Forward any per-snippet validation.env entries (the entry's
+	// declarations win; scaffold-supplied entries fill in gaps so a
+	// scaffold can publish defaults that a wrappee can override).
+	extraEnv := map[string]string{}
+	if eff != s {
+		for k, v := range eff.Frontmatter.Validation.Env {
+			extraEnv[k] = v
+		}
+	}
+	for k, v := range s.Frontmatter.Validation.Env {
+		extraEnv[k] = v
+	}
+
 	switch runner.Mode {
 	case "docker":
-		return runDocker(cfg, runner, runnerDir, stageDir, entrypoint, env)
+		return runDocker(cfg, runner, runnerDir, stageDir, entrypoint, env, extraEnv)
 	case "native":
-		return runNative(runnerDir, stageDir, entrypoint, env)
+		return runNative(runnerDir, stageDir, entrypoint, env, extraEnv)
 	default:
 		return fmt.Errorf("validator runtime %q: unknown mode %q", runtime, runner.Mode)
 	}
@@ -352,7 +365,7 @@ func checkStagePath(rel string) error {
 // Build context is the entire `validators/` tree so each Dockerfile can pull
 // from `shared/` (the shared harness library) as well as its own
 // `languages/<runtime>/` subtree.
-func runDocker(cfg Config, runner *Runner, runnerDir, stageDir, entrypoint string, env envInputs) error {
+func runDocker(cfg Config, runner *Runner, runnerDir, stageDir, entrypoint string, env envInputs, extraEnv map[string]string) error {
 	dockerfile := filepath.Join(runnerDir, "Dockerfile")
 	if _, err := os.Stat(dockerfile); err != nil {
 		return fmt.Errorf("validator Dockerfile not found at %s: %w", runnerDir, err)
@@ -378,6 +391,9 @@ func runDocker(cfg Config, runner *Runner, runnerDir, stageDir, entrypoint strin
 	for _, kv := range envForRun(env) {
 		args = append(args, "-e", kv)
 	}
+	for k, v := range extraEnv {
+		args = append(args, "-e", k+"="+v)
+	}
 	args = append(args, tag)
 	run := exec.Command("docker", args...)
 	run.Stdout = os.Stdout
@@ -392,7 +408,7 @@ func runDocker(cfg Config, runner *Runner, runnerDir, stageDir, entrypoint strin
 // path passed as $SNIPPET_DIR. Used for runtimes whose toolchains can't run
 // in a Linux container (iOS / xcodebuild) or are too heavy to dockerize for
 // CI (Android emulator, Flutter).
-func runNative(runnerDir, stageDir, entrypoint string, env envInputs) error {
+func runNative(runnerDir, stageDir, entrypoint string, env envInputs, extraEnv map[string]string) error {
 	script := filepath.Join(runnerDir, "harness", "run.sh")
 	if _, err := os.Stat(script); err != nil {
 		return fmt.Errorf("native validator run.sh not found at %s: %w", script, err)
@@ -405,6 +421,9 @@ func runNative(runnerDir, stageDir, entrypoint string, env envInputs) error {
 		"SNIPPET_ENTRYPOINT="+entrypoint,
 	)
 	cmd.Env = append(cmd.Env, envForRun(env)...)
+	for k, v := range extraEnv {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("native validator failed: %w", err)
 	}

--- a/snippets/internal/validate/validate.go
+++ b/snippets/internal/validate/validate.go
@@ -28,10 +28,10 @@ type Config struct {
 // into snippets at validation time. Each field maps to one EXAM-HELLO env
 // var and to a snippet-input type.
 type envInputs struct {
-	sdkKey        string // LAUNCHDARKLY_SDK_KEY        ↔ type: sdk-key
-	flagKey       string // LAUNCHDARKLY_FLAG_KEY       ↔ type: flag-key
-	mobileKey     string // LAUNCHDARKLY_MOBILE_KEY     ↔ type: mobile-key
-	clientSideID  string // LAUNCHDARKLY_CLIENT_SIDE_ID ↔ type: client-side-id
+	sdkKey       string // LAUNCHDARKLY_SDK_KEY        ↔ type: sdk-key
+	flagKey      string // LAUNCHDARKLY_FLAG_KEY       ↔ type: flag-key
+	mobileKey    string // LAUNCHDARKLY_MOBILE_KEY     ↔ type: mobile-key
+	clientSideID string // LAUNCHDARKLY_CLIENT_SIDE_ID ↔ type: client-side-id
 }
 
 // Run finds validatable snippets under cfg.SDKsDir and routes each through
@@ -228,6 +228,16 @@ func stageSnippet(entry *model.Snippet, all map[string]*model.Snippet, env envIn
 			os.RemoveAll(stageDir)
 			return "", fmt.Errorf("snippet %s: %w", entry.Frontmatter.ID, err)
 		}
+		// Wrappee-declared placeholders apply to the wrappee body before
+		// it's spliced into the scaffold. Scaffold-side substitution would
+		// also catch the strings, but doing it here matches authors'
+		// expectations: "this snippet's `'YOUR_SDK_KEY'` placeholder
+		// becomes the env value."
+		wrappeeBody, err = applyPlaceholders(wrappeeBody, entry.Frontmatter.Validation.Placeholders, env)
+		if err != nil {
+			os.RemoveAll(stageDir)
+			return "", fmt.Errorf("snippet %s: %w", entry.Frontmatter.ID, err)
+		}
 
 		// Build the scaffold's input map: env-derived typed inputs from
 		// the scaffold itself, overlaid with the wrappee's
@@ -243,6 +253,17 @@ func stageSnippet(entry *model.Snippet, all map[string]*model.Snippet, env envIn
 		if err := stageRender(stageDir, eff, scaffoldInputs, env); err != nil {
 			os.RemoveAll(stageDir)
 			return "", err
+		}
+	}
+
+	// Plain-snippet placeholders: rewrite the staged file in place. (For
+	// scaffolded snippets the substitution already happened on the
+	// wrappee body, before scaffold composition.)
+	if eff == entry && len(entry.Frontmatter.Validation.Placeholders) > 0 {
+		if err := applyPlaceholdersToFile(filepath.Join(stageDir, entry.Frontmatter.File),
+			entry.Frontmatter.Validation.Placeholders, env); err != nil {
+			os.RemoveAll(stageDir)
+			return "", fmt.Errorf("snippet %s: %w", entry.Frontmatter.ID, err)
 		}
 	}
 
@@ -406,8 +427,9 @@ func envForRun(env envInputs) []string {
 
 // requireEnvForInputs walks the entrypoint snippet AND its companions; for
 // every input typed as one of the EXAM-HELLO key types, the corresponding
-// env var must be set. This produces a clear error before a downstream pip-
-// install or docker-build has wasted time.
+// env var must be set. Same check is applied to validation.placeholders.
+// This produces a clear error before a downstream pip-install or
+// docker-build has wasted time.
 func requireEnvForInputs(entry *model.Snippet, all map[string]*model.Snippet, env envInputs) error {
 	check := func(s *model.Snippet) error {
 		for name, in := range s.Frontmatter.Inputs {
@@ -428,6 +450,28 @@ func requireEnvForInputs(entry *model.Snippet, all map[string]*model.Snippet, en
 				if env.clientSideID == "" {
 					return fmt.Errorf("snippet %s input %q (type=client-side-id) requires LAUNCHDARKLY_CLIENT_SIDE_ID to be set", s.Frontmatter.ID, name)
 				}
+			}
+		}
+		for needle, envName := range s.Frontmatter.Validation.Placeholders {
+			switch envName {
+			case "LAUNCHDARKLY_SDK_KEY":
+				if env.sdkKey == "" {
+					return fmt.Errorf("snippet %s placeholder %q requires LAUNCHDARKLY_SDK_KEY to be set", s.Frontmatter.ID, needle)
+				}
+			case "LAUNCHDARKLY_FLAG_KEY":
+				if env.flagKey == "" {
+					return fmt.Errorf("snippet %s placeholder %q requires LAUNCHDARKLY_FLAG_KEY to be set", s.Frontmatter.ID, needle)
+				}
+			case "LAUNCHDARKLY_MOBILE_KEY":
+				if env.mobileKey == "" {
+					return fmt.Errorf("snippet %s placeholder %q requires LAUNCHDARKLY_MOBILE_KEY to be set", s.Frontmatter.ID, needle)
+				}
+			case "LAUNCHDARKLY_CLIENT_SIDE_ID":
+				if env.clientSideID == "" {
+					return fmt.Errorf("snippet %s placeholder %q requires LAUNCHDARKLY_CLIENT_SIDE_ID to be set", s.Frontmatter.ID, needle)
+				}
+			default:
+				return fmt.Errorf("snippet %s placeholder %q maps to unknown env var %q", s.Frontmatter.ID, needle, envName)
 			}
 		}
 		return nil
@@ -481,6 +525,53 @@ func runtimeInputs(s *model.Snippet, env envInputs) (map[string]string, error) {
 		}
 	}
 	return out, nil
+}
+
+// applyPlaceholders rewrites every literal occurrence of each key in the
+// placeholders map with the corresponding env-var value. Returns an error
+// if a placeholder maps to an env var that's empty or to a name outside
+// the allow-list.
+func applyPlaceholders(body string, placeholders map[string]string, env envInputs) (string, error) {
+	if len(placeholders) == 0 {
+		return body, nil
+	}
+	for needle, envName := range placeholders {
+		var val string
+		switch envName {
+		case "LAUNCHDARKLY_SDK_KEY":
+			val = env.sdkKey
+		case "LAUNCHDARKLY_FLAG_KEY":
+			val = env.flagKey
+		case "LAUNCHDARKLY_MOBILE_KEY":
+			val = env.mobileKey
+		case "LAUNCHDARKLY_CLIENT_SIDE_ID":
+			val = env.clientSideID
+		default:
+			return "", fmt.Errorf("placeholder %q maps to unknown env var %q (allowed: LAUNCHDARKLY_SDK_KEY, LAUNCHDARKLY_FLAG_KEY, LAUNCHDARKLY_MOBILE_KEY, LAUNCHDARKLY_CLIENT_SIDE_ID)", needle, envName)
+		}
+		if val == "" {
+			return "", fmt.Errorf("placeholder %q requires %s to be set", needle, envName)
+		}
+		if !strings.Contains(body, needle) {
+			return "", fmt.Errorf("placeholder %q not found in snippet body", needle)
+		}
+		body = strings.ReplaceAll(body, needle, val)
+	}
+	return body, nil
+}
+
+// applyPlaceholdersToFile reads the file, applies placeholders, and writes
+// the result back. Used for plain (non-scaffolded) snippets.
+func applyPlaceholdersToFile(path string, placeholders map[string]string, env envInputs) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	out, err := applyPlaceholders(string(raw), placeholders, env)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(out), 0o644)
 }
 
 // checkRequirements rejects values that would let a snippet author smuggle

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -234,55 +234,81 @@ realistic install path.
 
 **Severity**: informational
 
-**Context**: Extended validation was added for sdk-info snippets in a
-follow-up PR. Coverage today:
+**Context**: Extended validation was added for sdk-info snippets across
+two PRs. Current coverage:
 
-- 23 install snippets (npm/pnpm/yarn × Node-family SDKs, pip × python,
-  go × go-server) → `validation.runtime: shell-install`. The new
-  validator under `validators/languages/shell-install/` runs the body
-  in a clean ephemeral dir against a real package registry and asserts
-  the package landed where expected.
-- 6 flag-eval snippets (python, node-server, java, js-client, dotnet-client) →
-  bound to per-language syntax-only scaffolds. React-client flag-eval
-  is unbound: the body has top-level imports plus an unguarded
-  `useFlags()` call, so wrapping it in a function-scope scaffold
-  produces "imports not at top level" while letting it run at module
-  scope crashes outside a React render context.
-- 3 init snippets (python-server, node-server, go-server) → bound to
+**Install (26 of 29 snippets validated end-to-end)**:
+
+- 23 Linux-runnable installs (npm/pnpm/yarn × Node-family SDKs, pip ×
+  python, go × go-server) → `validation.runtime: shell-install` runs
+  the body in a clean dir and asserts the package landed.
+- 3 iOS installs (Cartfile, Package.swift, Podfile) →
+  `validation.runtime: ios-install` runs on macos-latest. Each kind
+  (selected via `validation.env: { INSTALL_KIND: ... }`) wraps the
+  fragment in a minimal stub project (synthesized Package.swift /
+  Podfile + xcodeproj-generated stub project / Cartfile) and runs the
+  real package manager (`swift package resolve` / `pod install` /
+  `carthage update --no-build`).
+
+**Init (10 of 13 snippets validated end-to-end)**:
+
+- python-server, node-server, go-server, java-server, dotnet-server →
   per-SDK init-runner scaffolds with `validation.placeholders` for
-  `YOUR_SDK_KEY`. End-to-end against the LD sandbox key in CI; the
-  wrappee is exec'd through runpy / dynamic import / `os/exec` so
-  the EXAM-HELLO success line is emitted on a successful init.
+  `YOUR_SDK_KEY`. EXAM-HELLO success line emitted on a real LD init.
+- node-client, dotnet-client, js-client, react-client, vue-client →
+  per-SDK init-runner scaffolds with `YOUR_CLIENT_SIDE_ID` /
+  `YOUR_MOBILE_KEY` placeholders.
+  - js-client/react-client/vue-client run in headless Chromium via
+    Playwright (Vite/tsdown bundle + preview server).
+  - node-client runs under Node's dynamic-import path, asserting
+    `client.waitForInitialization` resolves.
+  - dotnet-client wraps top-level statements in a `Microsoft.NET.Sdk`
+    console project with `LaunchDarkly.ClientSdk` pulled from NuGet.
+- react-native-client → existing jest+react-native-preset harness;
+  init scaffold supplies a `YourComponent` that calls
+  `useLDClient().waitForInitialization()` and renders the
+  EXAM-HELLO sentinel on success. The harness was hardened to wait
+  for jest's exit code (the original `await_success_line` matched
+  jest's failure output, which echoes the regex pattern).
+
+**Flag-eval (5 of 6 snippets validated)**:
+
+- python, node-server, java, js-client, dotnet-client →
+  per-language syntax-only scaffolds.
+- react-client flag-eval is unbound: top-level imports plus an
+  unguarded `useFlags()` call, so wrapping in a function-scope
+  scaffold produces "imports not at top level" while running at
+  module scope crashes outside a React render context.
 
 **Deferred (no current validation)**:
 
-- iOS install snippets (Cartfile, Package.swift, Podfile) — need a
-  Mac runner for cocoapods + swift package manager + carthage. The
-  Package.swift body is also a `//...`-bracketed fragment, not a
-  complete manifest.
+- ios-client/sdk-info/init — Swift `LDClient.start(...)` requires a
+  full Apple toolchain runtime (macOS app or simulator); SwiftPM
+  resolve on its own won't execute init code. Defer until we have
+  an iOS-simulator-driven runner.
+- android-client/sdk-info/init — Kotlin body uses
+  `this@BaseApplication` (an Activity context) plus
+  `com.launchdarkly.sdk.android.LDClient.init`, both of which require
+  the Android runtime. Defer pending an Android-emulator-driven
+  runner.
 - Android install snippets (groovy + kotlin) — manifest fragments
   meant to be pasted into `build.gradle`; no standalone runnable
   surface.
-- Java/Maven install (xml + gradle) — same shape as Android: dependency
-  manifest fragments, not standalone units.
+- Java/Maven install (xml + gradle) — same shape as Android:
+  dependency manifest fragments, not standalone units.
 - .NET install (PowerShell `Install-Package`) — runs only under the
   legacy NuGet PowerShell host, not modern `dotnet add package`. See
   the dedicated note above.
-- React-client flag-eval — top-level imports prevent wrapping; body
-  isn't standalone-runnable without rewriting.
-- Java/dotnet-server/all-mobile init snippets (java-server,
-  dotnet-server, android, ios, dotnet-client, react-native, vue,
-  js-client, react, node-client) — frontend/mobile inits need GUI or
-  ASP.NET runtime; Java init's `public class Main` plus the harness's
-  entrypoint-class discovery would need a wrapper-class refactor.
+- React-client flag-eval (above).
 - js-client-sdk install-bower — bower's resolver can't fetch the
   unpkg URL; documented separately above.
 
-**Recommended action**: When mobile SDK validation lands (Mac runners),
-revisit iOS / Android / dotnet-client init snippets. When the wider
-consumer refactor lands, evaluate whether the manifest-fragment install
-snippets should ship as full-file scaffolds with a copy-paste hint, or
-remain documentation fragments outside the runnable validation surface.
+**Recommended action**: When iOS and Android runtime runners land
+(simulator/emulator), revisit the ios-client and android-client init
+snippets. When the wider consumer refactor lands, evaluate whether
+the manifest-fragment install snippets should ship as full-file
+scaffolds with a copy-paste hint, or remain documentation fragments
+outside the runnable validation surface.
 
 >## Rendered files always end with a trailing newline
 

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -155,6 +155,53 @@ snippet as documentation-only (no `validation:` block) and rely on a
 separate runnable `Package.swift` companion under `getting-started/`
 for end-to-end coverage.
 
+## go-server-sdk init.txt has an unused import (fixed)
+
+**Severity**: ~~medium~~ resolved
+
+**SDKs affected**: go-server-sdk
+
+**What we observed**: `init.txt` imports
+`github.com/launchdarkly/go-sdk-common/v3/ldcontext` but never references
+any symbol from that package. Go rejects unused imports as a compile
+error, so following the snippet verbatim into a `main.go` produces:
+
+```
+imported and not used: "github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+```
+
+**Resolution**: Unused import removed. Deliberate divergence from
+gonfalon's `packages/sdk-info/src/snippets/go-server-sdk/init.txt`;
+the contradiction (the snippet doesn't reference `ldcontext` but
+imports it) exists in the gonfalon source today and is a correctness
+bug worth correcting before extended validation runs against the
+rendered output.
+
+## js-client-sdk install-bower URL is not a valid bower target
+
+**Severity**: low (deferred — bower is deprecated)
+
+**SDKs affected**: js-client-sdk
+
+**What we observed**: `install-bower.txt` reads
+`bower install https://unpkg.com/@launchdarkly/js-client-sdk@4`. Bower's
+URL resolver expects a tarball, zipfile, or git remote — unpkg.com
+returns a `text/javascript` body for that URL, which produces:
+
+```
+ENORESTARGET URL sources can't resolve targets
+```
+
+The original gonfalon source had the same issue against the v3 unpkg
+URL; bumping to v4 (this branch) didn't change the underlying
+incompatibility. Bower itself has been deprecated since 2017.
+
+**Recommended action**: Skip validation for this snippet; leave the body
+unchanged so gonfalon's `?raw` import keeps shipping the canonical
+fragment. When the wider consumer-refactor lands, drop the bower
+install entry from the install-card surface — bower is no longer a
+realistic install path.
+
 ## Rendered files always end with a trailing newline
 
 **Severity**: informational

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -155,7 +155,136 @@ snippet as documentation-only (no `validation:` block) and rely on a
 separate runnable `Package.swift` companion under `getting-started/`
 for end-to-end coverage.
 
-## Rendered files always end with a trailing newline
+## python-server-sdk flagEval.txt has an empty if/else body (fixed)
+
+**Severity**: ~~medium~~ resolved
+
+**SDKs affected**: python-server-sdk
+
+**What we observed**: `flagEval.txt` reads:
+
+```python
+if flag_value:
+    # TODO: Put your feature here
+else:
+    # TODO: Put your fallback behavior here
+```
+
+A bare comment is not a statement; Python rejects this with
+`SyntaxError: expected an indented block after 'if' statement`. The
+snippet is presented as the "Add the SDK to your code" example and is
+copy-pasted by users into their own program — pasting verbatim
+produces an immediate syntax error before the user's TODO has a chance
+to replace the comments.
+
+**Resolution**: Each branch was rewritten as `pass  # TODO: …` so the
+fragment is syntactically complete and parses cleanly with the
+`python-server-sdk/scaffolds/python-syntax-only` validator. The visible
+TODO hint is preserved as a trailing comment; users still know where
+to insert their feature code.
+
+## go-server-sdk init.txt has an unused import (fixed)
+
+**Severity**: ~~medium~~ resolved
+
+**SDKs affected**: go-server-sdk
+
+**What we observed**: `init.txt` imports
+`github.com/launchdarkly/go-sdk-common/v3/ldcontext` but never references
+any symbol from that package. Go rejects unused imports as a compile
+error, so following the snippet verbatim into a `main.go` produces:
+
+```
+imported and not used: "github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+```
+
+**Resolution**: Unused import removed. Deliberate divergence from
+gonfalon's `packages/sdk-info/src/snippets/go-server-sdk/init.txt`;
+the contradiction (the snippet doesn't reference `ldcontext` but
+imports it) exists in the gonfalon source today and is a correctness
+bug worth correcting before extended validation runs against the
+rendered output.
+
+## js-client-sdk install-bower URL is not a valid bower target
+
+**Severity**: low (deferred — bower is deprecated)
+
+**SDKs affected**: js-client-sdk
+
+**What we observed**: `install-bower.txt` reads
+`bower install https://unpkg.com/@launchdarkly/js-client-sdk@4`. Bower's
+URL resolver expects a tarball, zipfile, or git remote — unpkg.com
+returns a `text/javascript` body for that URL, which produces:
+
+```
+ENORESTARGET URL sources can't resolve targets
+```
+
+The original gonfalon source had the same issue against the v3 unpkg
+URL; bumping to v4 (this branch) didn't change the underlying
+incompatibility. Bower itself has been deprecated since 2017.
+
+**Recommended action**: Skip validation for this snippet; leave the body
+unchanged so gonfalon's `?raw` import keeps shipping the canonical
+fragment. When the wider consumer-refactor lands, drop the bower
+install entry from the install-card surface — bower is no longer a
+realistic install path.
+
+## Validation coverage and deferred snippets
+
+**Severity**: informational
+
+**Context**: Extended validation was added for sdk-info snippets in a
+follow-up PR. Coverage today:
+
+- 23 install snippets (npm/pnpm/yarn × Node-family SDKs, pip × python,
+  go × go-server) → `validation.runtime: shell-install`. The new
+  validator under `validators/languages/shell-install/` runs the body
+  in a clean ephemeral dir against a real package registry and asserts
+  the package landed where expected.
+- 6 flag-eval snippets (python, node-server, java, js-client, dotnet-client) →
+  bound to per-language syntax-only scaffolds. React-client flag-eval
+  is unbound: the body has top-level imports plus an unguarded
+  `useFlags()` call, so wrapping it in a function-scope scaffold
+  produces "imports not at top level" while letting it run at module
+  scope crashes outside a React render context.
+- 3 init snippets (python-server, node-server, go-server) → bound to
+  per-SDK init-runner scaffolds with `validation.placeholders` for
+  `YOUR_SDK_KEY`. End-to-end against the LD sandbox key in CI; the
+  wrappee is exec'd through runpy / dynamic import / `os/exec` so
+  the EXAM-HELLO success line is emitted on a successful init.
+
+**Deferred (no current validation)**:
+
+- iOS install snippets (Cartfile, Package.swift, Podfile) — need a
+  Mac runner for cocoapods + swift package manager + carthage. The
+  Package.swift body is also a `//...`-bracketed fragment, not a
+  complete manifest.
+- Android install snippets (groovy + kotlin) — manifest fragments
+  meant to be pasted into `build.gradle`; no standalone runnable
+  surface.
+- Java/Maven install (xml + gradle) — same shape as Android: dependency
+  manifest fragments, not standalone units.
+- .NET install (PowerShell `Install-Package`) — runs only under the
+  legacy NuGet PowerShell host, not modern `dotnet add package`. See
+  the dedicated note above.
+- React-client flag-eval — top-level imports prevent wrapping; body
+  isn't standalone-runnable without rewriting.
+- Java/dotnet-server/all-mobile init snippets (java-server,
+  dotnet-server, android, ios, dotnet-client, react-native, vue,
+  js-client, react, node-client) — frontend/mobile inits need GUI or
+  ASP.NET runtime; Java init's `public class Main` plus the harness's
+  entrypoint-class discovery would need a wrapper-class refactor.
+- js-client-sdk install-bower — bower's resolver can't fetch the
+  unpkg URL; documented separately above.
+
+**Recommended action**: When mobile SDK validation lands (Mac runners),
+revisit iOS / Android / dotnet-client init snippets. When the wider
+consumer refactor lands, evaluate whether the manifest-fragment install
+snippets should ship as full-file scaffolds with a copy-paste hint, or
+remain documentation fragments outside the runnable validation surface.
+
+>## Rendered files always end with a trailing newline
 
 **Severity**: informational
 

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -155,53 +155,6 @@ snippet as documentation-only (no `validation:` block) and rely on a
 separate runnable `Package.swift` companion under `getting-started/`
 for end-to-end coverage.
 
-## go-server-sdk init.txt has an unused import (fixed)
-
-**Severity**: ~~medium~~ resolved
-
-**SDKs affected**: go-server-sdk
-
-**What we observed**: `init.txt` imports
-`github.com/launchdarkly/go-sdk-common/v3/ldcontext` but never references
-any symbol from that package. Go rejects unused imports as a compile
-error, so following the snippet verbatim into a `main.go` produces:
-
-```
-imported and not used: "github.com/launchdarkly/go-sdk-common/v3/ldcontext"
-```
-
-**Resolution**: Unused import removed. Deliberate divergence from
-gonfalon's `packages/sdk-info/src/snippets/go-server-sdk/init.txt`;
-the contradiction (the snippet doesn't reference `ldcontext` but
-imports it) exists in the gonfalon source today and is a correctness
-bug worth correcting before extended validation runs against the
-rendered output.
-
-## js-client-sdk install-bower URL is not a valid bower target
-
-**Severity**: low (deferred — bower is deprecated)
-
-**SDKs affected**: js-client-sdk
-
-**What we observed**: `install-bower.txt` reads
-`bower install https://unpkg.com/@launchdarkly/js-client-sdk@4`. Bower's
-URL resolver expects a tarball, zipfile, or git remote — unpkg.com
-returns a `text/javascript` body for that URL, which produces:
-
-```
-ENORESTARGET URL sources can't resolve targets
-```
-
-The original gonfalon source had the same issue against the v3 unpkg
-URL; bumping to v4 (this branch) didn't change the underlying
-incompatibility. Bower itself has been deprecated since 2017.
-
-**Recommended action**: Skip validation for this snippet; leave the body
-unchanged so gonfalon's `?raw` import keeps shipping the canonical
-fragment. When the wider consumer-refactor lands, drop the bower
-install entry from the install-card surface — bower is no longer a
-realistic install path.
-
 ## Rendered files always end with a trailing newline
 
 **Severity**: informational

--- a/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only.snippet.md
@@ -13,22 +13,39 @@ inputs:
 validation:
   runtime: dotnet-client
   entrypoint: Program.cs
+  # The harness reads requirements.txt as a list of `dotnet add package`
+  # arguments — one per line.
+  requirements: |
+    LaunchDarkly.ClientSdk
 ---
 
 ```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Client;
+
 namespace LaunchDarklySnippet
 {
     public class Program
     {
+        // Stub so the wrappee body's `client.BoolVariation(...)`,
+        // `client.StringVariation(...)`, etc. resolve at compile time.
+        // Never invoked at runtime — Main below short-circuits to print
+        // the EXAM-HELLO line.
+        #pragma warning disable CS8625
+        private static LdClient client = null;
+        #pragma warning restore CS8625
+
         public static void Main(string[] args)
         {
             System.Console.WriteLine("feature flag evaluates to true");
         }
 
+        #pragma warning disable CS0162
         private void Wrappee()
         {
 {{ body }}
         }
+        #pragma warning restore CS0162
     }
 }
 ```

--- a/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,41 @@
+---
+id: dotnet-client-sdk/scaffolds/init-runner
+sdk: dotnet-client-sdk
+kind: scaffold
+lang: csharp
+file: Program.cs
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. The wrappee body uses C# top-level statements: it builds a
+  context, awaits `LdClient.InitAsync`, then conditionally prints
+  `SDK successfully initialized!`. The scaffold drops the body verbatim
+  and appends `Console.WriteLine("feature flag evaluates to true");`
+  so the harness's `await_success_line` regex sees the EXAM-HELLO line
+  on a clean run. The body uses `client.Initialized` as the gate; if
+  init fails the trailer still runs (the body has no `Environment.Exit`
+  in the failure branch), so the trailer is wrapped in an
+  `if (client.Initialized)` guard tied to the same lexical `client`.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: dotnet-client
+  entrypoint: Program.cs
+  requirements: |
+    LaunchDarkly.ClientSdk
+---
+
+```csharp
+{{ body }}
+
+if (client.Initialized)
+{
+    Console.WriteLine("feature flag evaluates to true");
+}
+else
+{
+    Console.Error.WriteLine("scaffold: client.Initialized is false after InitAsync");
+    Environment.Exit(1);
+}
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -5,6 +5,8 @@ kind: flag-eval
 lang: csharp
 file: dotnet-client-sdk/flagEval.txt
 description: Flag evaluation example for dotnet-client-sdk.
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: csharp
 file: dotnet-client-sdk/init.txt
 description: Client initialization snippet for dotnet-client-sdk.
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_MOBILE_KEY: LAUNCHDARKLY_MOBILE_KEY
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/init-runner-csproj.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/init-runner-csproj.snippet.md
@@ -1,0 +1,25 @@
+---
+id: dotnet-server-sdk/scaffolds/init-runner-csproj
+sdk: dotnet-server-sdk
+kind: scaffold
+lang: xml
+file: HelloDotNet.csproj
+description: |
+  Companion `.csproj` for the dotnet-server init scaffold. Uses the
+  ASP.NET Core SDK so `WebApplication.CreateBuilder` resolves; the
+  harness's run.sh skips synthesizing its default console-only csproj
+  when one is already staged.
+---
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>HelloDotNet</RootNamespace>
+    <AssemblyName>HelloDotNet</AssemblyName>
+  </PropertyGroup>
+</Project>
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,40 @@
+---
+id: dotnet-server-sdk/scaffolds/init-runner
+sdk: dotnet-server-sdk
+kind: scaffold
+lang: csharp
+file: Program.cs
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. The wrappee body uses C# top-level statements that include
+  `WebApplication.CreateBuilder(args)` (gonfalon's docs target ASP.NET
+  Core hosting) plus a regular `LdClient` initialization.
+
+  Layout:
+    - Program.cs (this scaffold) — the snippet body verbatim, with the
+      literal SDK-key placeholder substituted by `validation.placeholders`.
+      We append a final `Console.WriteLine("feature flag evaluates to true")`
+      after the body so the harness's `await_success_line` regex sees the
+      EXAM-HELLO line on a clean run. The body's failure branch calls
+      `Environment.Exit(1)` so a failed init never reaches the trailer.
+    - HelloDotNet.csproj (companion) — overrides the harness's default
+      console-only `.csproj` with `Microsoft.NET.Sdk.Web`, so
+      `WebApplication.CreateBuilder` resolves at compile time.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: dotnet-server
+  entrypoint: Program.cs
+  companions:
+    - dotnet-server-sdk/scaffolds/init-runner-csproj
+  requirements: |
+    LaunchDarkly.ServerSdk
+---
+
+```csharp
+{{ body }}
+
+Console.WriteLine("feature flag evaluates to true");
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: csharp
 file: dotnet-server-sdk/init.txt
 description: Client initialization snippet for dotnet-server-sdk.
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
 ---
 
 ```csharp

--- a/snippets/sdks/go-server-sdk/snippets/scaffolds/init-runner-main.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/scaffolds/init-runner-main.snippet.md
@@ -1,0 +1,40 @@
+---
+id: go-server-sdk/scaffolds/init-runner-main
+sdk: go-server-sdk
+kind: scaffold
+lang: go
+file: main.go
+description: |
+  Runner half of the Go init scaffold pair. Staged as a companion of
+  `init-runner` so it lands at `main.go` in the staging dir while the
+  wrappee body sits at `wrappee/init.go`. `validation.entrypoint:
+  main.go` on the parent scaffold makes the harness run this file.
+---
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	cmd := exec.Command("go", "run", "wrappee/init.go")
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "scaffold: wrappee exited with error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "wrappee stdout: %s\n", out)
+		os.Exit(1)
+	}
+	if !strings.Contains(string(out), "SDK successfully initialized") {
+		fmt.Fprintf(os.Stderr, "scaffold: wrappee did not print 'SDK successfully initialized'\n")
+		fmt.Fprintf(os.Stderr, "wrappee stdout: %s\n", out)
+		os.Exit(1)
+	}
+	fmt.Println("feature flag evaluates to true")
+}
+```

--- a/snippets/sdks/go-server-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,37 @@
+---
+id: go-server-sdk/scaffolds/init-runner
+sdk: go-server-sdk
+kind: scaffold
+lang: go
+file: wrappee/init.go
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. Layout:
+    - wrappee/init.go (this scaffold) — the snippet body verbatim, with
+      the `'YOUR_SDK_KEY'` placeholder substituted at validate time. The
+      scaffold's `file:` is intentionally `wrappee/init.go` so the
+      runner can reference it as a sub-package.
+    - main.go (companion `init-runner-main`) — invokes `go run
+      wrappee/init.go`, captures its stdout, asserts the wrappee printed
+      `SDK successfully initialized!`, then emits the EXAM-HELLO success
+      line the harness greps for. The scaffold sets
+      `validation.entrypoint: main.go` so the harness runs the runner,
+      not the wrappee.
+
+  Two `package main` files in different directories don't conflict;
+  Go module resolution picks up the wrappee's imports through the
+  shared `go.mod` the harness initializes at the staging-dir root.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, written into wrappee/init.go.
+validation:
+  runtime: go
+  entrypoint: main.go
+  companions:
+    - go-server-sdk/scaffolds/init-runner-main
+---
+
+```go
+{{ body }}
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-info/init.snippet.md
@@ -15,7 +15,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	ld "github.com/launchdarkly/go-server-sdk/v7"
 )
 

--- a/snippets/sdks/go-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: go
 file: go-server-sdk/init.txt
 description: Client initialization snippet for go-server-sdk.
+validation:
+  scaffold: go-server-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-info/install-go.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-info/install-go.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: go-server-sdk/install-go.txt
 description: Install command for go-server-sdk (go).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-cartfile.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-cartfile.snippet.md
@@ -5,6 +5,10 @@ kind: install
 lang: text
 file: ios-client-sdk/install-cartfile.txt
 description: Install command for ios-client-sdk (cartfile).
+validation:
+  runtime: ios-install
+  env:
+    INSTALL_KIND: cartfile
 ---
 
 ```text

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-package-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-package-swift.snippet.md
@@ -10,7 +10,7 @@ description: Install command for ios-client-sdk (package-swift).
 ```swift
 //...
     dependencies: [
-        .package(url: "https://github.com/launchdarkly/ios-client-sdk.git", .upToNextMajor("9.15.0")),
+        .package(url: "https://github.com/launchdarkly/ios-client-sdk.git", .upToNextMajor(from: "9.15.0")),
    ],
     targets: [
         .target(

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-package-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-package-swift.snippet.md
@@ -5,6 +5,10 @@ kind: install
 lang: swift
 file: ios-client-sdk/install-package-swift.txt
 description: Install command for ios-client-sdk (package-swift).
+validation:
+  runtime: ios-install
+  env:
+    INSTALL_KIND: swift-package
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-podfile.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-info/install-podfile.snippet.md
@@ -5,6 +5,10 @@ kind: install
 lang: ruby
 file: ios-client-sdk/install-podfile.txt
 description: Install command for ios-client-sdk (podfile).
+validation:
+  runtime: ios-install
+  env:
+    INSTALL_KIND: podfile
 ---
 
 ```ruby

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/init-runner-main.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/init-runner-main.snippet.md
@@ -1,0 +1,45 @@
+---
+id: java-server-sdk/scaffolds/init-runner-main
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/runner/Runner.java
+description: |
+  Runner half of the Java init scaffold pair. Lives under a different
+  package (`com.launchdarkly.tutorial.runner`) so both this and the
+  wrappee's `Main` class can be public top-level classes. Listed as a
+  companion of `init-runner` and used as the maven mainClass via the
+  parent scaffold's `validation.entrypoint`.
+---
+
+```java
+package com.launchdarkly.tutorial.runner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class Runner {
+    public static void main(String[] args) throws Exception {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        PrintStream tee = new PrintStream(new java.io.OutputStream() {
+            @Override public void write(int b) {
+                System.err.write(b);
+                buf.write(b);
+            }
+        }, true);
+        PrintStream origOut = System.out;
+        System.setOut(tee);
+        try {
+            com.launchdarkly.tutorial.Main.main(args);
+        } finally {
+            System.setOut(origOut);
+        }
+        String captured = buf.toString();
+        if (!captured.contains("SDK successfully initialized")) {
+            System.err.println("scaffold: wrappee did not print 'SDK successfully initialized'");
+            System.exit(1);
+        }
+        System.out.println("feature flag evaluates to true");
+    }
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,43 @@
+---
+id: java-server-sdk/scaffolds/init-runner
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. The wrappee body declares its own `public class Main` with a
+  `main` method, so this scaffold drops the body verbatim under the
+  `com.launchdarkly.tutorial` package and lets the jvm harness compile
+  it. A separate runner companion (different package, different class)
+  is the maven entrypoint: it invokes `Main.main(args)` via reflection,
+  asserts the wrappee printed `SDK successfully initialized`, and emits
+  the EXAM-HELLO success line the validator harness greps for.
+
+  Layout:
+    - src/main/java/com/launchdarkly/tutorial/Main.java (this scaffold) —
+      the snippet body verbatim, with the literal SDK-key placeholder
+      already substituted via `validation.placeholders`.
+    - src/main/java/com/launchdarkly/tutorial/runner/Runner.java
+      (companion `init-runner-main`) — top-level runner that the harness
+      treats as the maven mainClass.
+
+  Two top-level public `Main` classes can't coexist in the same package
+  in Java; the runner sits under a sub-package to keep both as public
+  classes in their own files.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: jvm
+  entrypoint: src/main/java/com/launchdarkly/tutorial/runner/Runner.java
+  companions:
+    - java-server-sdk/scaffolds/init-runner-main
+---
+
+```java
+package com.launchdarkly.tutorial;
+
+{{ body }}
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -18,12 +18,21 @@ validation:
 ```java
 package com.launchdarkly;
 
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+
 public class Snippet {
+    // Stub instance the wrappee body refers to. Never used at runtime;
+    // present so the body's `client.boolVariation(…)` calls resolve a
+    // symbol during compilation.
+    @SuppressWarnings("unused")
+    private static final LDClient client = null;
+
     public static void main(String[] args) {
         System.out.println("feature flag evaluates to true");
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "ConstantConditions"})
     private void wrappee() {
         try {
 {{ body }}

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -5,6 +5,8 @@ kind: flag-eval
 lang: java
 file: java-server-sdk/flagEval.txt
 description: Flag evaluation example for java-server-sdk.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: java
 file: java-server-sdk/init.txt
 description: Client initialization snippet for java-server-sdk.
+validation:
+  scaffold: java-server-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
 ---
 
 ```java

--- a/snippets/sdks/js-client-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,49 @@
+---
+id: js-client-sdk/scaffolds/init-runner
+sdk: js-client-sdk
+kind: scaffold
+lang: javascript
+file: src/app.ts
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. The init body assumes `createClient` is in scope (gonfalon's docs
+  put the import on the install snippet) — the scaffold prepends the
+  v4 module import. The js-client validator builds this with tsdown and
+  loads it in headless Chromium; on a clean wrappee run we set the
+  page's body text to the EXAM-HELLO line so the harness's polling loop
+  matches.
+
+  The body's failure branch logs to `console.error`; we mirror that to
+  `document.body.textContent` only on the success path so a failed init
+  never produces a false positive.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: js-client
+  entrypoint: src/app.ts
+---
+
+```javascript
+import { createClient } from '@launchdarkly/js-client-sdk';
+
+(async () => {
+  let _scaffoldSucceeded = false;
+  const _origLog = console.log.bind(console);
+  console.log = (...args) => {
+    if (args.join(' ').includes('SDK successfully initialized')) {
+      _scaffoldSucceeded = true;
+    }
+    _origLog(...args);
+  };
+
+  {{ body }}
+
+  if (_scaffoldSucceeded) {
+    document.body.textContent = 'feature flag evaluates to true';
+  } else {
+    document.body.textContent = 'scaffold: wrappee did not print success';
+  }
+})();
+```

--- a/snippets/sdks/js-client-sdk/snippets/scaffolds/js-syntax-only.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/scaffolds/js-syntax-only.snippet.md
@@ -3,23 +3,30 @@ id: js-client-sdk/scaffolds/js-syntax-only
 sdk: js-client-sdk
 kind: scaffold
 lang: javascript
-file: index.js
+file: src/app.ts
 description: |
-  Parse-only validator for JavaScript client SDK doc fragments.
+  Parse-only validator for JavaScript client SDK doc fragments. Stages
+  itself as `src/app.ts` so the js-client validator's pre-baked tsdown
+  project picks it up; the bundle is loaded into headless Chromium and
+  the page is asserted to print the EXAM-HELLO success line.
+
+  The wrappee body is wrapped inside a never-invoked function — its
+  references to `ldclient`, hooks like `useFlags`, etc. don't have to
+  resolve, but the file must be syntactically valid TypeScript-flavored
+  JS.
 inputs:
   body:
     type: string
     description: The wrappee snippet's rendered body, inserted into the parse-only harness.
 validation:
   runtime: js-client
-  entrypoint: index.js
+  entrypoint: src/app.ts
 ---
 
 ```javascript
-(async () => {
-  function _wrappee() {
+function _wrappee() {
 {{ body }}
-  }
-  console.log('feature flag evaluates to true');
-})();
+}
+
+document.body.textContent = 'feature flag evaluates to true';
 ```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -5,6 +5,8 @@ kind: flag-eval
 lang: javascript
 file: js-client-sdk/flagEval.txt
 description: Flag evaluation example for js-client-sdk.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```javascript

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: javascript
 file: js-client-sdk/init.txt
 description: Client initialization snippet for js-client-sdk.
+validation:
+  scaffold: js-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_CLIENT_SIDE_ID: LAUNCHDARKLY_CLIENT_SIDE_ID
 ---
 
 ```javascript

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: js-client-sdk/install-npm.txt
 description: Install command for js-client-sdk (npm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: js-client-sdk/install-pnpm.txt
 description: Install command for js-client-sdk (pnpm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: js-client-sdk/install-yarn.txt
 description: Install command for js-client-sdk (yarn).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/node-client-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,42 @@
+---
+id: node-client-sdk/scaffolds/init-runner
+sdk: node-client-sdk
+kind: scaffold
+lang: javascript
+file: index.mjs
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. Same shape as the node-server scaffold: write the wrappee body to
+  a sibling `.mjs` file, dynamic-import it, then assert the client
+  `LaunchDarkly.initialize(...)` returned a client whose
+  `waitForInitialization` call settled successfully.
+
+  The snippet itself doesn't print on success (it has empty try/catch
+  branches), so we tail-append a second `await client.waitForInitialization(5)`
+  on the same lexical `client` the body declared. If init has settled
+  successfully the awaiting promise resolves immediately; if init failed
+  in the body's swallowed catch, the second await rejects, the
+  rejection is caught here, and we exit non-zero.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: node
+  entrypoint: index.mjs
+  requirements: |
+    launchdarkly-node-client-sdk
+---
+
+```javascript
+{{ body }}
+
+try {
+  await client.waitForInitialization(5);
+  console.log('feature flag evaluates to true');
+  await client.close();
+} catch (err) {
+  console.error('scaffold: waitForInitialization rejected:', err && err.message ? err.message : err);
+  process.exit(1);
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: javascript
 file: node-client-sdk/init.txt
 description: Client initialization snippet for node-client-sdk.
+validation:
+  scaffold: node-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_CLIENT_SIDE_ID: LAUNCHDARKLY_CLIENT_SIDE_ID
 ---
 
 ```javascript

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: node-client-sdk/install-npm.txt
 description: Install command for node-client-sdk (npm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: node-client-sdk/install-pnpm.txt
 description: Install command for node-client-sdk (pnpm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: node-client-sdk/install-yarn.txt
 description: Install command for node-client-sdk (yarn).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/node-server-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,72 @@
+---
+id: node-server-sdk/scaffolds/init-runner
+sdk: node-server-sdk
+kind: scaffold
+lang: javascript
+file: index.mjs
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. The wrappee's literal SDK-key placeholder is substituted at
+  validate time via the snippet's `validation.placeholders` map (handled
+  by the dispatcher), so by the time the body executes here it already
+  carries the real key.
+
+  The scaffold writes the wrappee body to a sibling `.mjs` file and
+  dynamic-imports it so the wrappee's top-level statements run with
+  `node_modules` resolution rooted in the staging dir. It then waits a
+  bounded period for the wrappee's `client.once('ready', …)` callback
+  to print the snippet's success line, and emits the EXAM-HELLO line
+  the validator harness greps for. The shared `await_success_line`
+  helper SIGTERMs us as soon as the EXAM-HELLO line appears, so the
+  bounded wait below is just a ceiling.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: node
+  entrypoint: index.mjs
+  requirements: |
+    @launchdarkly/node-server-sdk
+---
+
+```javascript
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// String.raw on a tagged template prevents \\ escape-collapsing and
+// keeps the wrappee body byte-identical to the snippet source. None of
+// the node init bodies we ship contain backticks; document the
+// constraint here for any future port that adds one.
+const wrappeeBody = String.raw`
+{{ body }}
+`;
+
+let sawSuccess = false;
+const origLog = console.log.bind(console);
+console.log = (...args) => {
+  if (args.join(' ').includes('SDK successfully initialized')) {
+    sawSuccess = true;
+  }
+  origLog(...args);
+};
+
+// Write into the same directory as this scaffold's entry file so the
+// wrappee's `import '@launchdarkly/node-server-sdk'` resolves through
+// the local node_modules the harness installed.
+const here = dirname(fileURLToPath(import.meta.url));
+const bodyPath = join(here, '_init-body.mjs');
+writeFileSync(bodyPath, wrappeeBody);
+
+await import(bodyPath);
+
+await new Promise((resolve) => setTimeout(resolve, 30_000));
+
+if (!sawSuccess) {
+  console.error("scaffold: wrappee did not print 'SDK successfully initialized'");
+  process.exit(1);
+}
+
+origLog('feature flag evaluates to true');
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -5,6 +5,8 @@ kind: flag-eval
 lang: javascript
 file: node-server-sdk/flagEval.txt
 description: Flag evaluation example for node-server-sdk.
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 ---
 
 ```javascript

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: javascript
 file: node-server-sdk/init.txt
 description: Client initialization snippet for node-server-sdk.
+validation:
+  scaffold: node-server-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
 ---
 
 ```javascript

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: node-server-sdk/install-npm.txt
 description: Install command for node-server-sdk (npm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: node-server-sdk/install-pnpm.txt
 description: Install command for node-server-sdk (pnpm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: node-server-sdk/install-yarn.txt
 description: Install command for node-server-sdk (yarn).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/python-server-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,79 @@
+---
+id: python-server-sdk/scaffolds/init-runner
+sdk: python-server-sdk
+kind: scaffold
+lang: python
+file: main.py
+description: |
+  Runs an `init.txt`-style snippet end-to-end against a real LaunchDarkly
+  env. The wrappee's literal SDK-key placeholder is substituted at validate
+  time via the snippet's `validation.placeholders` map (handled by the
+  dispatcher), so by the time the body is spliced in below it already
+  carries the real key.
+
+  The wrappee runs through runpy.run_path with `run_name="__main__"` so
+  any `if __name__ == '__main__'` block in the body fires. The scaffold
+  watches for the wrappee's own `SDK successfully initialized` line; on
+  a clean run it then emits the EXAM-HELLO success line the validator
+  harness greps for.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: python
+  entrypoint: main.py
+  requirements: |
+    launchdarkly-server-sdk
+---
+
+```python
+import io
+import runpy
+import sys
+import tempfile
+
+# The wrappee body is embedded as a raw triple-quoted string. None of the
+# init snippets we ship use the `'''` token at module scope, so this is
+# safe today; document the constraint here for any future port that
+# adds one.
+_WRAPPEE_BODY = r'''
+{{ body }}
+'''
+
+with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+    fh.write(_WRAPPEE_BODY)
+    body_path = fh.name
+
+# Capture stdout from the wrappee so we can assert its success line.
+buf = io.StringIO()
+
+class Tee:
+    def __init__(self, *streams):
+        self.streams = streams
+    def write(self, s):
+        for st in self.streams:
+            st.write(s)
+    def flush(self):
+        for st in self.streams:
+            st.flush()
+
+real_stdout = sys.stdout
+sys.stdout = Tee(real_stdout, buf)
+try:
+    runpy.run_path(body_path, run_name="__main__")
+except SystemExit as e:
+    if e.code not in (0, None):
+        sys.stdout = real_stdout
+        print(f"scaffold: wrappee exited with non-zero code {e.code}", file=sys.stderr)
+        sys.exit(1)
+finally:
+    sys.stdout = real_stdout
+
+if "SDK successfully initialized" not in buf.getvalue():
+    print("scaffold: wrappee did not print 'SDK successfully initialized'", file=sys.stderr)
+    sys.exit(1)
+
+# Match the EXAM-HELLO success regex the harness watches for.
+print("feature flag evaluates to true")
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -15,7 +15,7 @@ context = Context.builder("context-key-123abc").name("Sandy").build()
 flag_value = client.variation("featureKey", context, False)
 
 if flag_value:
-    # TODO: Put your feature here
+    pass  # TODO: Put your feature here
 else:
-    # TODO: Put your fallback behavior here
+    pass  # TODO: Put your fallback behavior here
 ```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval.snippet.md
@@ -5,6 +5,8 @@ kind: flag-eval
 lang: python
 file: python-server-sdk/flagEval.txt
 description: Flag evaluation example for python-server-sdk.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: python
 file: python-server-sdk/init.txt
 description: Client initialization snippet for python-server-sdk.
+validation:
+  scaffold: python-server-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/install-pip.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/install-pip.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: python-server-sdk/install-pip.txt
 description: Install command for python-server-sdk (pip).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-client-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,54 @@
+---
+id: react-client-sdk/scaffolds/init-runner
+sdk: react-client-sdk
+kind: scaffold
+lang: tsx
+file: src/main.tsx
+description: |
+  Runs an `init.txt`-style React snippet end-to-end against a real
+  LaunchDarkly env. The init body is a complete entrypoint: it imports
+  React + the LD provider, declares an `App` component, and calls
+  `createRoot(...).render(<LDProvider>...<App />...</LDProvider>)`. The
+  scaffold drops the body verbatim into `src/main.tsx`, then appends a
+  poll loop that watches the React-rendered DOM. As soon as the body's
+  `App` renders its sentinel text inside `#root`, we mirror the
+  EXAM-HELLO success line into `document.body` so the validator's
+  Playwright check matches.
+
+  LDProvider only renders its children after the SDK has initialized
+  (or its `deferInitialization` timeout fires); seeing the body's
+  sentinel text is the end-to-end signal that init succeeded against a
+  real LD env. If init fails, the children never mount and the poll
+  times out.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: react-client
+  entrypoint: src/main.tsx
+---
+
+```tsx
+{{ body }}
+
+(function pollForBodySentinel() {
+  const sentinel = 'Let your feature flags fly';
+  const deadline = Date.now() + 25_000;
+  const tick = () => {
+    const root = document.getElementById('root');
+    const text = (root && root.textContent) || '';
+    if (text.includes(sentinel)) {
+      document.body.setAttribute('data-validator', 'ok');
+      document.body.innerHTML = '<p>feature flag evaluates to true</p>';
+      return;
+    }
+    if (Date.now() < deadline) {
+      setTimeout(tick, 200);
+      return;
+    }
+    document.body.innerHTML = '<p>scaffold: sentinel never rendered (LDProvider did not finish initializing)</p>';
+  };
+  tick();
+})();
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: tsx
 file: react-client-sdk/init.txt
 description: Client initialization snippet for react-client-sdk.
+validation:
+  scaffold: react-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_CLIENT_SIDE_ID: LAUNCHDARKLY_CLIENT_SIDE_ID
 ---
 
 ```tsx

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-client-sdk/install-npm.txt
 description: Install command for react-client-sdk (npm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-client-sdk/install-pnpm.txt
 description: Install command for react-client-sdk (pnpm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-client-sdk/install-yarn.txt
 description: Install command for react-client-sdk (yarn).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-native-client-sdk/snippets/scaffolds/init-runner-welcome.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/scaffolds/init-runner-welcome.snippet.md
@@ -1,0 +1,21 @@
+---
+id: react-native-client-sdk/scaffolds/init-runner-welcome
+sdk: react-native-client-sdk
+kind: scaffold
+lang: tsx
+file: src/welcome.tsx
+description: |
+  Stub welcome companion for the react-native-client init scaffold.
+  The harness copies `src/welcome.tsx` from the staged snippet into the
+  pre-baked project; the init scaffold doesn't actually use a Welcome
+  component but the file has to exist for the cp to succeed.
+---
+
+```tsx
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function Welcome() {
+  return <View><Text>welcome stub (unused by init scaffold)</Text></View>;
+}
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,60 @@
+---
+id: react-native-client-sdk/scaffolds/init-runner
+sdk: react-native-client-sdk
+kind: scaffold
+lang: tsx
+file: App.tsx
+description: |
+  Runs an `init.txt`-style React Native snippet end-to-end against a
+  real LaunchDarkly env, using the same jest+react-native-preset
+  harness as the syntax-only flow. The init body declares an `App`
+  component that wraps a `<YourComponent />` in `<LDProvider>` and
+  exports App as default. The body references `useEffect` (assumed
+  imported) and `YourComponent` (assumed defined) — both supplied by
+  this scaffold's prelude.
+
+  We prepend `import { useEffect } from 'react';` and a `YourComponent`
+  definition that reads the EXAM-HELLO flag via `useFlags`/`useLDClient`
+  and renders the canonical success text once the flag resolves to
+  true. The harness's jest test renders `<App />` and asserts the
+  flattened text contains `feature flag evaluates to true`.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: react-native-client
+  entrypoint: App.tsx
+  companions:
+    - react-native-client-sdk/scaffolds/init-runner-welcome
+---
+
+```tsx
+import { useEffect, useState } from 'react';
+import { Text, View } from 'react-native';
+import { useLDClient } from '@launchdarkly/react-native-client-sdk';
+
+const YourComponent = () => {
+  const ldClient = useLDClient();
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    if (!ldClient) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await ldClient.waitForInitialization(5_000);
+        if (!cancelled) setReady(true);
+      } catch (e) {
+        // leave ready=false; the test will time out and report the real error
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [ldClient]);
+  if (!ready) {
+    return <View><Text>waiting for LD client</Text></View>;
+  }
+  return <View><Text>feature flag evaluates to true</Text></View>;
+};
+
+{{ body }}
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: tsx
 file: react-native-client-sdk/init.txt
 description: Client initialization snippet for react-native-client-sdk.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_MOBILE_KEY: LAUNCHDARKLY_MOBILE_KEY
 ---
 
 ```tsx

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm-async-storage.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm-async-storage.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-native-client-sdk/install-npm-async-storage.txt
 description: Install command for react-native-client-sdk (npm-async-storage).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-native-client-sdk/install-npm.txt
 description: Install command for react-native-client-sdk (npm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm-async-storage.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm-async-storage.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-native-client-sdk/install-pnpm-async-storage.txt
 description: Install command for react-native-client-sdk (pnpm-async-storage).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-native-client-sdk/install-pnpm.txt
 description: Install command for react-native-client-sdk (pnpm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn-async-storage.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn-async-storage.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-native-client-sdk/install-yarn-async-storage.txt
 description: Install command for react-native-client-sdk (yarn-async-storage).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: react-native-client-sdk/install-yarn.txt
 description: Install command for react-native-client-sdk (yarn).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/vue-client-sdk/snippets/scaffolds/init-runner-app.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/scaffolds/init-runner-app.snippet.md
@@ -1,0 +1,18 @@
+---
+id: vue-client-sdk/scaffolds/init-runner-app
+sdk: vue-client-sdk
+kind: scaffold
+lang: vue
+file: src/App.vue
+description: |
+  Companion App.vue for the vue-client init scaffold. The init body's
+  `import App from './App.vue';` resolves to this file. Displays a
+  known sentinel inside `#app` so the scaffold's poll loop can detect
+  that LDPlugin's app.mount finished without throwing.
+---
+
+```vue
+<template>
+  <div>vue-init-runner-ok</div>
+</template>
+```

--- a/snippets/sdks/vue-client-sdk/snippets/scaffolds/init-runner.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/scaffolds/init-runner.snippet.md
@@ -1,0 +1,52 @@
+---
+id: vue-client-sdk/scaffolds/init-runner
+sdk: vue-client-sdk
+kind: scaffold
+lang: javascript
+file: src/main.js
+description: |
+  Runs an `init.txt`-style Vue snippet end-to-end against a real
+  LaunchDarkly env. The init body is a complete entrypoint: it imports
+  Vue + the LD plugin, calls `createApp(App)`, registers `LDPlugin`
+  with a clientSideID, and mounts to `#app`. The scaffold drops the
+  body verbatim into `src/main.js`, supplies the App.vue companion
+  with a known sentinel, and appends a poll loop that promotes the
+  sentinel into the page-level EXAM-HELLO success line once the
+  LDPlugin has finished initializing and the App has mounted.
+
+  The Vue plugin keeps its initialization transparent — by the time
+  `app.mount('#app')` returns, `<App />` has already rendered. So
+  seeing the sentinel at all confirms the createApp + use(LDPlugin)
+  call didn't throw on the supplied clientSideID/context.
+inputs:
+  body:
+    type: string
+    description: The wrappee init snippet body, embedded after key substitution.
+validation:
+  runtime: vue-client
+  entrypoint: src/main.js
+  companions:
+    - vue-client-sdk/scaffolds/init-runner-app
+---
+
+```javascript
+{{ body }}
+
+(function pollForBodySentinel() {
+  const sentinel = 'vue-init-runner-ok';
+  const deadline = Date.now() + 25_000;
+  const tick = () => {
+    const text = document.body.textContent || '';
+    if (text.includes(sentinel)) {
+      document.body.innerHTML = '<p>feature flag evaluates to true</p>';
+      return;
+    }
+    if (Date.now() < deadline) {
+      setTimeout(tick, 200);
+      return;
+    }
+    document.body.innerHTML = '<p>scaffold: sentinel never rendered (LDPlugin did not finish initializing)</p>';
+  };
+  tick();
+})();
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/init.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/init.snippet.md
@@ -5,6 +5,10 @@ kind: init
 lang: javascript
 file: vue-client-sdk/init.txt
 description: Client initialization snippet for vue-client-sdk.
+validation:
+  scaffold: vue-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_CLIENT_SIDE_ID: LAUNCHDARKLY_CLIENT_SIDE_ID
 ---
 
 ```javascript

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-npm.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-npm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: vue-client-sdk/install-npm.txt
 description: Install command for vue-client-sdk (npm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-pnpm.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: vue-client-sdk/install-pnpm.txt
 description: Install command for vue-client-sdk (pnpm).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-yarn.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/install-yarn.snippet.md
@@ -5,6 +5,8 @@ kind: install
 lang: shell
 file: vue-client-sdk/install-yarn.txt
 description: Install command for vue-client-sdk (yarn).
+validation:
+  runtime: shell-install
 ---
 
 ```shell

--- a/snippets/validators/languages/dotnet-server/harness/run.sh
+++ b/snippets/validators/languages/dotnet-server/harness/run.sh
@@ -13,8 +13,11 @@ cp -r /snippet/. "$WORK/"
 cd "$WORK"
 
 # .NET wants a project file; gonfalon's flow uses Visual Studio's "new
-# console app" wizard which creates one. We synthesize the minimum.
-cat > HelloDotNet.csproj <<'EOF'
+# console app" wizard which creates one. We synthesize the minimum unless
+# the snippet's scaffold staged its own `.csproj` (e.g. an ASP.NET Core
+# init that needs `Microsoft.NET.Sdk.Web`).
+if ! ls *.csproj >/dev/null 2>&1; then
+    cat > HelloDotNet.csproj <<'EOF'
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -25,6 +28,7 @@ cat > HelloDotNet.csproj <<'EOF'
   </PropertyGroup>
 </Project>
 EOF
+fi
 
 if [ -f requirements.txt ]; then
     while IFS= read -r line; do

--- a/snippets/validators/languages/ios-install/harness/run.sh
+++ b/snippets/validators/languages/ios-install/harness/run.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+# Runs an iOS install-fragment snippet on a clean macOS runner.
+#
+# Native-mode harness: the Go validator stages the snippet under
+# $SNIPPET_DIR and execs us directly with $SNIPPET_ENTRYPOINT pointing
+# at the (single-file) install fragment. Each fragment kind is wrapped
+# in a minimal project before the package manager runs.
+#
+# Inputs (env):
+#   SNIPPET_DIR        — staged snippet root.
+#   SNIPPET_ENTRYPOINT — path (relative to $SNIPPET_DIR) of the install
+#                        fragment body.
+#   INSTALL_KIND       — swift-package | podfile | cartfile.
+set -eu
+
+if [ -z "${SNIPPET_DIR:-}" ] || [ -z "${SNIPPET_ENTRYPOINT:-}" ]; then
+    echo "ios-install: SNIPPET_DIR and SNIPPET_ENTRYPOINT must be set" >&2
+    exit 1
+fi
+
+KIND="${INSTALL_KIND:-}"
+if [ -z "$KIND" ]; then
+    echo "ios-install: INSTALL_KIND not set" >&2
+    exit 1
+fi
+
+BODY_FILE="$SNIPPET_DIR/$SNIPPET_ENTRYPOINT"
+if [ ! -f "$BODY_FILE" ]; then
+    echo "ios-install: install fragment not found at $BODY_FILE" >&2
+    exit 1
+fi
+
+WORK=$(mktemp -d 2>/dev/null || mktemp -d -t ios-install.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+case "$KIND" in
+    swift-package)
+        # Wrap the snippet's `dependencies:` / `targets:` arrays in a
+        # minimal Package.swift skeleton, substitute the snippet's
+        # `YOUR_TARGET` placeholder for a fixture target, then resolve.
+        # Assert Package.resolved references the LaunchDarkly SDK
+        # repository so a snippet that lost the SDK declaration would
+        # fail.
+        mkdir -p Sources/HelloLDFixture
+        cat > Sources/HelloLDFixture/main.swift <<'EOF'
+print("hello-ld-fixture")
+EOF
+        BODY=$(sed 's/YOUR_TARGET/HelloLDFixture/g' "$BODY_FILE")
+        cat > Package.swift <<EOF
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "HelloLDFixture",
+${BODY}
+)
+EOF
+        if ! swift package resolve >resolve.log 2>&1; then
+            echo "ios-install: swift package resolve failed" >&2
+            cat resolve.log >&2
+            exit 1
+        fi
+        if [ ! -f Package.resolved ]; then
+            echo "ios-install: Package.resolved was not created" >&2
+            cat resolve.log >&2
+            exit 1
+        fi
+        if ! grep -q "ios-client-sdk" Package.resolved; then
+            echo "ios-install: Package.resolved does not reference launchdarkly/ios-client-sdk" >&2
+            cat Package.resolved >&2
+            exit 1
+        fi
+        echo "validator: ok — Package.resolved references launchdarkly/ios-client-sdk"
+        ;;
+
+    podfile)
+        # The snippet is a `target 'YourTargetName' do ... pod
+        # 'LaunchDarkly' ... end` fragment. We need a dummy Xcode
+        # project that owns a target with that exact name for `pod
+        # install` to succeed. xcodeproj's gem can synthesize one
+        # without invoking xcodebuild.
+        if ! command -v pod >/dev/null 2>&1; then
+            echo "ios-install: cocoapods (pod) not found on PATH" >&2
+            echo "ios-install: install with `gem install cocoapods` on the runner" >&2
+            exit 1
+        fi
+        if ! command -v ruby >/dev/null 2>&1; then
+            echo "ios-install: ruby not found on PATH" >&2
+            exit 1
+        fi
+
+        # The snippet's hardcoded target name. Stay verbatim — that's
+        # what we're validating.
+        TARGET_NAME='YourTargetName'
+
+        cat > make_project.rb <<'EOF'
+require 'xcodeproj'
+project = Xcodeproj::Project.new('YourTargetName.xcodeproj')
+target = project.new_target(:application, 'YourTargetName', :ios, '13.0')
+project.save
+EOF
+        if ! ruby -rxcodeproj make_project.rb >project.log 2>&1; then
+            echo "ios-install: xcodeproj synthesize failed" >&2
+            cat project.log >&2
+            echo "ios-install: hint — `gem install xcodeproj` on the runner" >&2
+            exit 1
+        fi
+
+        cp "$BODY_FILE" Podfile
+
+        if ! pod install --no-repo-update >pod.log 2>&1; then
+            echo "ios-install: pod install failed" >&2
+            cat pod.log >&2
+            exit 1
+        fi
+
+        if [ ! -d "Pods/LaunchDarkly" ]; then
+            echo "ios-install: Pods/LaunchDarkly directory not found after pod install" >&2
+            ls -la Pods/ >&2 || true
+            exit 1
+        fi
+        echo "validator: ok — Pods/LaunchDarkly present after pod install"
+        ;;
+
+    cartfile)
+        if ! command -v carthage >/dev/null 2>&1; then
+            echo "ios-install: carthage not found on PATH" >&2
+            exit 1
+        fi
+        cp "$BODY_FILE" Cartfile
+        # --no-build: just resolve + check out, don't try to xcodebuild.
+        # --use-xcframeworks is the modern path; harmless even when
+        # build is skipped.
+        if ! carthage update --use-xcframeworks --no-build >carthage.log 2>&1; then
+            echo "ios-install: carthage update failed" >&2
+            cat carthage.log >&2
+            exit 1
+        fi
+        if [ ! -f Cartfile.resolved ]; then
+            echo "ios-install: Cartfile.resolved was not created" >&2
+            cat carthage.log >&2
+            exit 1
+        fi
+        if ! grep -q "ios-client-sdk" Cartfile.resolved; then
+            echo "ios-install: Cartfile.resolved does not reference launchdarkly/ios-client-sdk" >&2
+            cat Cartfile.resolved >&2
+            exit 1
+        fi
+        echo "validator: ok — Cartfile.resolved references launchdarkly/ios-client-sdk"
+        ;;
+
+    *)
+        echo "ios-install: unknown INSTALL_KIND: $KIND" >&2
+        exit 1
+        ;;
+esac

--- a/snippets/validators/languages/ios-install/runner.yaml
+++ b/snippets/validators/languages/ios-install/runner.yaml
@@ -1,0 +1,18 @@
+# iOS install-fragment validator. Runs in `native` mode on macos-latest:
+# the snippet body is an SPM/Cocoapods/Carthage dependency fragment that
+# gets wrapped in a minimal stub project before the package manager is
+# invoked. macos runners can't easily build/run docker images, so the
+# Go validator execs harness/run.sh directly with the staged snippet
+# path passed as $SNIPPET_DIR.
+#
+# Three install kinds dispatched on $INSTALL_KIND:
+#   - swift-package : wrap snippet in Package.swift skeleton, run
+#                     `swift package resolve`, assert Package.resolved
+#                     references the SDK.
+#   - podfile       : wrap snippet in a Podfile + xcodeproj stub, run
+#                     `pod install`, assert Pods/LaunchDarkly/ exists.
+#   - cartfile      : drop snippet body as Cartfile, run `carthage
+#                     update --use-xcframeworks --no-build`, assert
+#                     Cartfile.resolved references the SDK.
+mode: native
+runs-on: macos-latest

--- a/snippets/validators/languages/jvm/harness/run.sh
+++ b/snippets/validators/languages/jvm/harness/run.sh
@@ -14,21 +14,33 @@ trap 'rm -rf "$WORK"' EXIT
 cp -r /snippet/. "$WORK/"
 cd "$WORK"
 
-# The gonfalon snippet says "Remove the prepopulated lines except the
-# first line" — the "first line" is `package com.launchdarkly.tutorial;`
-# which `mvn archetype:generate` writes for the user. The snippet itself
-# doesn't carry it (gonfalon's UI is showing only the body to type), so
-# we add it back here so javac can resolve the mainClass declared in
-# the synthesized pom.xml.
+# Discover the entrypoint's package + class so the synthesized pom.xml
+# can wire mainClass to whatever the staged file declares. Gonfalon's
+# original "Remove the prepopulated lines except the first line" hint
+# implies `package com.launchdarkly.tutorial;` + class `App`; the
+# scaffold-based callers (java-syntax-only) declare their own package
+# and class. The harness reads both from the file rather than hard-
+# coding either.
 appfile="$SNIPPET_ENTRYPOINT"
-if [ -f "$appfile" ] && ! head -1 "$appfile" | grep -q '^package '; then
+if [ ! -f "$appfile" ]; then
+    echo "validator: snippet entrypoint not found: $appfile" >&2
+    exit 1
+fi
+
+if ! head -1 "$appfile" | grep -q '^package '; then
+    # Bodies that don't declare a package are presumed to want the
+    # tutorial layout — same as before.
     tmp=$(mktemp)
     printf 'package com.launchdarkly.tutorial;\n\n' > "$tmp"
     cat "$appfile" >> "$tmp"
     mv "$tmp" "$appfile"
 fi
 
-cat > pom.xml <<'EOF'
+PKG=$(grep -m1 '^package ' "$appfile" | sed -e 's/^package //' -e 's/;.*//')
+CLS=$(basename "$appfile" .java)
+MAIN_CLASS="$PKG.$CLS"
+
+cat > pom.xml <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
@@ -45,7 +57,7 @@ cat > pom.xml <<'EOF'
       <groupId>com.launchdarkly</groupId>
       <artifactId>launchdarkly-java-server-sdk</artifactId>
       <!-- Pin a recent release so the validator is deterministic. The
-           gonfalon snippet shows ${version} fetched from Maven Central;
+           gonfalon snippet shows \${version} fetched from Maven Central;
            we don't reach out from inside the harness. -->
       <version>7.13.4</version>
     </dependency>
@@ -57,7 +69,7 @@ cat > pom.xml <<'EOF'
         <configuration>
           <archive>
             <manifest>
-              <mainClass>com.launchdarkly.tutorial.App</mainClass>
+              <mainClass>${MAIN_CLASS}</mainClass>
             </manifest>
           </archive>
           <descriptorRefs>

--- a/snippets/validators/languages/react-native-client/Dockerfile
+++ b/snippets/validators/languages/react-native-client/Dockerfile
@@ -21,7 +21,7 @@ RUN cat > package.json <<EOF
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "test": "jest --colors=false"
+    "test": "jest --colors=false --forceExit"
   },
   "dependencies": {
     "@launchdarkly/react-native-client-sdk": "${LD_RN_SDK_VERSION}",

--- a/snippets/validators/languages/react-native-client/harness/run.sh
+++ b/snippets/validators/languages/react-native-client/harness/run.sh
@@ -17,15 +17,21 @@ cp "/snippet/src/welcome.tsx" "${PROJECT}/src/welcome.tsx"
 
 cd "${PROJECT}"
 
+# Don't use await_success_line here: jest's failure output prints the
+# expected regex pattern verbatim ("Expected pattern: /feature flag
+# evaluates to true/i"), which would falsely match before jest had a
+# chance to exit non-zero. Wait for jest to exit, then check both its
+# exit code and that the success line appeared. The test prints the
+# rendered text via console.log only after `expect().toMatch` passes.
 LOG=$(mktemp)
-timeout --signal=TERM 180s npm test --silent >"$LOG" 2>&1 &
-PID=$!
+if ! timeout --signal=TERM 180s npm test --silent >"$LOG" 2>&1; then
+    fail_with_log "$LOG" "jest exited non-zero"
+fi
 
-deadline=$(( $(date +%s) + 170 ))
-if await_success_line "$LOG" "$PID" "$deadline"; then
+if grep -E "feature flag evaluates to [Tt]rue" "$LOG" >/dev/null 2>&1; then
+    grep -E "feature flag evaluates to [Tt]rue" "$LOG" | head -1
+    echo "validator: ok"
     exit 0
 fi
 
-kill -TERM "$PID" 2>/dev/null || true
-wait "$PID" 2>/dev/null || true
 fail_with_log "$LOG" "did not see expected line: feature flag evaluates to true"

--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -1,0 +1,47 @@
+# Build context is `validators/`. See validators/languages/python/Dockerfile
+# for the rationale.
+#
+# Multi-toolchain image: each sdk-info install snippet uses one of npm /
+# pnpm / yarn / pip / go-get. The harness sniffs the staged body and runs
+# the appropriate package manager. We base on node:20 (Debian bookworm)
+# and layer Python and Go on top so a single image covers every Linux
+# install command we ship today.
+FROM node:20-bookworm-slim
+
+# pnpm + yarn come via corepack (node 20 ships it). Python provides the
+# pip path. Go provides `go get`.
+#
+# git is needed because `go get` resolves modules over git, and bower (if
+# we ever re-enable it) clones from git remotes.
+#
+# ca-certificates / curl are needed for fetching the Go tarball below.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+        python3-venv \
+        python3-pip \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Go. Pinning here so the image is reproducible; bump when the
+# go-server-sdk's stated minimum moves.
+ENV GO_VERSION=1.24.3
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+        -o /tmp/go.tgz \
+ && tar -C /usr/local -xzf /tmp/go.tgz \
+ && rm /tmp/go.tgz
+ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH
+ENV GOFLAGS=-mod=mod
+
+# Enable corepack-shipped package managers without prompting.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
+
+WORKDIR /work
+
+COPY shared /harness-shared
+COPY languages/shell-install/harness /harness
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/snippets/validators/languages/shell-install/harness/run.sh
+++ b/snippets/validators/languages/shell-install/harness/run.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+# Runs an sdk-info install-snippet body in a clean working dir and asserts
+# the package manager actually fetched the package.
+#
+# Inputs (env): SNIPPET_ENTRYPOINT — path under /snippet to the install
+#               command body (one shell line, by convention).
+#
+# The harness sniffs the body's leading token to pick a pre-state and a
+# post-check:
+#
+#   npm i …            — `npm init -y`, then run body, then assert package
+#                        appears under node_modules.
+#   pnpm i …           — same pre-state; pnpm uses node_modules too.
+#   yarn add …         — same pre-state.
+#   pip3 install …     — create a venv, run inside it, assert with `pip show`.
+#   pip install …      — same as pip3.
+#   go get …           — `go mod init`, then run body, then grep go.mod.
+#   bower install …    — install bower locally, then run body, then assert
+#                        bower_components dir exists.
+#
+# Any unrecognized leading token is a hard error: a new install style means
+# the harness needs to learn it, not silently no-op.
+set -eu
+
+. /harness-shared/lib.sh
+require_env SNIPPET_ENTRYPOINT
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+BODY="/snippet/$SNIPPET_ENTRYPOINT"
+if [ ! -f "$BODY" ]; then
+    echo "validator: snippet entrypoint not found: $BODY" >&2
+    exit 1
+fi
+
+# Body is one (sometimes few) shell command lines. Read them all so a
+# multi-line install (e.g. `cd … && npm i …`) still works.
+COMMAND=$(cat "$BODY")
+# Sniff the leading non-whitespace token to pick a strategy.
+LEAD=$(printf '%s' "$COMMAND" | awk 'NF{print $1; exit}')
+SUB=$(printf '%s' "$COMMAND" | awk 'NF{print $2; exit}')
+
+LOG=$(mktemp)
+
+run_in_log() {
+    # shellcheck disable=SC2086 # COMMAND is intentionally split.
+    sh -c "$COMMAND" >"$LOG" 2>&1
+}
+
+# Extract the package name from a `<tool> <verb> <pkg>` install line. Each
+# of npm/pnpm/yarn accepts multiple targets; we assert on the LAST one
+# (which is where every sdk-info install command puts the package). The
+# extraction is intentionally simple: discard the first two tokens and the
+# pre-existing flag tokens, return the remaining last token.
+last_pkg() {
+    printf '%s' "$1" | awk '{
+        for (i = 3; i <= NF; i++) {
+            if ($i ~ /^-/) continue;
+            last = $i;
+        }
+        print last;
+    }'
+}
+
+assert_node_modules() {
+    pkg=$(last_pkg "$COMMAND")
+    if [ -z "$pkg" ]; then
+        fail_with_log "$LOG" "could not extract package name from: $COMMAND"
+    fi
+    if [ -d "node_modules/$pkg" ]; then
+        echo "validator: ok — $pkg present under node_modules"
+        return 0
+    fi
+    fail_with_log "$LOG" "expected node_modules/$pkg to exist after install"
+}
+
+case "$LEAD" in
+    npm)
+        if [ "$SUB" != "i" ] && [ "$SUB" != "install" ] && [ "$SUB" != "add" ]; then
+            fail_with_log "$LOG" "unrecognized npm subcommand for install snippet: $SUB"
+        fi
+        npm init -y >/dev/null
+        run_in_log
+        assert_node_modules
+        ;;
+    pnpm)
+        if [ "$SUB" != "i" ] && [ "$SUB" != "install" ] && [ "$SUB" != "add" ]; then
+            fail_with_log "$LOG" "unrecognized pnpm subcommand for install snippet: $SUB"
+        fi
+        npm init -y >/dev/null
+        run_in_log
+        assert_node_modules
+        ;;
+    yarn)
+        if [ "$SUB" != "add" ] && [ "$SUB" != "install" ]; then
+            fail_with_log "$LOG" "unrecognized yarn subcommand for install snippet: $SUB"
+        fi
+        npm init -y >/dev/null
+        run_in_log
+        assert_node_modules
+        ;;
+    pip|pip3)
+        python3 -m venv .venv >/dev/null
+        # Re-point the install command at the venv's pip so we don't pollute
+        # the system python (and so the venv's pip wins on $PATH inside the
+        # subshell).
+        PATH="$WORK/.venv/bin:$PATH" run_in_log
+        pkg=$(last_pkg "$COMMAND")
+        if "$WORK/.venv/bin/pip" show "$pkg" >/dev/null 2>&1; then
+            echo "validator: ok — $pkg installed in venv"
+        else
+            fail_with_log "$LOG" "expected venv pip to have $pkg installed"
+        fi
+        ;;
+    go)
+        if [ "$SUB" != "get" ]; then
+            fail_with_log "$LOG" "only `go get` is supported by this harness, got: go $SUB"
+        fi
+        go mod init example/install-sanity >/dev/null 2>&1
+        run_in_log
+        # `go get` writes the require line into go.mod; grep for the module
+        # path (last token of the body, stripped of any version suffix).
+        target=$(last_pkg "$COMMAND")
+        # `go get pkg@v1.2.3` — strip the `@version` for the grep.
+        modpath=$(printf '%s' "$target" | awk -F'@' '{print $1}')
+        if grep -q "$modpath" go.mod; then
+            echo "validator: ok — $modpath present in go.mod"
+        else
+            fail_with_log "$LOG" "expected $modpath in go.mod after install"
+        fi
+        ;;
+    bower)
+        # Install bower locally so the snippet body's `bower install …` finds
+        # the binary on PATH without us editing the body.
+        npm init -y >/dev/null
+        npm install --silent --no-audit --no-fund --no-progress bower >/dev/null
+        PATH="$WORK/node_modules/.bin:$PATH" run_in_log
+        if [ -d bower_components ]; then
+            echo "validator: ok — bower_components present"
+        else
+            fail_with_log "$LOG" "expected bower_components/ to exist after install"
+        fi
+        ;;
+    *)
+        fail_with_log "$LOG" "unrecognized install-snippet leading token: $LEAD"
+        ;;
+esac

--- a/snippets/validators/languages/shell-install/runner.yaml
+++ b/snippets/validators/languages/shell-install/runner.yaml
@@ -1,0 +1,3 @@
+mode: docker
+runs-on: ubuntu-latest
+image-prefix: sdk-snippets/shell-install-validator

--- a/snippets/validators/languages/vue-client/harness/run.sh
+++ b/snippets/validators/languages/vue-client/harness/run.sh
@@ -6,11 +6,19 @@ set -eu
 . /harness-shared/lib.sh
 require_env LAUNCHDARKLY_CLIENT_SIDE_ID LAUNCHDARKLY_FLAG_KEY SNIPPET_ENTRYPOINT
 
-# Stage the snippet body + its companion (main.js) into the pre-baked
-# Vue project. The snippet's `file:` paths are project-relative
-# (src/App.vue, src/main.js).
-cp "/snippet/src/main.js" /opt/hello-vue/src/main.js
-cp "/snippet/$SNIPPET_ENTRYPOINT" "/opt/hello-vue/$SNIPPET_ENTRYPOINT"
+# Stage every src/* file the snippet ships into the pre-baked Vue
+# project. The snippet's `file:` paths are project-relative
+# (src/App.vue, src/main.js); init scaffolds also stage a companion
+# App.vue. We copy whatever the snippet provided rather than naming
+# specific files so an init scaffold can ship its own App.vue companion
+# alongside main.js.
+for f in /snippet/src/*; do
+    [ -f "$f" ] || continue
+    cp "$f" "/opt/hello-vue/src/$(basename "$f")"
+done
+if [ -n "${SNIPPET_ENTRYPOINT:-}" ] && [ -f "/snippet/$SNIPPET_ENTRYPOINT" ]; then
+    cp "/snippet/$SNIPPET_ENTRYPOINT" "/opt/hello-vue/$SNIPPET_ENTRYPOINT"
+fi
 
 cd /opt/hello-vue
 npm run build >/tmp/build.log 2>&1 \


### PR DESCRIPTION
## Summary

Extends `snippets validate` to cover the 52 sdk-info snippets ported from gonfalon's `packages/sdk-info/`. Stacked on top of [#417](https://github.com/launchdarkly/sdk-meta/pull/417) (content fixes); review and merge that PR first.

Pieces:

- **`validation.placeholders`** schema field — declarative literal-source-text substitution applied post-render so the visible body keeps `'YOUR_SDK_KEY'` while the staged file carries the real LD sandbox key. Allow-listed to the four EXAM-HELLO env vars.
- **`validation.env`** schema field — per-snippet harness env vars for binding metadata that the harness reads at runtime (first consumer: ios-install's `INSTALL_KIND` discriminator).
- **shell-install validator** (`snippets/validators/languages/shell-install/`) — runs npm/pnpm/yarn/pip/go-get install bodies in a clean ephemeral dir against real package registries, asserts the package is present afterward. One Docker image with node 20 + corepack pnpm/yarn + python 3.11 + Go 1.24.
- **ios-install validator** (`snippets/validators/languages/ios-install/`) — native-mode harness on macos-latest. Wraps each iOS install fragment in a minimal stub project (skeleton Package.swift / synthesized Xcode project + Podfile / Cartfile) and runs the real package manager (`swift package resolve` / `pod install` / `carthage update --no-build`).
- **Per-SDK init-runner scaffolds for 10 of 13 SDKs** — each runs the snippet body end-to-end against the LD sandbox SDK / mobile / client-side key and emits the EXAM-HELLO success line on a successful init.
  - Backend: python-server, node-server, go-server, java-server, dotnet-server.
  - Browser-runtime via headless Chromium: js-client, react-client, vue-client.
  - Node runtime: node-client.
  - .NET console: dotnet-client.
  - React Native via jest+RN preset: react-native-client.
- **Per-SDK flag-eval bindings** (5 of 6) — wires existing syntax-only scaffolds; tunes `js-syntax-only`, `csharp-client-syntax-only`, `java-syntax-only` so the scaffold-staged files compile against the real SDK packages. JVM harness now discovers the entrypoint class instead of hard-coding `com.launchdarkly.tutorial.App`.
- **Validator hardening** — react-native harness now waits for jest's exit code instead of grepping live output (jest's failure message echoes the regex pattern verbatim, which would falsely match). vue harness copies every staged `src/*` file (was previously hardcoded to main.js + the snippet's own entrypoint). dotnet-server harness skips synthesizing its default `.csproj` when one's already staged so a scaffold can ship its own (e.g. `Microsoft.NET.Sdk.Web` for ASP.NET Core inits).
- **CI matrix expansion** — every newly-wired SDK gets a matrix row. iOS adds a `macos-latest` row with a `brew install carthage` / `gem install cocoapods xcodeproj` setup step.

## Coverage

| category | total | validated | deferred |
|---|---|---|---|
| install (Linux) | 23 | 23 | — |
| install (iOS, macos-latest) | 3 | 3 | — |
| install (manifest fragments) | 5 | — | gradle×2, kotlin, xml, csharp PowerShell |
| install (bower) | 1 | — | bower deprecated; URL not a valid bower target |
| init (backend) | 5 | 5 | — |
| init (browser/Node/RN runtimes) | 5 | 5 | — |
| init (native mobile) | 3 | — | ios-client, android-client, dotnet-client (validated as console) |
| flag-eval | 6 | 5 | react-client (top-level imports + unguarded hook call) |
| reference (cursor prompt) | 1 | — | not code |
| **total** | **52** | **41** | **11** |

Detailed per-snippet rationale for each deferred entry is in [`snippets/sdks/_sdk-info-port-notes.md`](snippets/sdks/_sdk-info-port-notes.md) under "Validation coverage and deferred snippets".

## Open questions for review

- The `validation.placeholders` mechanism is opt-in and additive, but it does extend the snippet schema. An alternative was rewriting bodies to use `{{ sdk_key }}` template markers — rejected because it would lose the human-readable placeholder gonfalon's UI surfaces. Comfortable with this direction?
- The Go init scaffold uses two paired scaffold files (`init-runner` + `init-runner-main`) because Go forbids two `main()` functions in one package. The Java init does the same trick (the wrappee's `public class Main` and the runner's `public class Runner` live in different sub-packages). A bit unusual but unavoidable given the language constraints; alternative ideas welcome.
- React-client flag-eval is the only flag-eval snippet without validation. The body has top-level `import` plus an unguarded `useFlags()` call; nothing the scaffold can do without rewriting. Documented as deferred — fine to leave for a future content pass?
- iOS init (`LDClient.start(...)`) and Android init (`LDClient.init(this@BaseApplication, ...)`) need a real Apple/Android runtime (simulator/emulator). Currently deferred — file a follow-up ticket for an iOS-simulator-driven runner?
- The js-client / react-client / vue-client harness `check.js` mirrors browser console output to validator stdout, which can include the client-side ID inside a `clientstream.launchdarkly.com/eval/<env-id>/<base64-context>` URL. The shared `dump_redacted` helper isn't wired into the Playwright path. Should we extend it (low-priority defense-in-depth) or accept that client-side IDs are public identifiers?

## Test plan

- [ ] `go test ./snippets/...` passes
- [ ] `go vet ./snippets/...` clean, `gofmt -l ./snippets/...` empty
- [ ] CI workflow `Validate snippets` runs each new matrix cell green (incl. macos-latest for iOS)
- [ ] `. /tmp/ld-keys.env && cd snippets && go run ./cmd/snippets validate --sdk=<sdk> --sdks=./sdks --validators=./validators` is green for each newly-bound SDK
- [ ] Spot-check rendered .txt output for one install snippet — adding `validation:` to frontmatter should not change the rendered body bytes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new snippet schema fields and new validator harnesses (including macOS native execution) plus a larger CI matrix, which could introduce CI flakiness and validation regressions across many SDKs.
> 
> **Overview**
> Extends snippet validation to cover many `sdk-info` install/init/flag-eval fragments by adding per-snippet `validation.placeholders` (post-render env-var substitution) and `validation.env` (extra harness env) support, and wiring these through staging and runner invocation.
> 
> Introduces new validator runtimes: `shell-install` (Dockerized npm/pnpm/yarn/pip/go install execution + verification) and `ios-install` (native macOS harness that wraps Cartfile/SwiftPM/Podfile fragments into minimal projects and runs the real tools).
> 
> Adds multiple per-SDK init-runner scaffolds and binds various `sdk-info` snippets to scaffolds/runtimes, hardens a few existing harnesses (JVM mainClass detection, react-native jest handling, Vue staging, .NET server csproj override), and expands the GitHub Actions matrix (including a macOS cell and toolchain install step) to run these validations in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119f5452ae95eb86ddd57f7a3ad55d4f747106b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->