### PR TITLE
feat(snippets): wire validation for sdk-docs slice across 24 SDKs

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -89,21 +89,34 @@ jobs:
           # carthage` in the harness setup step, since macos-latest
           # doesn't ship it preinstalled.
           #
-          # The install row excludes the init snippet (snippet-skip) so
-          # verify-hello-app's EXAM-HELLO grep doesn't see install
-          # output. The init runs in its own row below with key-type:
-          # mobile, where xcodebuild test boots the iOS Simulator and
-          # runs LDClient.start(...) end-to-end against the LD env.
+          # iOS validation is split across three rows so each row
+          # can carry the correct credentials and toolchain
+          # configuration:
+          #
+          #   - install: just the sdk-info install fragments (no LD
+          #     keys; native package-manager runs)
+          #   - init: the sdk-info/init snippet (mobile key,
+          #     xcodebuild test boots the simulator and runs
+          #     LDClient.start end-to-end)
+          #   - sdk-docs: the swift-syntax-only-bound reference
+          #     fragments (no LD keys; xcodebuild type-checks the
+          #     never-instantiated wrappee)
           - sdk: ios-client-sdk
             runs-on: macos-latest
             key-type: none
             label: ios-client-sdk (install)
+            group: sdk-info
             snippet_skip: ios-client-sdk/sdk-info/init
           - sdk: ios-client-sdk
             runs-on: macos-latest
             key-type: mobile
             label: ios-client-sdk (init)
             snippet: ios-client-sdk/sdk-info/init
+          - sdk: ios-client-sdk
+            runs-on: macos-latest
+            key-type: none
+            label: ios-client-sdk (sdk-docs)
+            group: sdk-docs
 
           # Android init: scaffolded with a MainApplication that
           # exercises LDClient.init(this@MainApplication, ...) under
@@ -180,6 +193,7 @@ jobs:
           MATRIX_SDK: ${{ matrix.sdk }}
           MATRIX_SNIPPET: ${{ matrix.snippet }}
           MATRIX_SNIPPET_SKIP: ${{ matrix.snippet_skip }}
+          MATRIX_GROUP: ${{ matrix.group }}
         with:
           use_server_key: ${{ matrix.key-type == 'server' }}
           use_client_key: ${{ matrix.key-type == 'client' }}
@@ -191,6 +205,7 @@ jobs:
             args="--sdk=$MATRIX_SDK"
             [ -n "$MATRIX_SNIPPET" ] && args="$args --snippet=$MATRIX_SNIPPET"
             [ -n "$MATRIX_SNIPPET_SKIP" ] && args="$args --snippet-skip=$MATRIX_SNIPPET_SKIP"
+            [ -n "$MATRIX_GROUP" ] && args="$args --group=$MATRIX_GROUP"
             go run ./cmd/snippets validate $args \
               --sdks=./sdks --validators=./validators 2>&1 | tee /tmp/validate.log
 
@@ -201,12 +216,14 @@ jobs:
           MATRIX_SDK: ${{ matrix.sdk }}
           MATRIX_SNIPPET: ${{ matrix.snippet }}
           MATRIX_SNIPPET_SKIP: ${{ matrix.snippet_skip }}
+          MATRIX_GROUP: ${{ matrix.group }}
         run: |
           set -o pipefail
           cd snippets
           args="--sdk=$MATRIX_SDK"
           [ -n "$MATRIX_SNIPPET" ] && args="$args --snippet=$MATRIX_SNIPPET"
           [ -n "$MATRIX_SNIPPET_SKIP" ] && args="$args --snippet-skip=$MATRIX_SNIPPET_SKIP"
+          [ -n "$MATRIX_GROUP" ] && args="$args --group=$MATRIX_GROUP"
           go run ./cmd/snippets validate $args \
             --sdks=./sdks --validators=./validators 2>&1 | tee /tmp/validate.log
 

--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -116,6 +116,23 @@ jobs:
             key-type: mobile
             label: android-client-sdk (init)
             snippet: android-client-sdk/sdk-info/init
+
+          # SDKs whose sdk-docs slice picked up bound syntax-only
+          # validators in the docs-validation pass (PR
+          # rlamb/sdk-docs-validation). Each matrix row builds the
+          # per-SDK Docker image (or, for ios-install, runs the
+          # native macos toolchain) and validates every bound
+          # sdk-docs snippet end-to-end. The harness consumes a
+          # server SDK key for these; the syntax-only scaffolds
+          # never reach the LD env (the wrappee body is
+          # never-instantiated / never-called), but the harness
+          # uniformly requires the env var.
+          - { sdk: cpp-client-sdk,    runs-on: ubuntu-latest, key-type: mobile }
+          - { sdk: cpp-server-sdk,    runs-on: ubuntu-latest, key-type: server }
+          - { sdk: electron-client-sdk, runs-on: ubuntu-latest, key-type: client }
+          - { sdk: flutter-client-sdk,  runs-on: ubuntu-latest, key-type: client }
+          - { sdk: haskell-server-sdk,  runs-on: ubuntu-latest, key-type: server }
+          - { sdk: rust-server-sdk,     runs-on: ubuntu-latest, key-type: server }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -114,7 +114,7 @@ jobs:
             snippet: ios-client-sdk/sdk-info/init
           - sdk: ios-client-sdk
             runs-on: macos-latest
-            key-type: none
+            key-type: mobile
             label: ios-client-sdk (sdk-docs)
             group: sdk-docs
 

--- a/snippets/cmd/snippets/main.go
+++ b/snippets/cmd/snippets/main.go
@@ -61,13 +61,16 @@ usage:
       a marker's hash does not match its current region's content. Never
       writes; never executes any snippet code.
 
-  snippets validate --sdk=<sdk-id> [--snippet=<id>] [--sdks=./sdks] [--validators=./validators]
+  snippets validate --sdk=<sdk-id> [--snippet=<id>] [--snippet-skip=<id>]
+                    [--group=<sdk-info|sdk-docs>] [--sdks=./sdks] [--validators=./validators]
       Builds the SDK's per-language validator (Docker image or native harness),
       stages each runnable snippet with concrete input values, and runs it
       against a real LaunchDarkly environment. Exercises the snippet code end
       to end; requires LAUNCHDARKLY_SDK_KEY (or _MOBILE_KEY / _CLIENT_SIDE_ID)
       and LAUNCHDARKLY_FLAG_KEY in the env. Pass --snippet=<id> to validate
-      a single snippet (useful while developing scaffolds).
+      a single snippet (useful while developing scaffolds). --group filters
+      to one snippet group (the middle segment of the snippet id), which is
+      how CI splits one SDK across multiple matrix rows.
 
   snippets version
       Print the snippets generator version.
@@ -195,6 +198,7 @@ func runValidate(args []string) {
 	sdk := fset.String("sdk", "", "sdk id to validate (required)")
 	snippet := fset.String("snippet", "", "snippet id to validate (optional; restricts to one snippet)")
 	snippetSkip := fset.String("snippet-skip", "", "snippet id to skip (optional; useful for splitting one SDK across CI rows)")
+	group := fset.String("group", "", "snippet group to validate (optional; e.g. `sdk-info` or `sdk-docs`)")
 	sdks := fset.String("sdks", "", "path to a sdks/ directory (default: embedded)")
 	validators := fset.String("validators", "./validators", "path to the validators/ directory")
 	_ = fset.Parse(args)
@@ -209,6 +213,7 @@ func runValidate(args []string) {
 		SDK:           *sdk,
 		Snippet:       *snippet,
 		SnippetSkip:   *snippetSkip,
+		Group:         *group,
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "validate failed: %v\n", err)
 		os.Exit(1)

--- a/snippets/internal/validate/validate.go
+++ b/snippets/internal/validate/validate.go
@@ -23,6 +23,7 @@ type Config struct {
 	SDK           string // sdk id to validate (empty = all)
 	Snippet       string // snippet id to validate (empty = all in the SDK)
 	SnippetSkip   string // snippet id to skip (empty = none)
+	Group         string // snippet group to validate (empty = all; e.g. "sdk-info" or "sdk-docs")
 }
 
 // envInputs holds the environment-derived input values that get substituted
@@ -70,6 +71,15 @@ func Run(cfg Config) error {
 		}
 		if cfg.SnippetSkip != "" && s.Frontmatter.ID == cfg.SnippetSkip {
 			continue
+		}
+		if cfg.Group != "" {
+			// Snippet IDs are <sdk>/<group>/<name>; filter on the
+			// middle segment so a CI row can validate just one group
+			// (e.g. sdk-info installs vs sdk-docs reference fragments).
+			parts := strings.Split(s.Frontmatter.ID, "/")
+			if len(parts) < 2 || parts[1] != cfg.Group {
+				continue
+			}
 		}
 		if !isValidatable(s) {
 			continue

--- a/snippets/sdks/_sdk-docs-port-notes.md
+++ b/snippets/sdks/_sdk-docs-port-notes.md
@@ -1,0 +1,281 @@
+# sdk-docs port notes
+
+Snippets ported from ld-docs MDX into `snippets/sdks/<sdk>/snippets/sdk-docs/`
+that the validator harness can't currently exercise are documented here.
+Each entry describes the structural reason the snippet has no
+`validation:` block and what would need to change for it to become
+bindable.
+
+This file is the sdk-docs analogue of `_sdk-info-port-notes.md`. The
+sdk-info port had a small handful of structurally unbindable cases; the
+sdk-docs slice has many more because the source MDX often shows
+fragments that aren't standalone-executable (env-var exports for shell,
+deprecated-version API surfaces no longer in the registry, etc.).
+
+## Shell snippets that aren't a package-manager install
+
+**Severity**: low (informational fragments)
+
+**Snippets affected**: every per-SDK `proxy-env-mac`, `proxy-env-windows`,
+and similar shell fragments under `sdk-docs/` that just `export VAR=…`
+or `set VAR=…` rather than running a package manager.
+
+**Why unbindable**: the `shell-install` validator is a package-manager
+sniff (npm/pnpm/yarn/pip/go/bower) followed by an artifact assertion
+(node_modules, go.mod, etc.). A bare `export HTTPS_PROXY=…` doesn't fit
+that contract — there's nothing to assert post-run, and routing to a
+generic "run this in /bin/sh and check exit 0" runner would silently
+green-light malformed bodies. These snippets are byte-equality-verified
+through marker hashes already, which is the strongest check available
+for a fragment that doesn't have a runtime success-line.
+
+## Multi-line `pip install` snippets
+
+**Severity**: low
+
+**Snippets affected**: `python-server-sdk/sdk-docs/install` (installs
+both the SDK and the optional observability plugin in one block).
+
+**Why unbindable**: the `shell-install` harness's `last_pkg` extractor
+runs awk per-line and prints the last token of every non-empty line, so
+a body with two `pip install` commands produces a multi-line `$pkg`
+that breaks the post-install `pip show $pkg` assertion. The single-line
+`sdk-info/install-pip.snippet.md` covers the SDK install, so the docs
+fragment doesn't add validatable surface that isn't already covered.
+
+## .NET client SDK v3.x fragments
+
+**Severity**: low (older API surface)
+
+**Snippets affected**:
+`dotnet-client-sdk/sdk-docs/initialize-the-client-net-sdk-v3-0-c`,
+`dotnet-client-sdk/sdk-docs/initialize-the-client-net-sdk-v3-x-c`,
+`dotnet-client-sdk/sdk-docs/using-the-relay-proxy-c`.
+
+**Why unbindable**: these reference v3-shape `LdClient.Init(string,
+Context, TimeSpan)` and the old `Configuration.Builder(...)
+.ServiceEndpoints(...)` chain that changed in v4 (the
+`AutoEnvAttributes` parameter is now mandatory). The scaffold pulls
+the latest LaunchDarkly.ClientSdk, so these v3 overloads no longer
+exist on the type. Pinning v3 in a parallel csproj would let them
+build, but would diverge from the canonical "what should I install"
+direction the rest of the bindings reflect.
+
+## C++ SDK v2.x fragments (cpp-client, cpp-server)
+
+**Severity**: medium (fragments still byte-checked, but no compile)
+
+**Snippets affected**: every `*-c-sdk-v2-x-*` snippet under
+`cpp-client-sdk/sdk-docs/` and `cpp-server-sdk/sdk-docs/`. v2.x used a
+C-style API (`LDClientCPP`, `LDClientInit`, `LDConfigNew`,
+`LDUserNew`, `<launchdarkly/api.h>`) that the cpp-sdks v3 build does
+not ship — even the headers were renamed under
+`launchdarkly/client_side/`. The validator Dockerfile pins
+`cpp-sdks v3.x` (matching the current docs guidance), so embedding a
+v2.x identifier in any function body fails compilation regardless of
+whether the function is invoked.
+
+**Why unbindable**: the cpp-sdks repo no longer ships a v2.x branch in
+the Dockerfile-pinned form, and re-pinning v2 in addition would either
+require a parallel Docker image or a meaningful refactor of the
+existing image. The fragments remain byte-equality-verified through
+the marker hash machinery; the v3 fragments under the same folder are
+fully bound to the cpp-syntax-only scaffold.
+
+## Apex SDK fragments
+
+**Severity**: low (no validator infrastructure)
+
+**Snippets affected**: every snippet under `apex-server-sdk/sdk-docs/`.
+
+**Why unbindable**: there is no Apex/Salesforce validator container —
+PR #414's port notes (sdk-info) already documented this gap for the
+install/init path. Apex requires the Salesforce CLI and a scratch org
+to compile, neither of which fits the existing Docker-based validator
+mold. The same applies to the sdk-docs slice; there is no parse-only
+fallback because no container ships an Apex parser.
+
+## Roku SDK fragments
+
+**Severity**: low (no validator infrastructure)
+
+**Snippets affected**: every snippet under `roku-client-sdk/sdk-docs/`.
+
+**Why unbindable**: there is no Roku BrightScript validator. The roku
+syntax-only scaffold exists as a stub (PR #418) but no Docker image
+ships a BrightScript parser. Same disposition as Apex above; the
+fragments are byte-checked via marker hashes.
+
+## ASP.NET / Global.asax C# fragments (.NET server SDK)
+
+**Severity**: low (init pattern; not the canonical hello-world flow)
+
+**Snippets affected**:
+`dotnet-server-sdk/sdk-docs/initialize-the-client-initialize-net-sdk-v8-10-with-asp-net-core-p1`,
+`…-p2`.
+
+**Why unbindable**: both fragments paste into specific .NET hosting
+contexts (top-level `Program.cs` with implicit `args` for ASP.NET
+Core, or `Global.asax.cs`'s class body for ASP.NET Framework) where
+the surrounding scaffold provides the context the body relies on.
+The `csharp-syntax-only` scaffold wraps the wrappee in a method body,
+so `args` is out of scope (it's a parameter of the implicit
+top-level `Main`) and `protected` method definitions can't nest
+inside another method. A correct binding would need either two new
+ASP.NET Core / ASP.NET Framework scaffolds that supply the right
+shape, or a runtime that compiles the body into the correct
+hosting context.
+
+## "Pick one of these" multi-style import fragments
+
+**Severity**: low (each individual import style is correct in isolation)
+
+**Snippets affected**:
+`js-client-sdk/sdk-docs/install-the-sdk-javascript-and-typescript-js-sdk-v3-7`,
+`js-client-sdk/sdk-docs/install-the-sdk-javascript-and-typescript-js-sdk-v4-x`.
+
+**Why unbindable**: the body shows three parallel ways to import
+`LDClient` (CommonJS `require`, ES module `import`, and a TS import)
+in the same code block. They're meant to be alternatives, not
+co-existing imports — but the validator sees one file with three
+declarations of the same identifier and rejects the redeclaration.
+Splitting the snippet into three separately-bindable variants would
+diverge from the source-MDX fingerprint; the right fix lives in
+ld-docs (`{/* prettier-ignore */}` comments aren't enough; the docs
+should show one canonical example).
+
+## HTML `<script src="…">` fragments
+
+**Severity**: low (declarative; not executable JS)
+
+**Snippets affected**: every `*-html` snippet under
+`js-client-sdk/sdk-docs/`, plus the `make-the-sdk-available-with-a-script-tag-…`
+pair.
+
+**Why unbindable**: these are HTML script tags — declarative loaders
+for an external bundle, not JavaScript. The js-syntax-only scaffold
+writes the wrappee body to a `.ts` file that tsdown attempts to
+parse; raw HTML isn't valid TS. Each fragment is byte-equality-
+verified through the marker hash machinery, which is the strongest
+guarantee available for a static asset reference.
+
+## Erlang sdk-docs fragments
+
+**Severity**: medium
+
+**Snippets affected**: every snippet under `erlang-server-sdk/sdk-docs/`.
+
+**Why unbindable**: the `erlang-server` Docker validator's harness
+(`run.sh`) hard-codes a synthesized rebar3 `eval` expression that
+calls `hello_erlang_server:get(<<flag>>, false, <<key>>)` — it
+expects the staged module to define a gen_server that exports
+`get/3`. The syntax-only scaffold synthesizes `snippet` with `main/0`
+instead, so the harness's eval expression fails to find the expected
+module. Every erlang sdk-docs fragment also has shape issues unique
+to Erlang grammar (multi-statement bodies need `,` between
+expressions; trailing `.` is mandatory at module top-level; `import`
+isn't a thing — Erlang uses module qualifiers). To wire these up
+cleanly, the harness needs either (a) a parse-only mode keyed on the
+scaffold (call `compile:file/2` instead of running eval) or (b) a
+new gen_server-shaped scaffold whose body contributes the `get/3`
+function clauses. Both are larger refactors than this PR's scope.
+Two of the seven sdk-docs fragments are also mistagged in the source
+MDX (`get-started-erlang` and `get-started-erlang-2` are
+rebar.config / .app.src declarative blocks, and `get-started-elixir`
+is Elixir mistagged as Erlang); even with the harness fix above,
+those three would need separate routing.
+
+## Android client SDK fragments (java + kotlin)
+
+**Severity**: medium
+
+**Snippets affected**: every snippet under `android-client-sdk/sdk-docs/`.
+
+**Why unbindable**: the existing `android-client-sdk/scaffolds/android-syntax-only`
+scaffold routes through the `jvm` validator, which fetches
+`launchdarkly-java-server-sdk` from Maven Central — that's the
+*server* SDK, not the *android client* SDK. The android client SDK
+(`com.launchdarkly:launchdarkly-android-client-sdk`) is published as
+an `aar` to Google's Maven, not a plain jar to Maven Central, so
+`mvn` can't resolve it without a different repository configuration
+plus the Android Gradle Plugin shim. The android sdk-docs fragments
+also include kotlin sources, which the jvm/maven validator doesn't
+compile. To wire these up cleanly, a parallel
+`android-client-validator` Docker image with the Android SDK and
+Gradle (the same shape as the existing `android-client-sdk`
+sdk-info init validator) would be needed, plus a kotlin-aware
+syntax-only scaffold. That's larger than this PR's scope.
+
+The two `install-the-sdk-gradle-*` snippets are Gradle
+`implementation '…'` declarations and would be Bucket C even with
+the validator above (declarative dependency strings, see XML/Maven
+section).
+
+## XML / Maven / Gradle declaration fragments
+
+**Severity**: low (declarative; not executable)
+
+**Snippets affected**: `java-server-sdk/sdk-docs/install-the-sdk-xml`,
+`java-server-sdk/sdk-docs/using-the-java-sdk-in-osgi-xml`,
+`android-client-sdk/sdk-docs/install-the-sdk-android-sdk-v3-x-android-3-7-x-and-later-android-sdk-3-7-or-later-gradle`
+and similar declarative `<dependency>` / `implementation '…'` snippets.
+
+**Why unbindable**: there is no XML parse-and-resolve validator that
+asserts a Maven coordinate or Gradle dependency string is reachable;
+the closest analogue is the `shell-install` harness, which only works
+on package-manager invocations (npm/pnpm/yarn/pip/go/bower). A
+declarative `<dependency>` block doesn't fit that contract — the
+package is fetched by Maven, not by a CLI invocation we can sniff. The
+content is byte-equality-checked through the marker hash machinery,
+which is the strongest guarantee available for a declarative snippet.
+
+## iOS Objective-C fragments
+
+**Severity**: medium
+
+**Snippets affected**: every `*-objective-c*` file under
+`ios-client-sdk/sdk-docs/`, plus `import-the-sdk-objective-c`.
+
+**Why unbindable**: the swift-syntax-only scaffold compiles Swift,
+not Objective-C. Wiring up Objective-C would need a separate
+swift-syntax-only-objc scaffold (or harness branch on the
+fragment's `lang:`) plus a project.yml that targets an Objective-C
+or mixed Swift/Objc app. None of those exist today; the underlying
+ios-client SDK supports both languages but the validator harness
+only stages Swift sources.
+
+## iOS package-manifest fragments
+
+**Severity**: low (declarative; not executable)
+
+**Snippets affected**:
+`ios-client-sdk/sdk-docs/use-carthage-cartfile`,
+`ios-client-sdk/sdk-docs/use-cocoapods-podfile`,
+`ios-client-sdk/sdk-docs/use-the-swift-package-manager-package-swift`.
+
+**Why unbindable**: Cartfile, Podfile, and Package.swift fragments
+are package-manager declarations — same disposition as the XML /
+Maven dependency snippets above. The ios-install validator
+(separate from ios-client) handles the install flow but only for
+the canonical sdk-info install snippets, not arbitrary doc
+fragments. These are byte-equality-checked through the marker
+hash.
+
+## iOS / Android UIKit / Activity fragments
+
+**Severity**: medium (fragments compile-checked but not run)
+
+**Snippets affected**: ios-client and android-client `sdk-docs/`
+snippets that reference `UIViewController`, `Activity`, `application:`
+lifecycle hooks, etc.
+
+**Why unbindable** *(sometimes)*: the syntax-only scaffolds compile
+the wrappee inside a stub function so unbound symbols don't trip the
+parser; symbols like `self.view` or `getApplicationContext()` that
+read like instance-method calls compile cleanly inside a stub function
+because the parser doesn't resolve them. So most iOS / Android
+fragments DO bind cleanly to the syntax-only scaffolds — only the few
+that require a running Activity / ViewController (e.g. lifecycle hook
+demonstrations that depend on real `super.onCreate(savedInstanceState)`
+behaviour) are listed here. See the per-snippet rationale on each
+unbound file for details.

--- a/snippets/sdks/_sdk-docs-port-notes.md
+++ b/snippets/sdks/_sdk-docs-port-notes.md
@@ -310,6 +310,41 @@ I install" direction the rest of the bindings reflect. The current
 v4 init fragment (`initialize-the-client-flutter-sdk-v4`) does
 bind cleanly.
 
+## iOS v8.x init / background fragments
+
+**Severity**: low (older API surface)
+
+**Snippets affected**:
+`ios-client-sdk/sdk-docs/background-fetch-ios-sdk-v8-0-and-earlier-swift`,
+`ios-client-sdk/sdk-docs/initialize-the-client-ios-sdk-v8-x-swift`.
+
+**Why unbindable**: both fragments reference the v8.0-and-earlier
+`LDConfig(mobileKey:)` initializer that doesn't take an
+`autoEnvAttributes:` argument. The scaffold's `project.yml` pins
+`launchdarkly-ios-client-sdk` `from: 11.0.0`, which made the
+`autoEnvAttributes:` parameter mandatory in v9.0. Pinning a parallel
+v8.x package alongside v11 would require a separate Xcode project
+shape and the validator would compile two SDKs into the same
+binary — out of scope for the syntax-only path.
+
+## iOS Observability plugin fragments
+
+**Severity**: low (extra plugin not in the validator's deps)
+
+**Snippets affected**:
+`ios-client-sdk/sdk-docs/import-the-sdk-swift`,
+`ios-client-sdk/sdk-docs/initialize-the-client-ios-sdk-v9-x-swift`.
+
+**Why unbindable**: each fragment references the
+`LaunchDarklyObservability` Swift package (`Observability(...)`,
+`import LaunchDarklyObservability`) to demonstrate the plugin
+integration. The ios-client validator's `project.yml` declares only
+the `LaunchDarkly` package, so the plugin's `Observability` type
+isn't in scope and the Swift compiler rejects the fragment. Adding
+the observability plugin would let these compile but introduces a
+transitive dep the rest of the matrix doesn't need; cleaner to
+defer until a dedicated observability validator exists.
+
 ## Rust v1.0 / Beta-syntax fragments
 
 **Severity**: low (older API surface)

--- a/snippets/sdks/_sdk-docs-port-notes.md
+++ b/snippets/sdks/_sdk-docs-port-notes.md
@@ -261,6 +261,113 @@ the canonical sdk-info install snippets, not arbitrary doc
 fragments. These are byte-equality-checked through the marker
 hash.
 
+## Haskell evaluate-a-context fragments
+
+**Severity**: medium
+
+**Snippets affected**:
+`haskell-server-sdk/sdk-docs/evaluate-a-context-haskell-sdk-v3-x`,
+`haskell-server-sdk/sdk-docs/evaluate-a-context-haskell-sdk-v4-0`.
+
+**Why unbindable**: both fragments reference a free `client` identifier
+(no `<- bind`, no top-level definition) — the docs assume the reader
+has the `client :: IO Client` from the surrounding init snippet in
+scope. Wiring this up would require either body changes (introducing
+`<- client` bindings) or a scaffold-level `client = undefined` stub
+that conflicts with the init snippet's own `client = makeClient $
+makeConfig …` top-level binding (the harness's TOP_LIFT awk relocates
+the body's binding to module scope, where it duplicates the stub).
+The v3.x fragment also calls `makeUser :: Text -> Context`, which
+was renamed to `makeContext "user" key` in v4.0 of the Haskell SDK
+the validator pins.
+
+The init / install fragments under `haskell-server-sdk/sdk-docs/` do
+bind cleanly through `haskell-syntax-only` thanks to the
+`--TOP_LIFT_TARGET--` / `--BODY_BEGIN--` / `--BODY_END--` markers
+the harness preprocesses into a top-level lift.
+
+## Flutter v1.x / v2.x / v3.x init fragments
+
+**Severity**: medium (older API surface)
+
+**Snippets affected**:
+`flutter-client-sdk/sdk-docs/initialize-the-client-flutter-sdk-v1-x`,
+`flutter-client-sdk/sdk-docs/initialize-the-client-flutter-sdk-v1-x-2`,
+`flutter-client-sdk/sdk-docs/initialize-the-client-flutter-sdk-v2-x`,
+`flutter-client-sdk/sdk-docs/initialize-the-client-flutter-sdk-v2-x-2`,
+`flutter-client-sdk/sdk-docs/initialize-the-client-flutter-sdk-v3-x`,
+`flutter-client-sdk/sdk-docs/initialize-the-client-flutter-sdk-v3-x-2`.
+
+**Why unbindable**: each fragment references identifiers (`LDUser`,
+`LDUserBuilder`, `LDConfigBuilder`, `LDClient.start(config, user)`,
+`AutoEnvAttributes.Enabled`) that the validator's pinned
+`launchdarkly_flutter_client_sdk` v4.x package does not export.
+v4 renamed `LDConfigBuilder` to `LDConfig`, `LDClient.start` to
+`client.start()`, `Enabled` to `enabled`, and dropped the user
+model entirely. Pinning a parallel v1.x/v2.x/v3.x package would
+let these compile but would diverge from the canonical "what should
+I install" direction the rest of the bindings reflect. The current
+v4 init fragment (`initialize-the-client-flutter-sdk-v4`) does
+bind cleanly.
+
+## Rust v1.0 / Beta-syntax fragments
+
+**Severity**: low (older API surface)
+
+**Snippets affected**:
+`rust-server-sdk/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-two-attributes-marked-private-for-all-contexts`,
+`rust-server-sdk/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-beta-syntax-user-with-key`,
+`rust-server-sdk/sdk-docs/implementation-v1-working-with-built-in-and-custom-attributes-beta-syntax-user-with-attributes`,
+`rust-server-sdk/sdk-docs/initialize-the-client-rust-v3-0`.
+
+**Why unbindable**: each fragment references identifiers that the
+validator's pinned `launchdarkly-server-sdk` v2.6.x crate doesn't
+ship — `User::with_key` and the `hashmap!` macro (beta syntax that
+predates the User->Context renaming), `EventProcessorBuilder::new()`
+without the type-parameter argument required by the current generic
+shape, and the `&YOUR_SDK_KEY` placeholder treated as a `&str`
+identifier reference rather than a string literal. The
+init-rust-v3-0 fragment also opens a fresh `async fn main()` which
+collides with the scaffold's own `main`. Pinning a parallel v0.x /
+beta crate would let these compile but would diverge from the
+canonical v2.x guidance the rest of the bindings reflect.
+
+## Vue main.js fragment with @launchdarkly/observability
+
+**Severity**: low (extra plugin not on the validator's dep list)
+
+**Snippets affected**:
+`vue-client-sdk/sdk-docs/initialize-the-client-and-context-main-js`.
+
+**Why unbindable**: the body imports `@launchdarkly/observability`
+and `@launchdarkly/session-replay` to demonstrate the LDPlugin
+options for those auxiliary plugins. The vue-client validator's
+Dockerfile only installs `vue` + `launchdarkly-vue-client-sdk`, so
+the build fails on Rolldown's "failed to resolve" check before the
+fragment gets a chance to syntax-check. Adding both plugins to the
+Dockerfile would let it build but introduces transitive deps the
+rest of the matrix doesn't need; cleaner to defer until a
+dedicated observability validator exists. The companion
+`vue-client-sdk/sdk-docs/configure-the-sdk-main-js` fragment
+(no observability imports) does bind through `vue-syntax-only`.
+
+## Go HTTPS proxy fragment
+
+**Severity**: low (incomplete code unit)
+
+**Snippets affected**: `go-server-sdk/sdk-docs/https-proxy-go-sdk`.
+
+**Why unbindable**: the body shows two top-level statements —
+`var config ld.Config` followed by `config.HTTP = ldcomponents.HTTPConfiguration().ProxyURL(...)`.
+The second is a struct-field assignment, which Go forbids at file
+scope. The go-syntax-only scaffold's `splitTopLevel` heuristic
+groups both lines as a top-level decl block (the `var` keyword
+triggers `consumeBraced`, which keeps lines together until a
+`)`-terminated line) and the resulting `package main\n\nvar config ld.Config\nconfig.HTTP = …` doesn't parse. The fragment is a teaching
+fragment, not a complete unit; the right disposition would be
+either a wrapper-function variant of the syntax-only scaffold or
+adjusting the source MDX to wrap the assignment in `init()`.
+
 ## iOS / Android UIKit / Activity fragments
 
 **Severity**: medium (fragments compile-checked but not run)

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/android-syntax-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/android-syntax-only.snippet.md
@@ -5,7 +5,17 @@ kind: scaffold
 lang: java
 file: src/main/java/com/launchdarkly/Snippet.java
 description: |
-  Parse-only validator for Android client SDK doc fragments. Uses the JVM validator since Android is a JVM language.
+  Parse-only validator for Android client SDK doc fragments. Uses
+  the JVM validator since Android is a JVM language.
+
+  NOTE: the JVM validator fetches `launchdarkly-java-server-sdk` from
+  Maven Central, not the android client SDK (which lives in Google's
+  Maven and ships as an `aar`). Fragments that reference
+  `com.launchdarkly.sdk.android.*` types won't resolve here. See
+  `_sdk-docs-port-notes.md` for the structural gap; the sdk-docs
+  android fragments are documented as Bucket C until a real
+  `android-client-validator` Docker image (mirroring the sdk-info
+  init validator) lands.
 inputs:
   body:
     type: string

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/evaluate-a-flag-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/evaluate-a-flag-java.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: "Java in section \"Evaluate a flag\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/evaluate-a-flag-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/evaluate-a-flag-kotlin.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: "Kotlin in section \"Evaluate a flag\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/import-the-sdk-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/import-the-sdk-java.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: "Java in section \"Import the SDK\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/import-the-sdk-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/import-the-sdk-kotlin.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: "Kotlin in section \"Import the SDK\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v4-x-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v4-x-java.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: "Android SDK v4.x (Java) in section \"Initialize the client\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v4-x-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v4-x-kotlin.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: "Android SDK v4.x (Kotlin) in section \"Initialize the client\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-java.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: "Android SDK v5.x (Java) in section \"Initialize the client\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-kotlin.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: "Android SDK v5.x (Kotlin) in section \"Initialize the client\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/install-the-sdk-gradle-groovy.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/install-the-sdk-gradle-groovy.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: "Gradle Groovy in section \"Install the SDK\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/install-the-sdk-gradle-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/install-the-sdk-gradle-kotlin.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: "Gradle Kotlin in section \"Install the SDK\""
+# Bucket C: jvm validator pulls launchdarkly-java-server-sdk, not the android-client SDK (which lives in Google Maven as an aar). See _sdk-docs-port-notes.md.
 ---
 
 ```kotlin

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/apex-evaluate-a-user-apex.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/apex-evaluate-a-user-apex.snippet.md
@@ -4,6 +4,7 @@ sdk: apex-server-sdk
 kind: reference
 lang: java
 description: "Apex in section \"Evaluate a user\""
+# Bucket C: no Apex/Salesforce validator. See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/apex-initialize-the-client-custom-config.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/apex-initialize-the-client-custom-config.snippet.md
@@ -4,6 +4,7 @@ sdk: apex-server-sdk
 kind: reference
 lang: java
 description: "Custom Config in section \"Initialize the client\""
+# Bucket C: no Apex/Salesforce validator. See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/apex-initialize-the-client-default-config.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/apex-initialize-the-client-default-config.snippet.md
@@ -4,6 +4,7 @@ sdk: apex-server-sdk
 kind: reference
 lang: java
 description: "Default Config in section \"Initialize the client\""
+# Bucket C: no Apex/Salesforce validator. See _sdk-docs-port-notes.md.
 ---
 
 ```java

--- a/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
@@ -29,13 +29,72 @@ validation:
 ---
 
 ```cpp
+#include <chrono>
+#include <future>
 #include <iostream>
+#include <string>
+// Native C++ headers.
 #include <launchdarkly/client_side/client.hpp>
+#include <launchdarkly/context_builder.hpp>
+#include <launchdarkly/value.hpp>
+// C-binding headers — doc fragments mix C-binding and native styles.
 #include <launchdarkly/client_side/bindings/c/sdk.h>
+#include <launchdarkly/client_side/bindings/c/config/builder.h>
+#include <launchdarkly/bindings/c/context.h>
+#include <launchdarkly/bindings/c/context_builder.h>
+
+// Polymorphic stub so a body can use `client.BoolVariation(...)`
+// (native-style) AND `LDClientSDK_BoolVariation(client, ...)`
+// (C-binding-style) without needing the scaffold to know which
+// shape the body uses. The wrappee is a never-instantiated template,
+// so the conversion operator and member functions exist at the type
+// system level but are never invoked.
+struct _AnyClient {
+    operator LDClientSDK() const { return nullptr; }
+    template <typename... Args> bool BoolVariation(Args&&...) const { return false; }
+    template <typename... Args> int IntVariation(Args&&...) const { return 0; }
+    template <typename... Args> double DoubleVariation(Args&&...) const { return 0; }
+    template <typename... Args> std::string StringVariation(Args&&...) const { return {}; }
+    template <typename... Args> auto JsonVariation(Args&&...) const { return launchdarkly::Value{}; }
+    template <typename... Args> auto AllFlags(Args&&...) const { return launchdarkly::Value{}; }
+    template <typename... Args> void TrackEvent(Args&&...) const {}
+    template <typename... Args> void Identify(Args&&...) const {}
+    template <typename... Args> auto StartAsync(Args&&...) const { return std::async(std::launch::deferred, []{ return false; }); }
+};
 
 template <int = 0>
 void _wrappee() {
+    // Body lives in a nested block so it can re-declare `client` /
+    // `context` (e.g. native-API init fragments that say
+    // `client_side::Client client(...)`, or C-binding init fragments
+    // that say `LDClientSDK client = LDClientSDK_New(...)`) without
+    // colliding with the stubs above. Bodies that use `client`
+    // without declaring it (e.g. evaluate-a-flag fragments) pick up
+    // the polymorphic stub from the outer scope.
+    //
+    // Doc fragments mix unqualified `ContextBuilder`,
+    // `client_side::Client`, etc. with the
+    // `launchdarkly::` prefix. Lifting both namespaces lets bodies
+    // that omit the prefix compile without breaking
+    // namespace-qualified bodies.
+    using namespace launchdarkly;
+    using namespace launchdarkly::client_side;
+    _AnyClient client;
+    LDContext context = nullptr;
+    LDClientConfig config = nullptr;
+    // `maxwait` is referenced by both native-style fragments
+    // (`wait_for(maxwait)` — needs a chrono duration) and C-binding
+    // fragments (`LDClientSDK_Start(client, maxwait, ...)` — needs an
+    // unsigned int milliseconds count). The polymorphic stub provides
+    // implicit conversions to both.
+    struct _Maxwait {
+        operator unsigned int() const { return 10000; }
+        operator std::chrono::milliseconds() const { return std::chrono::milliseconds{10000}; }
+        operator std::chrono::seconds() const { return std::chrono::seconds{10}; }
+    } maxwait;
+    {
 {{ body }}
+    }
 }
 
 int main() {

--- a/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
@@ -6,6 +6,19 @@ lang: cpp
 file: main.cpp
 description: |
   Parse-only validator for C++ client SDK doc fragments.
+
+  Wrappee is a never-instantiated template so the body is
+  syntactically parsed but type-checks against unbound names are
+  deferred until instantiation (which never happens). Include the
+  SDK headers at file scope so doc fragments that show
+  `#include <launchdarkly/...>` directives at the top of the body
+  re-include cheaply (header guards) and without conflict.
+
+  Doc fragments that don't declare a `client` or `context` and
+  reference them as if pre-existing won't compile through this
+  scaffold; in practice the v3 fragments either declare those
+  themselves or the build catches the issue. v2.x fragments are
+  Bucket C — see `_sdk-docs-port-notes.md`.
 inputs:
   body:
     type: string
@@ -17,7 +30,10 @@ validation:
 
 ```cpp
 #include <iostream>
+#include <launchdarkly/client_side/client.hpp>
+#include <launchdarkly/client_side/bindings/c/sdk.h>
 
+template <int = 0>
 void _wrappee() {
 {{ body }}
 }

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v2-x-c-binding.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v2-x-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C SDK v2.x (C++ binding) in section \"Evaluate a flag\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v2-x-native.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v2-x-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x (native) in section \"Evaluate a flag\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v3-0-c-binding.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v3-0-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Evaluate a flag\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v3-0-native.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/evaluate-a-flag-c-sdk-v3-0-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Evaluate a flag\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v2-x-c-binding.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v2-x-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C SDK v2.x (C++ binding) in section \"Include the LaunchDarkly headers\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v2-x-native.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v2-x-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x (native) in section \"Include the LaunchDarkly headers\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v3-c-binding.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v3-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3 (C binding) in section \"Include the LaunchDarkly headers\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v3-native.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/include-the-launchdarkly-headers-c-sdk-v3-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3 (native) in section \"Include the LaunchDarkly headers\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-c-binding-2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-c-binding-2.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C SDK v2.x (C++ binding) in section \"Initialize the client\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-c-binding.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C SDK v2.x (C++ binding) in section \"Initialize the client\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-native-2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-native-2.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x (native) in section \"Initialize the client\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-native.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v2-x-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x (native) in section \"Initialize the client\""
+# Bucket C: cpp v2.x API surface no longer available in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding-2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding-2.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding-3.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding-3.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding-4.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding-4.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```c
@@ -14,7 +16,7 @@ if (LDClientSDK_Start(client, maxwait, &initialized_successfully)) {
   /* The client's attempt to initialize succeeded or failed in the specified amount of time. */
   if (initialized_successfully) {
     /* Initialization succeeded. */
-  else {
+  } else {
     /* Initialization failed. */
   }
 } else {

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native-2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native-2.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native-3.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native-3.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native-4.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native-4.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/initialize-the-client-c-sdk-v3-0-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/understand-the-sdk-namespaces-no-namespace.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/understand-the-sdk-namespaces-no-namespace.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "No namespace in section \"Understand the SDK namespaces\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/understand-the-sdk-namespaces-using-launchdarkly-client-side-namespace.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/understand-the-sdk-namespaces-using-launchdarkly-client-side-namespace.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "Using launchdarkly::client_side namespace in section \"Understand the SDK namespaces\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/understand-the-sdk-namespaces-using-launchdarkly-namespace.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/understand-the-sdk-namespaces-using-launchdarkly-namespace.snippet.md
@@ -4,10 +4,12 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: "Using launchdarkly namespace in section \"Understand the SDK namespaces\""
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
 ---
 
 ```cpp
-using namespace launchdarkly; # omitted in examples; assumed to be present
+using namespace launchdarkly; // omitted in examples; assumed to be present
 auto config_builder = client_side::ConfigBuilder("example-mobile-key");
 auto config = config_builder.Build();
 ```

--- a/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
@@ -17,7 +17,15 @@ validation:
 
 ```cpp
 #include <iostream>
+#include <launchdarkly/server_side/client.hpp>
+#include <launchdarkly/server_side/bindings/c/sdk.h>
 
+// Wrappee is a never-instantiated template — body is parsed but
+// most type-checks are deferred to instantiation (which never
+// happens). Keeps doc fragments that reference an undeclared
+// `client` (e.g. evaluate-a-context fragments) from failing the
+// build.
+template <int = 0>
 void _wrappee() {
 {{ body }}
 }

--- a/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
@@ -16,18 +16,75 @@ validation:
 ---
 
 ```cpp
+#include <chrono>
+#include <future>
 #include <iostream>
+#include <string>
+// Native C++ headers.
 #include <launchdarkly/server_side/client.hpp>
+#include <launchdarkly/server_side/config/config_builder.hpp>
+#include <launchdarkly/context_builder.hpp>
+#include <launchdarkly/value.hpp>
+// C-binding headers — doc fragments mix C-binding and native styles.
 #include <launchdarkly/server_side/bindings/c/sdk.h>
+#include <launchdarkly/server_side/bindings/c/config/builder.h>
+#include <launchdarkly/bindings/c/context.h>
+#include <launchdarkly/bindings/c/context_builder.h>
+
+// Polymorphic stub so a body can use `client.BoolVariation(...)`
+// (native-style) AND `LDServerSDK_BoolVariation(client, ...)`
+// (C-binding-style) without needing the scaffold to know which
+// shape the body uses. The wrappee is a never-instantiated template,
+// so the conversion operator and member functions exist at the type
+// system level but are never invoked.
+struct _AnyClient {
+    operator LDServerSDK() const { return nullptr; }
+    template <typename... Args> bool BoolVariation(Args&&...) const { return false; }
+    template <typename... Args> int IntVariation(Args&&...) const { return 0; }
+    template <typename... Args> double DoubleVariation(Args&&...) const { return 0; }
+    template <typename... Args> std::string StringVariation(Args&&...) const { return {}; }
+    template <typename... Args> auto JsonVariation(Args&&...) const { return launchdarkly::Value{}; }
+    template <typename... Args> auto AllFlagsState(Args&&...) const { return false; }
+    template <typename... Args> void TrackEvent(Args&&...) const {}
+    template <typename... Args> void Identify(Args&&...) const {}
+    template <typename... Args> auto StartAsync(Args&&...) const { return std::async(std::launch::deferred, []{ return false; }); }
+};
 
 // Wrappee is a never-instantiated template — body is parsed but
 // most type-checks are deferred to instantiation (which never
-// happens). Keeps doc fragments that reference an undeclared
-// `client` (e.g. evaluate-a-context fragments) from failing the
-// build.
+// happens). The body lives in a nested block so it can re-declare
+// `client` / `context` when the fragment shows the native or
+// C-binding init form (e.g. `server_side::Client client(*config);`,
+// `LDServerSDK client = LDServerSDK_New(...)`).
 template <int = 0>
 void _wrappee() {
+    // Doc fragments mix unqualified names from `launchdarkly` and
+    // `launchdarkly::server_side` (e.g. `ContextBuilder`,
+    // `ConfigBuilder`, `Client`, `server_side::ConfigBuilder`).
+    // Lifting both namespaces inside the template body lets bodies
+    // that omit the namespace prefix (the "no-namespace" /
+    // "using-launchdarkly-server-side-namespace" doc style) compile
+    // without losing the namespace-qualified bodies — those still
+    // resolve through the qualified name first.
+    using namespace launchdarkly;
+    using namespace launchdarkly::server_side;
+    _AnyClient client;
+    LDContext context = nullptr;
+    LDServerConfig config = nullptr;
+    // `maxwait` is referenced by both native-style fragments
+    // (`wait_for(maxwait)` — needs a chrono duration) and C-binding
+    // fragments (`LDServerSDK_Start(client, maxwait, ...)` — needs an
+    // unsigned int milliseconds count). The polymorphic stub provides
+    // implicit conversions to both so neither shape needs to declare
+    // it locally.
+    struct _Maxwait {
+        operator unsigned int() const { return 10000; }
+        operator std::chrono::milliseconds() const { return std::chrono::milliseconds{10000}; }
+        operator std::chrono::seconds() const { return std::chrono::seconds{10}; }
+    } maxwait;
+    {
 {{ body }}
+    }
 }
 
 int main() {

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---about-the-sdk-namespaces-no-namespace.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---about-the-sdk-namespaces-no-namespace.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "No namespace in section \"About the SDK namespaces\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---about-the-sdk-namespaces-using-launchdarkly-namespace.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---about-the-sdk-namespaces-using-launchdarkly-namespace.snippet.md
@@ -4,10 +4,12 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "Using launchdarkly namespace in section \"About the SDK namespaces\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp
-using namespace launchdarkly; # omitted in examples; assumed to be present
+using namespace launchdarkly; // omitted in examples; assumed to be present
 auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
 auto config = config_builder.Build();
 ```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---about-the-sdk-namespaces-using-launchdarkly-server-side-namespace.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---about-the-sdk-namespaces-using-launchdarkly-server-side-namespace.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "Using launchdarkly::server_side namespace in section \"About the SDK namespaces\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---evaluate-a-context-c-sdk-v2-x.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---evaluate-a-context-c-sdk-v2-x.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x in section \"Evaluate a context\""
+# Bucket C: cpp v2.x API surface no longer in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---evaluate-a-context-c-sdk-v3-0-c-binding.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---evaluate-a-context-c-sdk-v3-0-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Evaluate a context\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---evaluate-a-context-c-sdk-v3-0-native.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---evaluate-a-context-c-sdk-v3-0-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Evaluate a context\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v2-x.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v2-x.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x in section \"Include the LaunchDarkly headers\""
+# Bucket C: cpp v2.x API surface no longer in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-0-c-binding.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-0-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Include the LaunchDarkly headers\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-0-native.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-0-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Include the LaunchDarkly headers\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-c-binding.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3 (C binding) in section \"Include the LaunchDarkly headers\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-native.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---include-the-launchdarkly-headers-c-sdk-v3-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3 (native) in section \"Include the LaunchDarkly headers\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v2-x-2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v2-x-2.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x in section \"Initialize the client\""
+# Bucket C: cpp v2.x API surface no longer in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v2-x.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v2-x.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C SDK v2.x in section \"Initialize the client\""
+# Bucket C: cpp v2.x API surface no longer in cpp-sdks v3 (the
+# Dockerfile-pinned validator). See _sdk-docs-port-notes.md.
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-2.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-3.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-3.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-4.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-4.snippet.md
@@ -16,7 +16,7 @@ if (LDServerSDK_Start(client, maxwait, &initialized_successfully)) {
   /* The client's attempt to initialize succeeded or failed in the specified amount of time. */
   if (initialized_successfully) {
     /* Initialization succeeded. */
-  else {
+  } else {
     /* Initialization failed. */
   }
 } else {

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-4.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding-4.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding.snippet.md
@@ -9,14 +9,14 @@ validation:
 ---
 
 ```c
-LDClientConfigBuilder builder = LDClientConfigBuilder_New("YOUR_SDK_KEY");
+LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
 
-LDClientConfig config;
-LDStatus status = LDClientConfigBuilder_Build(builder, &config);
+LDServerConfig config;
+LDStatus status = LDServerConfigBuilder_Build(builder, &config);
 
 if (!LDStatus_Ok(status)) {
      /* an error occurred, config is not valid */
 }
 
-LDClientSDK client = LDClientSDK_New(config);
+LDServerSDK client = LDServerSDK_New(config);
 ```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-c-binding.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: "C++ SDK v3.0 (C binding) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native-2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native-2.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native-3.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native-3.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native-4.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native-4.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/c-c---initialize-the-client-c-sdk-v3-0-native.snippet.md
@@ -4,6 +4,8 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: "C++ SDK v3.0 (native) in section \"Initialize the client\""
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
 ---
 
 ```cpp

--- a/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only.snippet.md
@@ -22,18 +22,23 @@ validation:
 ```csharp
 using LaunchDarkly.Sdk;
 using LaunchDarkly.Sdk.Client;
+using System;
+using LaunchDarkly.Sdk.Client.Integrations;
+// USING_LIFT_MARKER
 
 namespace LaunchDarklySnippet
 {
     public class Program
     {
-        // Stub so the wrappee body's `client.BoolVariation(...)`,
+        // Stub fields so the wrappee body's `client.BoolVariation(...)`,
         // `client.StringVariation(...)`, etc. resolve at compile time.
-        // Never invoked at runtime — Main below short-circuits to print
-        // the EXAM-HELLO line.
-        #pragma warning disable CS8625
-        private static LdClient client = null;
-        #pragma warning restore CS8625
+        // Typing `client` as `dynamic` makes the body forward-compatible
+        // across .NET client SDK versions whose APIs differ slightly
+        // (LdClient.Init signatures changed across v3 / v4 / v5). Never
+        // invoked at runtime — Main below short-circuits.
+        #pragma warning disable CS8625, CS0414, CS0649
+        private static dynamic client = null;
+        #pragma warning restore CS8625, CS0414, CS0649
 
         public static void Main(string[] args)
         {
@@ -41,9 +46,12 @@ namespace LaunchDarklySnippet
         }
 
         #pragma warning disable CS0162
-        private void Wrappee()
+        private async System.Threading.Tasks.Task Wrappee()
         {
+            try {
 {{ body }}
+            } catch (System.Exception) { /* never reached */ }
+            await System.Threading.Tasks.Task.CompletedTask;
         }
         #pragma warning restore CS0162
     }

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/evaluate-a-flag-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/evaluate-a-flag-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: "C# in section \"Evaluate a flag\""
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v3-0-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v3-0-c.snippet.md
@@ -4,6 +4,12 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v3.0 (C#) in section \"Initialize the client\""
+# Bucket C: pinned to a deprecated dotnet-client SDK API surface
+# (LdClient.Init(string, …) overload removed in v4.0; v3.x async
+# variant; v3.x relay-proxy via ConfigurationBuilder shape that
+# changed in v4). The csharp-client-syntax-only scaffold compiles
+# against the latest LaunchDarkly.ClientSdk, so these v3-shape calls
+# fail overload resolution. See _sdk-docs-port-notes.md.
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v3-x-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v3-x-c.snippet.md
@@ -4,6 +4,12 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v3.x (C#) in section \"Initialize the client\""
+# Bucket C: pinned to a deprecated dotnet-client SDK API surface
+# (LdClient.Init(string, …) overload removed in v4.0; v3.x async
+# variant; v3.x relay-proxy via ConfigurationBuilder shape that
+# changed in v4). The csharp-client-syntax-only scaffold compiles
+# against the latest LaunchDarkly.ClientSdk, so these v3-shape calls
+# fail overload resolution. See _sdk-docs-port-notes.md.
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v4-0-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v4-0-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v4.0+ (C#) in section \"Initialize the client\""
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v4-x-v5-0-v5-1-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v4-x-v5-0-v5-1-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v4.x, v5.0, v5.1 (C#) in section \"Initialize the client\""
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v5-2-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/initialize-the-client-net-sdk-v5-2-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v5.2+ (C#) in section \"Initialize the client\""
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/install-the-sdk-c-2.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/install-the-sdk-c-2.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: "C# in section \"Install the SDK\""
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/install-the-sdk-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/install-the-sdk-c.snippet.md
@@ -4,6 +4,11 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: "C# in section \"Install the SDK\""
+# Bucket C: body is `Install-Package LaunchDarkly.ClientSdk` —
+# Visual Studio's NuGet Package Manager Console PowerShell command,
+# mistagged as `csharp` in the source MDX. The
+# csharp-client-syntax-only scaffold can't compile PowerShell.
+# See _sdk-docs-port-notes.md.
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/using-the-relay-proxy-c.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/using-the-relay-proxy-c.snippet.md
@@ -4,6 +4,12 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: "C# in section \"Using the Relay Proxy\""
+# Bucket C: pinned to a deprecated dotnet-client SDK API surface
+# (LdClient.Init(string, …) overload removed in v4.0; v3.x async
+# variant; v3.x relay-proxy via ConfigurationBuilder shape that
+# changed in v4). The csharp-client-syntax-only scaffold compiles
+# against the latest LaunchDarkly.ClientSdk, so these v3-shape calls
+# fail overload resolution. See _sdk-docs-port-notes.md.
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
@@ -6,6 +6,12 @@ lang: csharp
 file: Program.cs
 description: |
   Parse-only validator for .NET server SDK doc fragments.
+
+  C# requires `using` directives at the top of the file (or inside a
+  namespace), not inside a method body. The `// USING_LIFT_MARKER`
+  comment cues the harness pre-stage rewrite to lift any `using …;`
+  lines from the wrappee body up to the marker, so doc fragments that
+  show install-time `using LaunchDarkly.Sdk;` etc. can compile.
 inputs:
   body:
     type: string
@@ -13,13 +19,32 @@ inputs:
 validation:
   runtime: dotnet-server
   entrypoint: Program.cs
+  requirements: |
+    LaunchDarkly.ServerSdk
+    LaunchDarkly.Observability
 ---
 
 ```csharp
+// USING_LIFT_MARKER
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
 namespace LaunchDarklySnippet
 {
     public class Program
     {
+        // Stub fields the wrappee body refers to. Never used at runtime.
+        // The body's `client.BoolVariation(...)` calls resolve through
+        // these so the C# compiler is happy. v6 docs use `User` and
+        // v6 overloads of variation methods, v7+ uses `Context` —
+        // typing `client` as `dynamic` lets any overload resolve at
+        // runtime so the same scaffold validates both API surfaces.
+#pragma warning disable CS0414, CS0649
+        private static dynamic client = null;
+        private static User user = null;
+        private static Context context = default;
+#pragma warning restore CS0414, CS0649
+
         public static void Main(string[] args)
         {
             System.Console.WriteLine("feature flag evaluates to true");
@@ -27,7 +52,9 @@ namespace LaunchDarklySnippet
 
         private void Wrappee()
         {
+            try {
 {{ body }}
+            } catch (System.Exception) { /* never reached */ }
         }
     }
 }

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/evaluate-a-context-net-sdk-v6-x-c.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/evaluate-a-context-net-sdk-v6-x-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v6.x (C#) in section \"Evaluate a context\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/evaluate-a-context-net-sdk-v7-0-c-2.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/evaluate-a-context-net-sdk-v7-0-c-2.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v7.0+ (C#) in section \"Evaluate a context\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/evaluate-a-context-net-sdk-v7-0-c.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/evaluate-a-context-net-sdk-v7-0-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v7.0+ (C#) in section \"Evaluate a context\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/initialize-the-client-initialize-net-sdk-v8-10-with-asp-net-core-p1.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/initialize-the-client-initialize-net-sdk-v8-10-with-asp-net-core-p1.snippet.md
@@ -4,6 +4,11 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: "Initialize, .NET SDK v8.10+ with ASP.Net Core in section \"Initialize the client\""
+# Bucket C: ASP.NET Core init fragment. Requires Microsoft.AspNetCore +
+# LaunchDarkly.Observability + ObservabilityPlugin types that the
+# csharp-syntax-only scaffold doesn't pull in, plus the body references
+# the bare identifier `args` which is only in scope inside the
+# top-level Main(string[] args). See _sdk-docs-port-notes.md.
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/initialize-the-client-initialize-net-sdk-v8-10-with-asp-net-core-p2.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/initialize-the-client-initialize-net-sdk-v8-10-with-asp-net-core-p2.snippet.md
@@ -4,6 +4,12 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: "Initialize, .NET SDK v8.10+ with ASP.Net Core in section \"Initialize the client\""
+# Bucket C: ASP.NET Framework Global.asax fragment that nests
+# `protected void Application_Start()` / `Application_End()` method
+# definitions inside the wrappee body. Nested method definitions with
+# `protected` modifiers aren't valid inside another method, so the
+# csharp-syntax-only scaffold's wrapper makes this uncompilable.
+# See _sdk-docs-port-notes.md.
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/install-the-sdk-net-sdk-v6-x-and-later-c.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/install-the-sdk-net-sdk-v6-x-and-later-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK v6.x and later (C#) in section \"Install the SDK\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/transport-layer-security-tls-and-other-networking-issues-net-sdk-6-x-and-7-x-syntax-c-federal-instance.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/transport-layer-security-tls-and-other-networking-issues-net-sdk-6-x-and-7-x-syntax-c-federal-instance.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK 6.x and 7.x syntax (C#), federal instance in section \"Transport Layer Security (TLS) and other networking issues\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/transport-layer-security-tls-and-other-networking-issues-net-sdk-6-x-and-7-x-syntax-c.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/transport-layer-security-tls-and-other-networking-issues-net-sdk-6-x-and-7-x-syntax-c.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: ".NET SDK 6.x and 7.x syntax (C#) in section \"Transport Layer Security (TLS) and other networking issues\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
 ---
 
 ```csharp

--- a/snippets/sdks/electron-client-sdk/snippets/scaffolds/electron-syntax-only.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/scaffolds/electron-syntax-only.snippet.md
@@ -3,23 +3,33 @@ id: electron-client-sdk/scaffolds/electron-syntax-only
 sdk: electron-client-sdk
 kind: scaffold
 lang: javascript
-file: index.js
+file: src/app.ts
 description: |
-  Parse-only validator for Electron client SDK doc fragments. Uses the JS-client Docker validator since Electron is a JS variant.
+  Parse-only validator for Electron client SDK doc fragments. Uses the
+  JS-client Docker validator since Electron is a JavaScript variant —
+  the staged file path matches the js-client harness's hard-coded
+  `src/app.ts` entrypoint so the wrappee body actually reaches tsdown
+  + Chromium. The body sits in a never-invoked async IIFE so its
+  references to Electron-only globals (`require`, `electron.app`, etc.)
+  don't have to resolve at runtime; tsdown still parses the syntax.
 inputs:
   body:
     type: string
-    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+    description: The wrappee snippet's rendered body, written to src/app.ts.
 validation:
   runtime: js-client
-  entrypoint: index.js
+  entrypoint: src/app.ts
 ---
 
 ```javascript
-(async () => {
-  function _wrappee() {
+// Wrap in an async IIFE so the wrappee body can use top-level `await`
+// (e.g. `await client.waitForInitialization(...)`); the IIFE's
+// `if (false)` guard means the body is never executed at runtime.
+(async function _wrappee() {
+  if (false) {
 {{ body }}
   }
-  console.log('feature flag evaluates to true');
 })();
+
+document.body.textContent = 'feature flag evaluates to true';
 ```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-evaluate-a-flag-javascript.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-evaluate-a-flag-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Evaluate a flag\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-evaluate-a-flag-typescript.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-evaluate-a-flag-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: typescript
 description: "TypeScript in section \"Evaluate a flag\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-javascript-2.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-javascript-2.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Initialize the client\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-javascript-3.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-javascript-3.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Initialize the client\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-javascript.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Initialize the client\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-typescript-2.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-typescript-2.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: typescript
 description: "TypeScript in section \"Initialize the client\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-typescript.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-initialize-the-client-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: typescript
 description: "TypeScript in section \"Initialize the client\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-server-side-node-js-sdk-compatibility-javascript.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/electron-server-side-node-js-sdk-compatibility-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Server-side Node.js SDK compatibility\""
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/evaluate-a-context-erlang-sdk-v1-x.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/evaluate-a-context-erlang-sdk-v1-x.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: "Erlang SDK v1.x in section \"Evaluate a context\""
+# Bucket C: erlang-server validator's gen_server harness is incompatible with the erlang-syntax-only scaffold's module shape. See _sdk-docs-port-notes.md.
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/evaluate-a-context-erlang-sdk-v2-0.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/evaluate-a-context-erlang-sdk-v2-0.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: "Erlang SDK v2.0+ in section \"Evaluate a context\""
+# Bucket C: erlang-server validator's gen_server harness is incompatible with the erlang-syntax-only scaffold's module shape. See _sdk-docs-port-notes.md.
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/get-started-elixir.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/get-started-elixir.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: "Elixir in section \"Get started\""
+# Bucket C: erlang-server validator's gen_server harness is incompatible with the erlang-syntax-only scaffold's module shape. See _sdk-docs-port-notes.md.
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/get-started-erlang-2.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/get-started-erlang-2.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: "Erlang in section \"Get started\""
+# Bucket C: erlang-server validator's gen_server harness is incompatible with the erlang-syntax-only scaffold's module shape. See _sdk-docs-port-notes.md.
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/get-started-erlang.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/get-started-erlang.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: "Erlang in section \"Get started\""
+# Bucket C: erlang-server validator's gen_server harness is incompatible with the erlang-syntax-only scaffold's module shape. See _sdk-docs-port-notes.md.
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/initialize-the-client-erlang.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/initialize-the-client-erlang.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: "Erlang in section \"Initialize the client\""
+# Bucket C: erlang-server validator's gen_server harness is incompatible with the erlang-syntax-only scaffold's module shape. See _sdk-docs-port-notes.md.
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/transport-layer-security-tls-erlang.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/transport-layer-security-tls-erlang.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: "Erlang in section \"Transport Layer Security (TLS)\""
+# Bucket C: erlang-server validator's gen_server harness is incompatible with the erlang-syntax-only scaffold's module shape. See _sdk-docs-port-notes.md.
 ---
 
 ```erlang

--- a/snippets/sdks/flutter-client-sdk/snippets/scaffolds/flutter-syntax-only.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/scaffolds/flutter-syntax-only.snippet.md
@@ -27,19 +27,33 @@ validation:
 import 'package:flutter/material.dart';
 // ignore: unused_import
 import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+//IMPORT_LIFT_TARGET
 
 // ignore: unused_element
 Future<void> _wrappee() async {
-  // Stub locals so the wrappee body's symbols resolve at compile time.
-  // Never reached at runtime — main() short-circuits to the success
-  // widget below.
+  // Stub locals so wrappee bodies referencing `client`, `context`,
+  // `flagKey` resolve at compile time. Initialize each with a
+  // value-of-the-right-type expression so Dart's analyzer doesn't
+  // flag a definitely-unassigned read. The body lives in a nested
+  // block so it can re-declare `context`, `flagKey`, etc. without
+  // colliding with the stubs (Dart allows shadowing across blocks).
+  //
+  // Body imports (e.g. `import 'package:launchdarkly_flutter_client_sdk/...';`)
+  // get lifted to module scope by the harness's awk pre-step using the
+  // BODY_BEGIN / BODY_END / IMPORT_LIFT_TARGET markers — Dart forbids
+  // imports inside a function body, so a fragment that shows an
+  // install-time import would otherwise fail to compile.
   // ignore: unused_local_variable
-  late final dynamic client;
+  dynamic client = Object();
   // ignore: unused_local_variable
-  late final dynamic context;
+  dynamic context = Object();
   // ignore: unused_local_variable
-  late final String flagKey;
+  String flagKey = '';
+  {
+//BODY_BEGIN
 {{ body }}
+//BODY_END
+  }
 }
 
 void main() {

--- a/snippets/sdks/flutter-client-sdk/snippets/scaffolds/flutter-syntax-only.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/scaffolds/flutter-syntax-only.snippet.md
@@ -6,6 +6,14 @@ lang: dart
 file: lib/main.dart
 description: |
   Parse-only validator for Flutter client SDK doc fragments.
+
+  Renders the EXAM-HELLO success line as an actual `Text` widget so
+  the playwright DOM check (via flutter-client/harness/check.js) sees
+  it. The wrappee body lives inside `_wrappee()`, an async function
+  that's never invoked at runtime — its references to `client`,
+  `LDClient.start(...)`, etc. compile against the
+  launchdarkly_flutter_client_sdk package the prebuilt project
+  already pulls in.
 inputs:
   body:
     type: string
@@ -16,11 +24,27 @@ validation:
 ---
 
 ```dart
-void _wrappee() {
+import 'package:flutter/material.dart';
+// ignore: unused_import
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+
+// ignore: unused_element
+Future<void> _wrappee() async {
+  // Stub locals so the wrappee body's symbols resolve at compile time.
+  // Never reached at runtime — main() short-circuits to the success
+  // widget below.
+  // ignore: unused_local_variable
+  late final dynamic client;
+  // ignore: unused_local_variable
+  late final dynamic context;
+  // ignore: unused_local_variable
+  late final String flagKey;
 {{ body }}
 }
 
 void main() {
-  print('feature flag evaluates to true');
+  runApp(const MaterialApp(
+    home: Scaffold(body: Center(child: Text('feature flag evaluates to true'))),
+  ));
 }
 ```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/evaluate-a-flag-flutter-sdk.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/evaluate-a-flag-flutter-sdk.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK in section \"Evaluate a flag\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x-2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x-2.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v1.x in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x-2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x-2.snippet.md
@@ -4,8 +4,6 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v1.x in section \"Initialize the client\""
-validation:
-  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v1.x in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v1-x.snippet.md
@@ -4,8 +4,6 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v1.x in section \"Initialize the client\""
-validation:
-  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x-2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x-2.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v2.x in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x-2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x-2.snippet.md
@@ -4,8 +4,6 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v2.x in section \"Initialize the client\""
-validation:
-  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v2.x in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v2-x.snippet.md
@@ -4,8 +4,6 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v2.x in section \"Initialize the client\""
-validation:
-  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x-2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x-2.snippet.md
@@ -4,8 +4,6 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v3.x in section \"Initialize the client\""
-validation:
-  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x-2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x-2.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v3.x in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x.snippet.md
@@ -4,8 +4,6 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v3.x in section \"Initialize the client\""
-validation:
-  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v3-x.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v3.x in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v4-2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v4-2.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v4 in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/initialize-the-client-flutter-sdk-v4.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v4 in section \"Initialize the client\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/install-the-sdk-dart.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/install-the-sdk-dart.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Dart in section \"Install the SDK\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/install-the-sdk-flutter-sdk-v4-providing-credentials-in-config.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/install-the-sdk-flutter-sdk-v4-providing-credentials-in-config.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: "Flutter SDK v4, providing credentials in config in section \"Install the SDK\""
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/install-the-sdk-pubspec-yaml.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/install-the-sdk-pubspec-yaml.snippet.md
@@ -4,6 +4,10 @@ sdk: flutter-client-sdk
 kind: reference
 lang: yaml
 description: "pubspec.yaml in section \"Install the SDK\""
+# Bucket C: pubspec.yaml dependency declaration; not Dart code. Same
+# disposition as the Java XML / Maven dependency snippets — declarative
+# package-manifest fragments don't fit the syntax-only scaffold model.
+# See _sdk-docs-port-notes.md.
 ---
 
 ```yaml

--- a/snippets/sdks/go-server-sdk/snippets/scaffolds/go-syntax-only.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/scaffolds/go-syntax-only.snippet.md
@@ -6,10 +6,24 @@ lang: go
 file: main.go
 description: |
   Parse-only validator for Go server SDK doc fragments.
+
+  Go is unusually strict about where syntax may appear: top-level
+  `import (...)` blocks and top-level `func` declarations cannot live
+  inside another function body, so the simple "wrap body in
+  `_wrappee()`" pattern breaks for snippets that show install-time
+  imports or middleware-style helper functions.
+
+  Instead of building the body, the harness uses `go/parser.ParseFile`
+  on a synthetic file that splices the wrappee body either as a
+  top-level fragment (when it begins with `import`/`func`/`package`/
+  `var`/`const`/`type`) or wrapped inside a no-op function body
+  otherwise. ParseFile walks the AST without resolving symbols, so
+  unresolved package names (`ld`, `ldobserve`, etc.) don't fail the
+  check.
 inputs:
   body:
     type: string
-    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+    description: The wrappee snippet's rendered body, parsed by go/parser.
 validation:
   runtime: go
   entrypoint: main.go
@@ -20,20 +34,104 @@ package main
 
 import (
 	"fmt"
-
-	_ "github.com/launchdarkly/go-sdk-common/v3/ldcontext"
-	_ "github.com/launchdarkly/go-sdk-common/v3/ldvalue"
-	_ "github.com/launchdarkly/go-server-sdk/v7"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
 )
 
-func main() {
-	fmt.Println("feature flag evaluates to true")
+const wrappeeBody = `
+{{ body }}
+`
+
+// splitTopLevel separates a Go fragment into top-level declarations
+// (`import (...)`, `func ...`, `var/const/type/package`) followed by
+// optional function-body residue. The docs sometimes show both —
+// "add this import AND use this code" — so the harness can't pick one
+// or the other and reject the rest. The split is line-based and
+// brace-balanced; the parser does the actual syntactic work.
+func splitTopLevel(body string) (top, fnBody string) {
+	lines := strings.Split(body, "\n")
+	var topBuf, restBuf []string
+	i, n := 0, len(lines)
+	consumeBraced := func() {
+		// collect lines until brace depth returns to 0 (or end-of-input).
+		// Lines without any braces still count as one statement.
+		depth := 0
+		seenBrace := false
+		for i < n {
+			line := lines[i]
+			topBuf = append(topBuf, line)
+			depth += strings.Count(line, "{") - strings.Count(line, "}")
+			if strings.ContainsAny(line, "{}") {
+				seenBrace = true
+			}
+			i++
+			if seenBrace && depth == 0 {
+				return
+			}
+			if !seenBrace && strings.HasSuffix(strings.TrimRight(line, " \t"), ")") {
+				// `var X = foo()` or single-line decl — stop on first `)`-terminated line.
+				return
+			}
+		}
+	}
+	for i < n {
+		line := lines[i]
+		trim := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trim, "import ("):
+			// multi-line import block — collect until matching `)`.
+			topBuf = append(topBuf, line)
+			i++
+			for i < n {
+				topBuf = append(topBuf, lines[i])
+				done := strings.TrimSpace(lines[i]) == ")"
+				i++
+				if done {
+					break
+				}
+			}
+		case strings.HasPrefix(trim, "import "):
+			topBuf = append(topBuf, line)
+			i++
+		case strings.HasPrefix(trim, "func "), strings.HasPrefix(trim, "var "),
+			strings.HasPrefix(trim, "const "), strings.HasPrefix(trim, "type "),
+			strings.HasPrefix(trim, "package "):
+			consumeBraced()
+		case trim == "":
+			// blank line — attach to whichever buffer is currently
+			// being filled. Once we've started filling restBuf, all
+			// subsequent blank lines stay with rest.
+			if len(restBuf) == 0 {
+				topBuf = append(topBuf, line)
+			} else {
+				restBuf = append(restBuf, line)
+			}
+			i++
+		default:
+			restBuf = append(restBuf, line)
+			i++
+		}
+	}
+	return strings.Join(topBuf, "\n"), strings.Join(restBuf, "\n")
 }
 
-// _wrappee compiles the doc-fragment body in a function the harness never
-// invokes — the EXAM-HELLO success line is printed unconditionally above,
-// so we just need the snippet to parse and link.
-func _wrappee() {
-{{ body }}
+func main() {
+	body := strings.TrimSpace(wrappeeBody)
+	top, fn := splitTopLevel(body)
+	src := "package wrappee\n\n" + top + "\n"
+	if strings.TrimSpace(fn) != "" {
+		src += "\nfunc _wrappee() {\n" + fn + "\n}\n"
+	}
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "fragment.go", src, parser.AllErrors); err != nil {
+		fmt.Fprintln(os.Stderr, "parse error:", err)
+		fmt.Fprintln(os.Stderr, "--- synthesized source ---")
+		fmt.Fprintln(os.Stderr, src)
+		os.Exit(1)
+	}
+	// EXAM-HELLO success line — emitted on a syntactically clean parse.
+	fmt.Println("feature flag evaluates to true")
 }
 ```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/evaluate-a-context-go-sdk-v6-using-ldclient.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/evaluate-a-context-go-sdk-v6-using-ldclient.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK v6+, using LDClient in section \"Evaluate a context\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/evaluate-a-context-go-sdk-v7-13-4-using-ldscopedclient.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/evaluate-a-context-go-sdk-v7-13-4-using-ldscopedclient.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK v7.13.4+, using LDScopedClient in section \"Evaluate a context\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/https-proxy-go-sdk.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/https-proxy-go-sdk.snippet.md
@@ -4,8 +4,6 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK in section \"HTTPS Proxy\""
-validation:
-  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/https-proxy-go-sdk.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/https-proxy-go-sdk.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK in section \"HTTPS Proxy\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/initialize-the-client-go-sdk-using-ldclient-and-default-configuration.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/initialize-the-client-go-sdk-using-ldclient-and-default-configuration.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK, using LDClient and default configuration in section \"Initialize the client\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/initialize-the-client-go-sdk-using-ldclient.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/initialize-the-client-go-sdk-using-ldclient.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK, using LDClient in section \"Initialize the client\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go
@@ -11,7 +13,7 @@ description: "Go SDK, using LDClient in section \"Initialize the client\""
     ld.Config{
       // optional observability plugin, requires Go SDK v7.11+
       Plugins: []ldplugins.Plugin{
-        ldobserve.NewObservabilityPlugin()
+        ldobserve.NewObservabilityPlugin(),
       },
     }, 5*time.Second)
 ```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/initialize-the-client-go-sdk-using-ldscopedclient.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/initialize-the-client-go-sdk-using-ldscopedclient.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK, using LDScopedClient in section \"Initialize the client\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go
@@ -11,7 +13,7 @@ client, _ := ld.MakeCustomClient("YOUR_SDK_KEY",
   ld.Config{
     // optional observability plugin, requires Go SDK v7.11+
     Plugins: []ldplugins.Plugin{
-      ldobserve.NewObservabilityPlugin()
+      ldobserve.NewObservabilityPlugin(),
     },
   }, 5*time.Second)
 

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/install-the-sdk-go-sdk-v6.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/install-the-sdk-go-sdk-v6.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK v6 in section \"Install the SDK\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/install-the-sdk-go-sdk-v7.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/install-the-sdk-go-sdk-v7.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Go SDK v7 in section \"Install the SDK\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/use-go-contexts-with-ldscopedclient-add-ldscopedclient-to-go-context.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/use-go-contexts-with-ldscopedclient-add-ldscopedclient-to-go-context.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Add LDScopedClient to Go context in section \"Use Go contexts with LDScopedClient\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/use-go-contexts-with-ldscopedclient-example-using-ldscopedclient-in-go-context.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/use-go-contexts-with-ldscopedclient-example-using-ldscopedclient-in-go-context.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Example: Using LDScopedClient in Go context in section \"Use Go contexts with LDScopedClient\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/use-go-contexts-with-ldscopedclient-retrieve-ldscopedclient-from-go-context.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/use-go-contexts-with-ldscopedclient-retrieve-ldscopedclient-from-go-context.snippet.md
@@ -4,6 +4,8 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: "Retrieve LDScopedClient from Go context in section \"Use Go contexts with LDScopedClient\""
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
 ---
 
 ```go

--- a/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only.snippet.md
@@ -10,14 +10,13 @@ description: |
   The body is dropped inside `_wrappee = do { … }`. Doc fragments that
   show top-level constructs (`import …`, `name :: Type`, top-level
   bindings) won't fit inside a `do` block — Haskell wants those at the
-  module level. The harness pre-stage rewrite (in run.sh) splits the
-  body into top-level lines vs in-block lines using a simple
-  indentation rule: any line that begins with `import `, `data `,
-  `type `, `newtype `, `class `, `instance `, or matches `name :: …`
-  (a type-signature line) is lifted to the TOP_LIFT_MARKER above the
-  module, along with any subsequent line that starts at column 0
-  (top-level binding for that name). Everything else stays in the
-  `do` block.
+  module level. The harness pre-stage rewrite (in `run.sh`) splits the
+  body using `--BODY_BEGIN--` / `--BODY_END--` markers: any body line
+  at column 0 that begins with a top-level keyword (`import `, `data `,
+  `type `, `newtype `, `class `, `instance `) or matches a type-sig /
+  binding shape (`name ::` or `name =`) is lifted to the
+  `--TOP_LIFT_TARGET--` marker at module scope. Body residue stays
+  inline but is indented two spaces so it lands inside the do-block.
 inputs:
   body:
     type: string
@@ -28,17 +27,24 @@ validation:
 ---
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import qualified Data.Function as _LD
+import LaunchDarkly.Server
+import qualified Data.Function as LDStub
 
--- TOP_LIFT_MARKER
+--TOP_LIFT_TARGET--
 
 main :: IO ()
 main = putStrLn "feature flag evaluates to true"
 
+-- Body lives inside a do-block. The harness BB / BE markers
+-- delimit body content; the awk pre-step lifts top-level decls
+-- found there to the target marker above.
 _wrappee :: IO ()
 _wrappee = do
+--BODY_BEGIN--
 {{ body }}
+--BODY_END--
   return ()
 ```

--- a/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only.snippet.md
@@ -6,6 +6,18 @@ lang: haskell
 file: app/Main.hs
 description: |
   Parse-only validator for Haskell server SDK doc fragments.
+
+  The body is dropped inside `_wrappee = do { … }`. Doc fragments that
+  show top-level constructs (`import …`, `name :: Type`, top-level
+  bindings) won't fit inside a `do` block — Haskell wants those at the
+  module level. The harness pre-stage rewrite (in run.sh) splits the
+  body into top-level lines vs in-block lines using a simple
+  indentation rule: any line that begins with `import `, `data `,
+  `type `, `newtype `, `class `, `instance `, or matches `name :: …`
+  (a type-signature line) is lifted to the TOP_LIFT_MARKER above the
+  module, along with any subsequent line that starts at column 0
+  (top-level binding for that name). Everything else stays in the
+  `do` block.
 inputs:
   body:
     type: string
@@ -18,10 +30,15 @@ validation:
 ```haskell
 module Main where
 
+import qualified Data.Function as _LD
+
+-- TOP_LIFT_MARKER
+
 main :: IO ()
 main = putStrLn "feature flag evaluates to true"
 
 _wrappee :: IO ()
 _wrappee = do
 {{ body }}
+  return ()
 ```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v3-x.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v3-x.snippet.md
@@ -4,8 +4,6 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: "Haskell SDK v3.x in section \"Evaluate a context\""
-validation:
-  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v3-x.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v3-x.snippet.md
@@ -4,6 +4,8 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: "Haskell SDK v3.x in section \"Evaluate a context\""
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v4-0.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v4-0.snippet.md
@@ -4,8 +4,6 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: "Haskell SDK v4.0 in section \"Evaluate a context\""
-validation:
-  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v4-0.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/evaluate-a-context-haskell-sdk-v4-0.snippet.md
@@ -4,6 +4,8 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: "Haskell SDK v4.0 in section \"Evaluate a context\""
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/initialize-the-client-haskell.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/initialize-the-client-haskell.snippet.md
@@ -4,6 +4,8 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: "Haskell in section \"Initialize the client\""
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/install-the-sdk-haskell.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/install-the-sdk-haskell.snippet.md
@@ -4,6 +4,8 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: "Haskell in section \"Install the SDK\""
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
 ---
 
 ```haskell

--- a/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only-viewcontroller.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only-viewcontroller.snippet.md
@@ -1,0 +1,22 @@
+---
+id: ios-client-sdk/scaffolds/swift-syntax-only-viewcontroller
+sdk: ios-client-sdk
+kind: scaffold
+lang: swift
+file: ViewController.swift
+description: |
+  Companion ViewController for the swift-syntax-only scaffold. The
+  ios-client validator harness's `cp $SNIPPET_DIR/ViewController.swift`
+  step expects this file to exist; the syntax-only path doesn't
+  instantiate the controller (the EXAM-HELLO success line is
+  emitted by AppDelegate's didFinishLaunchingWithOptions).
+inputs: {}
+---
+
+```swift
+import UIKit
+
+class ViewController: UIViewController {
+    @IBOutlet weak var featureFlagLabel: UILabel!
+}
+```

--- a/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only.snippet.md
@@ -3,24 +3,59 @@ id: ios-client-sdk/scaffolds/swift-syntax-only
 sdk: ios-client-sdk
 kind: scaffold
 lang: swift
-file: Snippet.swift
+file: AppDelegate.swift
 description: |
   Parse-only validator for iOS client SDK doc fragments.
+
+  Outputs `Sources/AppDelegate.swift` (the path the ios-client
+  validator harness expects) plus a companion `Sources/ViewController.swift`
+  so xcodebuild has a complete project shape. The wrappee body lives
+  inside `_wrappee()`, an instance method on AppDelegate that's never
+  invoked at runtime — application(didFinishLaunchingWithOptions:)
+  returns true immediately and the XCTest case below asserts the
+  EXAM-HELLO success line is printed by the test itself, not by the
+  body.
+
+  The harness's existing import-lift Python pre-step will also
+  hoist any `import Foundation` / `import LaunchDarkly` lines that
+  came along in the body up to file scope.
 inputs:
   body:
     type: string
     description: The wrappee snippet's rendered body, inserted into the parse-only harness.
 validation:
   runtime: ios-client
-  entrypoint: Snippet.swift
+  entrypoint: AppDelegate.swift
+  companions:
+    - ios-client-sdk/scaffolds/swift-syntax-only-viewcontroller
 ---
 
 ```swift
+import UIKit
 import Foundation
+import LaunchDarkly
 
-func _wrappee() {
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // The XCTest case asserts the EXAM-HELLO success line is
+        // printed; the wrappee body is never invoked at runtime.
+        print("feature flag evaluates to true")
+        return true
+    }
+
+    // Stub so the wrappee body's `client.boolVariation(...)` etc.
+    // resolve at compile time. Never invoked.
+    var client: LDClient! = nil
+
+    // Wrappee body — references to client/context here resolve
+    // through the stubs above; xcodebuild type-checks but doesn't
+    // run.
+    @objc func _wrappee() {
 {{ body }}
+    }
 }
-
-print("feature flag evaluates to true")
 ```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v8-0-and-earlier-objective-c.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v8-0-and-earlier-objective-c.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objective-c
 description: "iOS SDK v8.0 and earlier (Objective-C) in section \"Background fetch\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v8-0-and-earlier-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v8-0-and-earlier-swift.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "iOS SDK v8.0 and earlier (Swift) in section \"Background fetch\""
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v8-0-and-earlier-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v8-0-and-earlier-swift.snippet.md
@@ -4,6 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "iOS SDK v8.0 and earlier (Swift) in section \"Background fetch\""
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v9-0-objective-c.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v9-0-objective-c.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objective-c
 description: "iOS SDK v9.0 (Objective-C) in section \"Background fetch\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v9-0-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/background-fetch-ios-sdk-v9-0-swift.snippet.md
@@ -4,6 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "iOS SDK v9.0 (Swift) in section \"Background fetch\""
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-objective-c-2.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-objective-c-2.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objective-c
 description: "Objective-C in section \"Evaluate a flag\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-objective-c.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-objective-c.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objective-c
 description: "Objective-C in section \"Evaluate a flag\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-swift-2.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-swift-2.snippet.md
@@ -4,6 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "Swift in section \"Evaluate a flag\""
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-swift-2.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-swift-2.snippet.md
@@ -13,7 +13,7 @@ let showFeature = client.boolVariation(forKey: "example-flag-key", defaultValue:
 
 if showFeature {
   // Application code to show the feature
-else {
+} else {
   // The code to run if the feature is off
 }
 ```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/evaluate-a-flag-swift.snippet.md
@@ -4,6 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "Swift in section \"Evaluate a flag\""
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/import-the-sdk-objective-c.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/import-the-sdk-objective-c.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objective-c
 description: "Objective-C in section \"Import the SDK\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/import-the-sdk-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/import-the-sdk-swift.snippet.md
@@ -4,6 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "Swift in section \"Import the SDK\""
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/import-the-sdk-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/import-the-sdk-swift.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "Swift in section \"Import the SDK\""
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v8-x-objective-c.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v8-x-objective-c.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objective-c
 description: "iOS SDK v8.x (Objective-C) in section \"Initialize the client\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v8-x-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v8-x-swift.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "iOS SDK v8.x (Swift) in section \"Initialize the client\""
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v8-x-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v8-x-swift.snippet.md
@@ -4,6 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "iOS SDK v8.x (Swift) in section \"Initialize the client\""
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v9-x-objective-c.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v9-x-objective-c.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objective-c
 description: "iOS SDK v9.x (Objective-C) in section \"Initialize the client\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v9-x-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v9-x-swift.snippet.md
@@ -4,6 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "iOS SDK v9.x (Swift) in section \"Initialize the client\""
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v9-x-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/initialize-the-client-ios-sdk-v9-x-swift.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "iOS SDK v9.x (Swift) in section \"Initialize the client\""
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/use-carthage-cartfile.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/use-carthage-cartfile.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "Cartfile in section \"Use Carthage\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/use-cocoapods-podfile.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/use-cocoapods-podfile.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: ruby
 description: "Podfile in section \"Use CocoaPods\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```ruby

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/use-the-swift-package-manager-package-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/use-the-swift-package-manager-package-swift.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: "Package.swift in section \"Use the Swift Package Manager\""
+# Bucket C: . See _sdk-docs-port-notes.md.
 ---
 
 ```swift

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -6,6 +6,16 @@ lang: java
 file: src/main/java/com/launchdarkly/Snippet.java
 description: |
   Parse-only validator for Java server SDK doc fragments.
+
+  The wrappee body is dropped inside `wrappee()` (where unresolved
+  `client.boolVariation(...)` calls don't fail compilation thanks to
+  the stub `client` field). Java forbids `import` statements inside a
+  method body, so any top-level `import …;` lines in the wrappee are
+  lifted out at validate-time by the harness's pre-stage rewrite —
+  `Snippet.java`'s body section reaches the compiler with imports
+  already at file scope. The IMPORT_LIFT_MARKER comment is the cue
+  the rewrite uses to splice extracted imports above the class
+  declaration.
 inputs:
   body:
     type: string
@@ -20,6 +30,7 @@ package com.launchdarkly;
 
 import com.launchdarkly.sdk.*;
 import com.launchdarkly.sdk.server.*;
+// IMPORT_LIFT_MARKER
 
 public class Snippet {
     // Stub instance the wrappee body refers to. Never used at runtime;

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/evaluate-a-context-java-sdk-v6-0.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/evaluate-a-context-java-sdk-v6-0.snippet.md
@@ -4,6 +4,8 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: "Java SDK v6.0+ in section \"Evaluate a context\""
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/initialize-the-client-java.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/initialize-the-client-java.snippet.md
@@ -4,6 +4,8 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: "Java in section \"Initialize the client\""
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-java.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-java.snippet.md
@@ -4,6 +4,8 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: "Java in section \"Install the SDK\""
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-xml.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-xml.snippet.md
@@ -4,6 +4,7 @@ sdk: java-server-sdk
 kind: reference
 lang: xml
 description: "XML in section \"Install the SDK\""
+# Bucket C: declarative XML <dependency> block; not executable Java. See _sdk-docs-port-notes.md.
 ---
 
 ```xml

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/using-the-java-sdk-in-osgi-xml.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/using-the-java-sdk-in-osgi-xml.snippet.md
@@ -4,6 +4,7 @@ sdk: java-server-sdk
 kind: reference
 lang: xml
 description: "XML in section \"Using the Java SDK in OSGi\""
+# Bucket C: declarative XML <dependency> block; not executable Java. See _sdk-docs-port-notes.md.
 ---
 
 ```xml

--- a/snippets/sdks/js-client-sdk/snippets/scaffolds/js-syntax-only.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/scaffolds/js-syntax-only.snippet.md
@@ -24,9 +24,16 @@ validation:
 ---
 
 ```javascript
-function _wrappee() {
+// Wrap in an async IIFE so the wrappee body can use top-level `await`
+// (e.g. `await client.waitForInitialization(...)`). tsdown's parser
+// rejects bare top-level `await` outside a module-scope `async` IIFE.
+// The body never executes — the IIFE's `if (false)` guard means the
+// EXAM-HELLO line is the only side effect.
+(async function _wrappee() {
+  if (false) {
 {{ body }}
-}
+  }
+})();
 
 document.body.textContent = 'feature flag evaluates to true';
 ```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/install-the-sdk-javascript-and-typescript-js-sdk-v3-7.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/install-the-sdk-javascript-and-typescript-js-sdk-v3-7.snippet.md
@@ -4,6 +4,11 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript and TypeScript, JS SDK v3.7+ in section \"Install the SDK\""
+# Bucket C: body shows three alternative `LDClient` import styles
+# (CommonJS require, ES module default import, TS import) as parallel
+# examples — but co-existing in one file they redeclare LDClient.
+# The docs intend "use one of these"; the validator can only see the
+# whole body. See _sdk-docs-port-notes.md.
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/install-the-sdk-javascript-and-typescript-js-sdk-v4-x.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/install-the-sdk-javascript-and-typescript-js-sdk-v4-x.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript and TypeScript, JS SDK v4.x in section \"Install the SDK\""
+# Bucket C: same shape as the v3.7 install snippet — three parallel
+# import styles in one body that redeclare LDClient. See
+# _sdk-docs-port-notes.md.
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/make-the-sdk-available-with-a-script-tag-loading-from-a-self-hosted-script.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/make-the-sdk-available-with-a-script-tag-loading-from-a-self-hosted-script.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: html
 description: "Loading from a self-hosted script in section \"Make the SDK available with a script tag\""
+# Bucket C: HTML <script src="…"> tag, not JS code; the
+# js-syntax-only scaffold writes the body as TypeScript and tsdown
+# rejects raw HTML. See _sdk-docs-port-notes.md.
 ---
 
 ```html

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/make-the-sdk-available-with-a-script-tag-loading-from-jsdelivr.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/make-the-sdk-available-with-a-script-tag-loading-from-jsdelivr.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: html
 description: "Loading from jsDelivr in section \"Make the SDK available with a script tag\""
+# Bucket C: HTML <script src="…"> tag, not JS code; the
+# js-syntax-only scaffold writes the body as TypeScript and tsdown
+# rejects raw HTML. See _sdk-docs-port-notes.md.
 ---
 
 ```html

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-add-a-polyfill-html.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-add-a-polyfill-html.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: html
 description: "HTML in section \"Add a polyfill\""
+# Bucket C: HTML <script src="…"> tag, not JS code; the
+# js-syntax-only scaffold writes the body as TypeScript and tsdown
+# rejects raw HTML. See _sdk-docs-port-notes.md.
 ---
 
 ```html

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-add-a-polyfill-javascript.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-add-a-polyfill-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Add a polyfill\""
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-document-queryselectorall-html.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-document-queryselectorall-html.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: html
 description: "HTML in section \"document.querySelectorAll()\""
+# Bucket C: HTML <script src="…"> tag, not JS code; the
+# js-syntax-only scaffold writes the body as TypeScript and tsdown
+# rejects raw HTML. See _sdk-docs-port-notes.md.
 ---
 
 ```html

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-document-queryselectorall-javascript.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-document-queryselectorall-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"document.querySelectorAll()\""
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-eventsource-loading-launchdarkly-s-eventsource-polyfill.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-eventsource-loading-launchdarkly-s-eventsource-polyfill.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: html
 description: "Loading LaunchDarkly's EventSource polyfill in section \"EventSource\""
+# Bucket C: HTML <script src="…"> tag, not JS code; the
+# js-syntax-only scaffold writes the body as TypeScript and tsdown
+# rejects raw HTML. See _sdk-docs-port-notes.md.
 ---
 
 ```html

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-promise-html.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-promise-html.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: html
 description: "HTML in section \"Promise\""
+# Bucket C: HTML <script src="…"> tag, not JS code; the
+# js-syntax-only scaffold writes the body as TypeScript and tsdown
+# rejects raw HTML. See _sdk-docs-port-notes.md.
 ---
 
 ```html

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-promise-javascript.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/requirements-polyfills-promise-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Promise\""
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-events-to-determine-when-the-client-is-ready-javascript-sdk-v3-x-v4-x.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-events-to-determine-when-the-client-is-ready-javascript-sdk-v3-x-v4-x.snippet.md
@@ -4,6 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript SDK, v3.x, v4.x in section \"Use events to determine when the client is ready\""
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-events-to-determine-when-the-client-is-ready-javascript-sdk-v4-x-typescript.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-events-to-determine-when-the-client-is-ready-javascript-sdk-v4-x-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: typescript
 description: "JavaScript SDK, v4.x (TypeScript) in section \"Use events to determine when the client is ready\""
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-promises-to-determine-when-the-client-is-ready-javascript-sdk-v4-x-typescript.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-promises-to-determine-when-the-client-is-ready-javascript-sdk-v4-x-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: typescript
 description: "JavaScript SDK, v4.x (TypeScript) in section \"Use promises to determine when the client is ready\""
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-promises-to-determine-when-the-client-is-ready-javascript-sdk-v4-x.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/use-promises-to-determine-when-the-client-is-ready-javascript-sdk-v4-x.snippet.md
@@ -4,6 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript SDK v4.x in section \"Use promises to determine when the client is ready\""
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/initialize-the-client-lua.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/initialize-the-client-lua.snippet.md
@@ -4,6 +4,8 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: "Lua in section \"Initialize the client\""
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/install-the-sdk-lua.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/install-the-sdk-lua.snippet.md
@@ -4,6 +4,8 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: "Lua in section \"Install the SDK\""
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
 ---
 
 ```lua

--- a/snippets/sdks/node-client-sdk/snippets/scaffolds/node-client-syntax-only.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/scaffolds/node-client-syntax-only.snippet.md
@@ -6,20 +6,56 @@ lang: javascript
 file: index.js
 description: |
   Parse-only validator for Node client SDK doc fragments.
+
+  The wrappee body is written to `fragment.mjs` and parse-checked
+  with `node --check` so top-level `import` statements parse as
+  module syntax. TypeScript-flavored snippets parse cleanly too:
+  `node --check` doesn't try to resolve TS type annotations, but a
+  body with non-JS-syntax (e.g. an interface declaration on its own
+  line) would fail. Our doc fragments use TS for type assertions
+  (`as boolean`, `: LDContext = …`) which `node --check` accepts
+  inside `.mjs` because TS-as-comment-stripped is still JS.
 inputs:
   body:
     type: string
-    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+    description: The wrappee snippet's rendered body, written to fragment.mjs and parse-checked.
 validation:
   runtime: node
   entrypoint: index.js
 ---
 
 ```javascript
-(async () => {
-  function _wrappee() {
+const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+// Stage the wrappee body as ESM so top-level `import` and `await`
+// statements parse as valid module syntax.
+const body = String.raw`
 {{ body }}
-  }
-  console.log('feature flag evaluates to true');
-})();
+`;
+
+// Strip simple TypeScript bits the doc fragments use (` as Type`
+// type assertions on identifiers, `: Type =` annotations on
+// `const`/`let`/`var`). Node's parser rejects these. The regexes
+// are intentionally narrow:
+//   - Type-annotated declarations: only when the identifier is
+//     followed by `: TYPE = …` (no balancing — TYPE may not contain
+//     `=` or `;`).
+//   - `as Type` assertions: only when preceded by `)` or an
+//     identifier (not by `*`, which would mis-erase
+//     `import * as Foo`).
+const erased = body
+  .replace(/(\bconst|\blet|\bvar)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*[^=;]+=/g, '$1 $2 =')
+  .replace(/([A-Za-z0-9_$\)])\s+as\s+[A-Za-z_$][A-Za-z0-9_$.<>\[\]\s|&,()]*/g, '$1');
+
+fs.writeFileSync('fragment.mjs', erased);
+
+try {
+  execFileSync(process.execPath, ['--check', 'fragment.mjs'], { stdio: 'pipe' });
+} catch (err) {
+  process.stderr.write(err.stderr || err.message);
+  process.exit(1);
+}
+
+console.log('feature flag evaluates to true');
 ```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-javascript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Initialize the client\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v3-javascript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v3-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: "Node.js SDK v3 (JavaScript) in section \"Initialize the client\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v3-typescript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v3-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: "Node.js SDK v3 (TypeScript) in section \"Initialize the client\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-typescript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: "TypeScript in section \"Initialize the client\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-javascript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Install the SDK\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-typescript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: "TypeScript in section \"Install the SDK\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/scaffolds/node-syntax-only.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/scaffolds/node-syntax-only.snippet.md
@@ -6,22 +6,48 @@ lang: javascript
 file: index.js
 description: |
   Parse-only validator for Node server SDK doc fragments.
+
+  The wrappee body is written to `fragment.mjs` (ESM) so top-level
+  `import` statements parse as valid module syntax, then `node --check`
+  is invoked to syntax-check it without actually resolving / running
+  the imports. A wrappee with malformed syntax fails the check; a
+  wrappee referencing unresolved symbols (`client`, `ldclient`, etc.)
+  passes because `--check` does not execute.
 inputs:
   body:
     type: string
-    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+    description: The wrappee snippet's rendered body, written to fragment.mjs and parse-checked.
 validation:
   runtime: node
   entrypoint: index.js
 ---
 
 ```javascript
-(async () => {
-  // Wrap the wrappee in a function that's never invoked. The presence of
-  // unresolved symbols won't trip a syntax error; only malformed JS will.
-  function _wrappee() {
+const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+// Stage the wrappee body as ESM so top-level `import` statements parse
+// as valid module syntax. `node --check` is purely syntactic; the
+// imported package names don't have to resolve.
+const body = String.raw`
 {{ body }}
-  }
-  console.log('feature flag evaluates to true');
-})();
+`;
+
+// Strip simple TS bits (`as Type` assertions, `: Type =`
+// declarations) before the parser sees them. Same approach as the
+// node-client scaffold; see comment there for regex shape rationale.
+const erased = body
+  .replace(/(\bconst|\blet|\bvar)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*[^=;]+=/g, '$1 $2 =')
+  .replace(/([A-Za-z0-9_$\)])\s+as\s+[A-Za-z_$][A-Za-z0-9_$.<>\[\]\s|&,()]*/g, '$1');
+
+fs.writeFileSync('fragment.mjs', erased);
+
+try {
+  execFileSync(process.execPath, ['--check', 'fragment.mjs'], { stdio: 'pipe' });
+} catch (err) {
+  process.stderr.write(err.stderr || err.message);
+  process.exit(1);
+}
+
+console.log('feature flag evaluates to true');
 ```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk.snippet.md
@@ -4,6 +4,8 @@ sdk: node-server-sdk
 kind: reference
 lang: javascript
 description: "Node.js SDK in section \"Initialize the client\""
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-node-js-sdk-v7-x.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-node-js-sdk-v7-x.snippet.md
@@ -4,6 +4,8 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: "Node.js SDK v7.x in section \"Install the SDK\""
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-node-js-sdk-v8-x.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-node-js-sdk-v8-x.snippet.md
@@ -4,6 +4,8 @@ sdk: node-server-sdk
 kind: reference
 lang: javascript
 description: "Node.js SDK v8.x+ in section \"Install the SDK\""
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/promises-and-async-javascript.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/promises-and-async-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-server-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Promises and async\""
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/promises-and-async-node-js-sdk-v7-x-and-later-javascript.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/promises-and-async-node-js-sdk-v7-x-and-later-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-server-sdk
 kind: reference
 lang: javascript
 description: "Node.js SDK v7.x and later (JavaScript) in section \"Promises and async\""
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/promises-and-async-node-js-sdk-v7-x-and-later-typescript.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/promises-and-async-node-js-sdk-v7-x-and-later-typescript.snippet.md
@@ -4,6 +4,8 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: "Node.js SDK v7.x and later (TypeScript) in section \"Promises and async\""
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 ---
 
 ```ts

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/install-the-sdk-php.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/install-the-sdk-php.snippet.md
@@ -4,6 +4,8 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: "PHP in section \"Install the SDK\""
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/using-guzzle-php-2.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/using-guzzle-php-2.snippet.md
@@ -4,6 +4,8 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: "PHP in section \"Using Guzzle\""
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/using-guzzle-php.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/using-guzzle-php.snippet.md
@@ -4,6 +4,9 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: "PHP in section \"Using Guzzle\""
+# Bucket C: body is shell composer commands mistagged as `php` in the
+# source MDX. The php-syntax-only scaffold can't parse shell. See
+# _sdk-docs-port-notes.md.
 ---
 
 ```php

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/considerations-with-worker-based-servers-python-sdk-v9-11.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/considerations-with-worker-based-servers-python-sdk-v9-11.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: "Python SDK v9.11+ in section \"Considerations with worker-based servers\""
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/evaluate-a-context-python-sdk-v8-0.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/evaluate-a-context-python-sdk-v8-0.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: "Python SDK v8.0+ in section \"Evaluate a context\""
+validation:
+  scaffold: python-server-sdk/scaffolds/with-test-data
 ---
 
 ```python
@@ -14,6 +16,8 @@ flag_value = client.variation("example-flag-key", context, False)
 
 if flag_value:
     # application code to show the feature
+    pass
 else:
     # the code to run if the feature is off
+    pass
 ```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/example-configure-uwsgi-python-uwsgi-initialization.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/example-configure-uwsgi-python-uwsgi-initialization.snippet.md
@@ -4,6 +4,10 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: "Python uWSGI initialization in section \"Example: Configure uWSGI\""
+validation:
+  # uWSGI isn't installable in the validator container; fall back to
+  # parse-only. Same constraint as the existing uwsgi-init binding.
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/https-proxy-python.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/https-proxy-python.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: "Python in section \"HTTPS proxy\""
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/init.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/init.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Initialize the singleton ldclient with the SDK key and the optional observability plugin.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/initialize-the-client-python.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/initialize-the-client-python.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: "Python in section \"Initialize the client\""
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/install-the-sdk-python.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/install-the-sdk-python.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: "Python in section \"Install the SDK\""
+validation:
+  scaffold: python-server-sdk/scaffolds/with-test-data
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/install.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/install.snippet.md
@@ -4,6 +4,7 @@ sdk: python-server-sdk
 kind: reference
 lang: shell
 description: pip install for the SDK plus the optional observability plugin (requires Python SDK v9.12+).
+# Bucket C: multi-line pip install body breaks the shell-install harness's per-package extractor. See _sdk-docs-port-notes.md.
 ---
 
 ```shell

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-mac.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-mac.snippet.md
@@ -4,6 +4,7 @@ sdk: python-server-sdk
 kind: reference
 lang: shell
 description: Mac/Linux HTTPS_PROXY environment variable.
+# Bucket C: bare shell export/set commands; not a package-manager install, no harness fits. See _sdk-docs-port-notes.md.
 ---
 
 ```shell

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-python.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-python.snippet.md
@@ -4,6 +4,8 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Set HTTPS_PROXY from inside Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-windows.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/proxy-env-windows.snippet.md
@@ -4,6 +4,7 @@ sdk: python-server-sdk
 kind: reference
 lang: shell
 description: Windows HTTPS_PROXY environment variable.
+# Bucket C: bare shell export/set commands; not a package-manager install, no harness fits. See _sdk-docs-port-notes.md.
 ---
 
 ```shell

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/initialize-the-client-and-identify-a-context-react-native-sdk-v10-x.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/initialize-the-client-and-identify-a-context-react-native-sdk-v10-x.snippet.md
@@ -4,6 +4,12 @@ sdk: react-native-client-sdk
 kind: reference
 lang: typescript
 description: "React Native SDK v10.x in section \"Initialize the client and identify a context\""
+# Bucket C: react-native validator harness expects a 2-file shape
+# (App.tsx + src/welcome.tsx) baked into the prebuilt jest project,
+# whereas the react-native-syntax-only scaffold writes a single App.js.
+# The harness needs a separate parse-only mode (or the scaffold needs
+# to output the App.tsx + src/welcome.tsx pair) before sdk-docs
+# fragments can validate. See _sdk-docs-port-notes.md.
 ---
 
 ```ts

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-react-native-sdk-v10.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-react-native-sdk-v10.snippet.md
@@ -4,6 +4,12 @@ sdk: react-native-client-sdk
 kind: reference
 lang: typescript
 description: "React Native SDK v10 in section \"Install the SDK\""
+# Bucket C: react-native validator harness expects a 2-file shape
+# (App.tsx + src/welcome.tsx) baked into the prebuilt jest project,
+# whereas the react-native-syntax-only scaffold writes a single App.js.
+# The harness needs a separate parse-only mode (or the scaffold needs
+# to output the App.tsx + src/welcome.tsx pair) before sdk-docs
+# fragments can validate. See _sdk-docs-port-notes.md.
 ---
 
 ```ts

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/evaluate-a-flag-brightscript-2.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/evaluate-a-flag-brightscript-2.snippet.md
@@ -4,6 +4,7 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: "BrightScript in section \"Evaluate a flag\""
+# Bucket C: no Roku BrightScript validator. See _sdk-docs-port-notes.md.
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/evaluate-a-flag-brightscript.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/evaluate-a-flag-brightscript.snippet.md
@@ -4,6 +4,7 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: "BrightScript in section \"Evaluate a flag\""
+# Bucket C: no Roku BrightScript validator. See _sdk-docs-port-notes.md.
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/initialize-an-interface-to-scenegraph-brightscript.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/initialize-an-interface-to-scenegraph-brightscript.snippet.md
@@ -4,6 +4,7 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: "BrightScript in section \"Initialize an interface to SceneGraph\""
+# Bucket C: no Roku BrightScript validator. See _sdk-docs-port-notes.md.
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/initialize-the-client-roku-sdk-v1-x-brightscript.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/initialize-the-client-roku-sdk-v1-x-brightscript.snippet.md
@@ -4,6 +4,7 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: "Roku SDK v1.x (BrightScript) in section \"Initialize the client\""
+# Bucket C: no Roku BrightScript validator. See _sdk-docs-port-notes.md.
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/initialize-the-client-roku-sdk-v2-0-brightscript.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/initialize-the-client-roku-sdk-v2-0-brightscript.snippet.md
@@ -4,6 +4,7 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: "Roku SDK v2.0 (BrightScript) in section \"Initialize the client\""
+# Bucket C: no Roku BrightScript validator. See _sdk-docs-port-notes.md.
 ---
 
 ```brightscript

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/initialize-the-client-ruby.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/initialize-the-client-ruby.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby in section \"Initialize the client\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/install-the-sdk-ruby.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/install-the-sdk-ruby.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby in section \"Install the SDK\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-a-rails-application-ruby.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-a-rails-application-ruby.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby in section \"Using a Rails application\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-passenger-ruby-passenger-initialization-with-rails.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-passenger-ruby-passenger-initialization-with-rails.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Passenger initialization with Rails in section \"Using Passenger\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-passenger-ruby-passenger-initialization.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-passenger-ruby-passenger-initialization.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Passenger initialization in section \"Using Passenger\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-puma-ruby-puma-initialization-with-rails.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-puma-ruby-puma-initialization-with-rails.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Puma initialization with Rails in section \"Using Puma\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-puma-ruby-puma-initialization.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-puma-ruby-puma-initialization.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Puma initialization in section \"Using Puma\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-spring-ruby-spring-initialization-with-rails.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-spring-ruby-spring-initialization-with-rails.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Spring initialization with Rails in section \"Using Spring\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-spring-ruby-spring-initialization.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-spring-ruby-spring-initialization.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Spring initialization in section \"Using Spring\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-unicorn-ruby-unicorn-initialization-with-rails.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-unicorn-ruby-unicorn-initialization-with-rails.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Unicorn initialization with Rails in section \"Using Unicorn\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-unicorn-ruby-unicorn-initialization.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/using-unicorn-ruby-unicorn-initialization.snippet.md
@@ -4,6 +4,8 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: "Ruby Unicorn initialization in section \"Using Unicorn\""
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
 ---
 
 ```ruby

--- a/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
@@ -16,12 +16,28 @@ validation:
 ---
 
 ```rust
-#[allow(dead_code, unused)]
-fn _wrappee() {
+// Pull SDK types into scope so doc-fragment bodies referencing
+// `ContextBuilder`, `MultiContextBuilder`, `Reference`, `Client`, etc.
+// resolve at compile time without requiring each fragment to repeat
+// the imports.
+#[allow(unused_imports)]
+use launchdarkly_server_sdk::{
+    AttributeValue, Client, ConfigBuilder, Context, ContextBuilder,
+    MultiContextBuilder, Reference,
+};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+#[allow(dead_code, unused, unused_variables, unused_must_use)]
+async fn _wrappee() -> Result<(), Box<dyn std::error::Error>> {
+    let client: Client = unimplemented!();
+    let context = ContextBuilder::new("stub").build()?;
 {{ body }}
+    Ok(())
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     println!("feature flag evaluates to true");
 }
 ```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/evaluate-a-context-rust.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/evaluate-a-context-rust.snippet.md
@@ -9,7 +9,7 @@ validation:
 ---
 
 ```rust
-let context = ContextBuilder::new("example-context-key").build();
+let context = ContextBuilder::new("example-context-key").build()?;
 let show_feature = client.bool_variation(&context, "example-flag-key", false);
 
 if show_feature {

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/evaluate-a-context-rust.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/evaluate-a-context-rust.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Rust in section \"Evaluate a context\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust
@@ -11,8 +13,8 @@ let context = ContextBuilder::new("example-context-key").build();
 let show_feature = client.bool_variation(&context, "example-flag-key", false);
 
 if show_feature {
-  # application code to show the feature
+  // application code to show the feature
 } else {
-  # the code to run if the feature is off
+  // the code to run if the feature is off
 }
 ```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-referencing-properties-of-an-attribute-object-1-0-syntax.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-referencing-properties-of-an-attribute-object-1-0-syntax.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax in section \"Referencing properties of an attribute object\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-alias-events-1-0-syntax.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-alias-events-1-0-syntax.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax in section \"Understanding changes to alias events\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-flag-evaluation-1-0-syntax.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-flag-evaluation-1-0-syntax.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax in section \"Understanding changes to flag evaluation\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-attribute-marked-private-for-one-context.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-attribute-marked-private-for-one-context.snippet.md
@@ -9,5 +9,5 @@ validation:
 ---
 
 ```rust
-ContextBuilder::new("example-context-key").add_private_attribute(Reference::new("/address/street"))
+ContextBuilder::new("example-context-key").add_private_attribute(Reference::new("/address/street"));
 ```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-attribute-marked-private-for-one-context.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-attribute-marked-private-for-one-context.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax, attribute marked private for one context in section \"Understanding changes to private attributes\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-two-attributes-marked-private-for-all-contexts.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-two-attributes-marked-private-for-all-contexts.snippet.md
@@ -4,8 +4,6 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax, two attributes marked private for all contexts in section \"Understanding changes to private attributes\""
-validation:
-  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-two-attributes-marked-private-for-all-contexts.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-changes-to-private-attributes-1-0-syntax-two-attributes-marked-private-for-all-contexts.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax, two attributes marked private for all contexts in section \"Understanding changes to private attributes\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-1-0-syntax-context-with-key.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-1-0-syntax-context-with-key.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax, context with key in section \"Understanding differences between users and contexts\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-1-0-syntax-multi-context.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-1-0-syntax-multi-context.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax, multi-context in section \"Understanding differences between users and contexts\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-1-0-syntax-single-context-builder.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-1-0-syntax-single-context-builder.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax, single context builder in section \"Understanding differences between users and contexts\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-beta-syntax-user-with-key.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-beta-syntax-user-with-key.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Beta syntax, user with key in section \"Understanding differences between users and contexts\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-beta-syntax-user-with-key.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-understanding-differences-between-users-and-contexts-beta-syntax-user-with-key.snippet.md
@@ -4,8 +4,6 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Beta syntax, user with key in section \"Understanding differences between users and contexts\""
-validation:
-  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-working-with-built-in-and-custom-attributes-1-0-syntax-context-with-attributes.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-working-with-built-in-and-custom-attributes-1-0-syntax-context-with-attributes.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "1.0 syntax, context with attributes in section \"Working with built-in and custom attributes\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-working-with-built-in-and-custom-attributes-beta-syntax-user-with-attributes.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-working-with-built-in-and-custom-attributes-beta-syntax-user-with-attributes.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Beta syntax, user with attributes in section \"Working with built-in and custom attributes\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-working-with-built-in-and-custom-attributes-beta-syntax-user-with-attributes.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/implementation-v1-working-with-built-in-and-custom-attributes-beta-syntax-user-with-attributes.snippet.md
@@ -4,8 +4,6 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Beta syntax, user with attributes in section \"Working with built-in and custom attributes\""
-validation:
-  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/initialize-the-client-rust-v3-0.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/initialize-the-client-rust-v3-0.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Rust, v3.0+ in section \"Initialize the client\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/initialize-the-client-rust-v3-0.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/initialize-the-client-rust-v3-0.snippet.md
@@ -4,8 +4,6 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Rust, v3.0+ in section \"Initialize the client\""
-validation:
-  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/initialize-the-client-rust.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/initialize-the-client-rust.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: "Rust in section \"Initialize the client\""
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 ---
 
 ```rust

--- a/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-sfc-syntax-only-main.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-sfc-syntax-only-main.snippet.md
@@ -1,0 +1,21 @@
+---
+id: vue-client-sdk/scaffolds/vue-sfc-syntax-only-main
+sdk: vue-client-sdk
+kind: scaffold
+lang: javascript
+file: src/main.js
+description: |
+  Companion main.js for the `vue-sfc-syntax-only` scaffold. Vite's
+  default entry is `src/main.js`; if we leave the Dockerfile's
+  placeholder `main.js` (which mounts the staged `App.vue`), the
+  body's `useLDClient` / `useLDFlag` calls fire at mount time with no
+  LDPlugin installed and the page renders an empty body instead of
+  the EXAM-HELLO line. Replacing main.js with this stub bypasses the
+  body-as-App render entirely and writes the success line directly to
+  the page, so the harness's DOM check matches as long as the staged
+  App.vue compiled cleanly.
+---
+
+```javascript
+document.body.textContent = 'feature flag evaluates to true';
+```

--- a/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-sfc-syntax-only.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-sfc-syntax-only.snippet.md
@@ -1,0 +1,33 @@
+---
+id: vue-client-sdk/scaffolds/vue-sfc-syntax-only
+sdk: vue-client-sdk
+kind: scaffold
+lang: vue
+file: src/App.vue
+description: |
+  Parse-only validator for Vue client SDK doc fragments whose body is
+  a Vue Single-File Component (SFC) -- typically a `<script setup>`
+  block followed by a `<template>` block. The body is staged as the
+  Vite project's `src/App.vue`, where `@vitejs/plugin-vue` compiles
+  the SFC and tsdown / vite catches syntax errors. The companion
+  `main.js` mounts an empty replacement App so the Vue runtime
+  doesn't try to evaluate the body's `useLDClient` etc. against a
+  missing LDPlugin -- success is signalled by the companion writing
+  the EXAM-HELLO line directly to the page.
+
+  For pure-JavaScript bodies (e.g. a `main.js` example wiring
+  `createApp(App).use(LDPlugin)`), use `vue-syntax-only` instead.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, written to src/App.vue.
+validation:
+  runtime: vue-client
+  entrypoint: src/App.vue
+  companions:
+    - vue-client-sdk/scaffolds/vue-sfc-syntax-only-main
+---
+
+```vue
+{{ body }}
+```

--- a/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-syntax-only-app.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-syntax-only-app.snippet.md
@@ -1,0 +1,21 @@
+---
+id: vue-client-sdk/scaffolds/vue-syntax-only-app
+sdk: vue-client-sdk
+kind: scaffold
+lang: vue
+file: src/App.vue
+description: |
+  Companion App.vue for `vue-syntax-only`. Provides a stable Vue
+  component the JS-body main.js can import (via the canonical
+  `import App from './App.vue'`) without supplying its own. The
+  component renders the EXAM-HELLO success line, but the syntax-only
+  scaffold's main.js sets `document.body.textContent` directly, so
+  this companion's render path is never the one the harness asserts
+  against — it exists purely to satisfy module resolution.
+---
+
+```vue
+<template>
+  <div>feature flag evaluates to true</div>
+</template>
+```

--- a/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-syntax-only.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/scaffolds/vue-syntax-only.snippet.md
@@ -3,22 +3,37 @@ id: vue-client-sdk/scaffolds/vue-syntax-only
 sdk: vue-client-sdk
 kind: scaffold
 lang: javascript
-file: src/snippet.js
+file: src/main.js
 description: |
-  Parse-only validator for Vue client SDK doc fragments.
+  Parse-only validator for Vue client SDK doc fragments whose body is
+  plain JavaScript (e.g. a `main.js` showing how to wire createApp +
+  LDPlugin). The body is staged as the Vite project's `src/main.js`
+  entrypoint, replacing the Dockerfile's placeholder; if it builds and
+  runs without throwing during mount, the companion `App.vue` renders
+  the EXAM-HELLO line.
+
+  For Vue SFC bodies (`<script setup>...</script><template>...</template>`),
+  use `vue-sfc-syntax-only` instead — those need to live at `src/App.vue`
+  with the Vite vue plugin handling the SFC compilation.
 inputs:
   body:
     type: string
-    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+    description: The wrappee snippet's rendered body, written to src/main.js.
 validation:
   runtime: vue-client
-  entrypoint: src/snippet.js
+  entrypoint: src/main.js
+  companions:
+    - vue-client-sdk/scaffolds/vue-syntax-only-app
 ---
 
 ```javascript
-(function _wrappee() {
-{{ body }}
-})();
+// Body is staged at module scope so its top-level
+// `import { ... } from '...';` directives resolve via Vite's
+// bundler. The body's runtime side-effects (createApp + mount)
+// may throw against an unconfigured LDPlugin; that's fine — the
+// EXAM-HELLO success line lives in the App.vue companion's
+// `<template>` and is rendered from a separate `index.html` body
+// element that the body never overwrites.
 
-console.log('feature flag evaluates to true');
+{{ body }}
 ```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/access-the-underlying-javascript-sdk-javascript.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/access-the-underlying-javascript-sdk-javascript.snippet.md
@@ -4,6 +4,8 @@ sdk: vue-client-sdk
 kind: reference
 lang: javascript
 description: "JavaScript in section \"Access the underlying JavaScript SDK\""
+validation:
+  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/access-the-underlying-javascript-sdk-javascript.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/access-the-underlying-javascript-sdk-javascript.snippet.md
@@ -5,7 +5,7 @@ kind: reference
 lang: javascript
 description: "JavaScript in section \"Access the underlying JavaScript SDK\""
 validation:
-  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
+  scaffold: vue-client-sdk/scaffolds/vue-sfc-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/configure-the-sdk-main-js.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/configure-the-sdk-main-js.snippet.md
@@ -4,6 +4,8 @@ sdk: vue-client-sdk
 kind: reference
 lang: javascript
 description: "main.js in section \"Configure the SDK\""
+validation:
+  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/determine-when-the-client-is-ready-vue.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/determine-when-the-client-is-ready-vue.snippet.md
@@ -5,7 +5,7 @@ kind: reference
 lang: html
 description: "Vue in section \"Determine when the client is ready\""
 validation:
-  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
+  scaffold: vue-client-sdk/scaffolds/vue-sfc-syntax-only
 ---
 
 ```html

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/determine-when-the-client-is-ready-vue.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/determine-when-the-client-is-ready-vue.snippet.md
@@ -4,6 +4,8 @@ sdk: vue-client-sdk
 kind: reference
 lang: html
 description: "Vue in section \"Determine when the client is ready\""
+validation:
+  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
 ---
 
 ```html

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-app-vue-vue-sdk-v2-x.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-app-vue-vue-sdk-v2-x.snippet.md
@@ -4,6 +4,8 @@ sdk: vue-client-sdk
 kind: reference
 lang: html
 description: "App.vue, Vue SDK v2.x in section \"Initialize the client and context\""
+validation:
+  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
 ---
 
 ```html

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-app-vue-vue-sdk-v2-x.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-app-vue-vue-sdk-v2-x.snippet.md
@@ -5,7 +5,7 @@ kind: reference
 lang: html
 description: "App.vue, Vue SDK v2.x in section \"Initialize the client and context\""
 validation:
-  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
+  scaffold: vue-client-sdk/scaffolds/vue-sfc-syntax-only
 ---
 
 ```html

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-main-js.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-main-js.snippet.md
@@ -4,6 +4,8 @@ sdk: vue-client-sdk
 kind: reference
 lang: javascript
 description: "main.js in section \"Initialize the client and context\""
+validation:
+  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-main-js.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/initialize-the-client-and-context-main-js.snippet.md
@@ -4,8 +4,6 @@ sdk: vue-client-sdk
 kind: reference
 lang: javascript
 description: "main.js in section \"Initialize the client and context\""
-validation:
-  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
 ---
 
 ```js

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/retrieve-flag-values-for-the-context-vue.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/retrieve-flag-values-for-the-context-vue.snippet.md
@@ -4,6 +4,8 @@ sdk: vue-client-sdk
 kind: reference
 lang: html
 description: "Vue in section \"Retrieve flag values for the context\""
+validation:
+  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
 ---
 
 ```html

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/retrieve-flag-values-for-the-context-vue.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/retrieve-flag-values-for-the-context-vue.snippet.md
@@ -5,7 +5,7 @@ kind: reference
 lang: html
 description: "Vue in section \"Retrieve flag values for the context\""
 validation:
-  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
+  scaffold: vue-client-sdk/scaffolds/vue-sfc-syntax-only
 ---
 
 ```html

--- a/snippets/validators/languages/dotnet-client/Dockerfile
+++ b/snippets/validators/languages/dotnet-client/Dockerfile
@@ -1,5 +1,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
+# python3 is used by the harness's USING_LIFT_MARKER pre-step
+# (see run.sh) to hoist `using …;` lines out of doc-fragment method
+# bodies before the C# compiler runs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /work
 
 COPY shared /harness-shared

--- a/snippets/validators/languages/dotnet-client/harness/run.sh
+++ b/snippets/validators/languages/dotnet-client/harness/run.sh
@@ -12,6 +12,33 @@ trap 'rm -rf "$WORK"' EXIT
 cp -r /snippet/. "$WORK/"
 cd "$WORK"
 
+# If the staged Program.cs (csharp-client-syntax-only scaffold)
+# contains the USING_LIFT_MARKER, lift any `using …;` line below the
+# marker up to the marker. C# wants `using` at file/namespace scope.
+if [ -f "$SNIPPET_ENTRYPOINT" ] && grep -q 'USING_LIFT_MARKER' "$SNIPPET_ENTRYPOINT"; then
+    python3 - "$SNIPPET_ENTRYPOINT" <<'PYEOF'
+import sys, re
+fp = sys.argv[1]
+with open(fp) as f:
+    lines = f.read().splitlines()
+marker_idx = next((i for i, l in enumerate(lines) if 'USING_LIFT_MARKER' in l), None)
+if marker_idx is None:
+    sys.exit(0)
+lift = []
+for i in range(marker_idx + 1, len(lines)):
+    s = lines[i].lstrip()
+    m = re.match(r'using\s+([A-Za-z_][A-Za-z0-9_.]*)\s*;\s*$', s)
+    if m:
+        if s not in lift:
+            lift.append(s.rstrip())
+        lines[i] = ''
+if lift:
+    lines = lines[:marker_idx] + lift + lines[marker_idx:]
+with open(fp, 'w') as f:
+    f.write('\n'.join(lines) + '\n')
+PYEOF
+fi
+
 cat > HelloDotNetClient.csproj <<'EOF'
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>

--- a/snippets/validators/languages/dotnet-server/Dockerfile
+++ b/snippets/validators/languages/dotnet-server/Dockerfile
@@ -1,5 +1,12 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
+# python3 is used by the harness's USING_LIFT_MARKER pre-step
+# (see run.sh) to hoist `using …;` lines out of doc-fragment method
+# bodies before the C# compiler runs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /work
 
 COPY shared /harness-shared

--- a/snippets/validators/languages/dotnet-server/harness/run.sh
+++ b/snippets/validators/languages/dotnet-server/harness/run.sh
@@ -12,6 +12,41 @@ trap 'rm -rf "$WORK"' EXIT
 cp -r /snippet/. "$WORK/"
 cd "$WORK"
 
+# If the staged Program.cs (csharp-syntax-only scaffold) contains the
+# USING_LIFT_MARKER, lift any `using …;` line that's between the
+# marker and the next class declaration up to the marker — C# wants
+# `using` at file or namespace scope, not inside method bodies. This
+# is the same idea as the JVM harness's IMPORT_LIFT_MARKER pre-step.
+if [ -f "$SNIPPET_ENTRYPOINT" ] && grep -q 'USING_LIFT_MARKER' "$SNIPPET_ENTRYPOINT"; then
+    python3 - "$SNIPPET_ENTRYPOINT" <<'PYEOF'
+import sys
+fp = sys.argv[1]
+with open(fp) as f:
+    lines = f.read().splitlines()
+marker_idx = next((i for i, l in enumerate(lines) if 'USING_LIFT_MARKER' in l), None)
+if marker_idx is None:
+    sys.exit(0)
+# Walk lines BELOW the marker. Collect any `using …;` line into a
+# block to splice ABOVE the marker, replace each lifted line with a
+# blank to preserve numbering. `using (var x = …)` C# statement form
+# is excluded by requiring a `;` immediately after the namespace path
+# (no `(`).
+import re
+lift = []
+for i in range(marker_idx + 1, len(lines)):
+    s = lines[i].lstrip()
+    m = re.match(r'using\s+([A-Za-z_][A-Za-z0-9_.]*)\s*;\s*$', s)
+    if m:
+        if s not in lift:
+            lift.append(s.rstrip())
+        lines[i] = ''
+if lift:
+    lines = lines[:marker_idx] + lift + lines[marker_idx:]
+with open(fp, 'w') as f:
+    f.write('\n'.join(lines) + '\n')
+PYEOF
+fi
+
 # .NET wants a project file; gonfalon's flow uses Visual Studio's "new
 # console app" wizard which creates one. We synthesize the minimum unless
 # the snippet's scaffold staged its own `.csproj` (e.g. an ASP.NET Core

--- a/snippets/validators/languages/flutter-client/harness/run.sh
+++ b/snippets/validators/languages/flutter-client/harness/run.sh
@@ -14,6 +14,59 @@ require_env LAUNCHDARKLY_CLIENT_SIDE_ID LAUNCHDARKLY_FLAG_KEY SNIPPET_ENTRYPOINT
 
 cp "/snippet/$SNIPPET_ENTRYPOINT" /opt/hello_flutter/lib/main.dart
 
+# If the staged main.dart uses the flutter-syntax-only scaffold's
+# body marker pair, lift any `import 'package:...';` directives from
+# inside the body up to module scope. Dart forbids imports inside a
+# function body, so doc fragments that show install-time imports
+# would otherwise fail to compile.
+if grep -qF -- '//IMPORT_LIFT_TARGET' /opt/hello_flutter/lib/main.dart; then
+    awk '
+    /^\/\/IMPORT_LIFT_TARGET$/ {
+        target_seen = 1;
+        pre[++npre] = $0;
+        target_index = npre;
+        next;
+    }
+    /^\/\/BODY_BEGIN$/ {
+        in_body = 1;
+        next;
+    }
+    /^\/\/BODY_END$/ {
+        in_body = 0;
+        body_done = 1;
+        next;
+    }
+    {
+        if (in_body) {
+            if ($0 ~ /^[ \t]*import [\x27"]/) {
+                sub(/^[ \t]+/, "", $0);
+                lift[++nlift] = $0;
+            } else {
+                rest[++nrest] = $0;
+            }
+        } else if (body_done) {
+            post[++npost] = $0;
+        } else if (target_seen) {
+            mid[++nmid] = $0;
+        } else {
+            pre[++npre] = $0;
+        }
+    }
+    END {
+        for (i = 1; i <= npre; i++) {
+            print pre[i];
+            if (target_seen && i == target_index) {
+                for (j = 1; j <= nlift; j++) print lift[j];
+            }
+        }
+        for (i = 1; i <= nmid; i++) print mid[i];
+        for (i = 1; i <= nrest; i++) print rest[i];
+        for (i = 1; i <= npost; i++) print post[i];
+    }
+    ' /opt/hello_flutter/lib/main.dart > /tmp/main.dart.lifted
+    mv /tmp/main.dart.lifted /opt/hello_flutter/lib/main.dart
+fi
+
 cd /opt/hello_flutter
 
 flutter build web --release --no-pub \

--- a/snippets/validators/languages/haskell-server/harness/run.sh
+++ b/snippets/validators/languages/haskell-server/harness/run.sh
@@ -10,6 +10,43 @@ require_env LAUNCHDARKLY_SDK_KEY LAUNCHDARKLY_FLAG_KEY SNIPPET_ENTRYPOINT
 
 cp "/snippet/$SNIPPET_ENTRYPOINT" /opt/hello-haskell/app/Main.hs
 
+# If the staged Main.hs contains the TOP_LIFT_MARKER comment (used by
+# the haskell-syntax-only scaffold), lift any line below the marker
+# that starts at column 0 with a top-level keyword (`import`, `data`,
+# `type`, `newtype`, `class`, `instance`) or that looks like a
+# type-signature / top-level binding (`identifier ::` or `identifier
+# =` at column 0) up above the marker. Haskell forbids these
+# constructs inside a `do` block, so doc fragments that mix top-level
+# decls with in-block code would otherwise fail to compile.
+if grep -q 'TOP_LIFT_MARKER' /opt/hello-haskell/app/Main.hs; then
+    awk '
+    BEGIN { state = "head"; }
+    /TOP_LIFT_MARKER/ {
+        # Buffer everything after the marker, then re-emit with lifted
+        # lines moved above the marker.
+        marker = NR;
+        print;
+        state = "body";
+        next;
+    }
+    state == "head" { print; next; }
+    state == "body" {
+        # First column non-whitespace and matches a top-level keyword?
+        if (match($0, /^(import |data |type |newtype |class |instance )/) ||
+            match($0, /^[A-Za-z_][A-Za-z0-9_'\'']*[[:space:]]+(::|=)/)) {
+            top[++ntop] = $0;
+        } else {
+            rest[++nrest] = $0;
+        }
+    }
+    END {
+        for (i = 1; i <= ntop; i++) print top[i];
+        for (i = 1; i <= nrest; i++) print rest[i];
+    }
+    ' /opt/hello-haskell/app/Main.hs > /tmp/Main.hs.lifted
+    mv /tmp/Main.hs.lifted /opt/hello-haskell/app/Main.hs
+fi
+
 cd /opt/hello-haskell
 cabal build >/tmp/build.log 2>&1 \
     || { cat /tmp/build.log >&2; exit 1; }

--- a/snippets/validators/languages/haskell-server/harness/run.sh
+++ b/snippets/validators/languages/haskell-server/harness/run.sh
@@ -10,38 +10,61 @@ require_env LAUNCHDARKLY_SDK_KEY LAUNCHDARKLY_FLAG_KEY SNIPPET_ENTRYPOINT
 
 cp "/snippet/$SNIPPET_ENTRYPOINT" /opt/hello-haskell/app/Main.hs
 
-# If the staged Main.hs contains the TOP_LIFT_MARKER comment (used by
-# the haskell-syntax-only scaffold), lift any line below the marker
-# that starts at column 0 with a top-level keyword (`import`, `data`,
-# `type`, `newtype`, `class`, `instance`) or that looks like a
-# type-signature / top-level binding (`identifier ::` or `identifier
-# =` at column 0) up above the marker. Haskell forbids these
-# constructs inside a `do` block, so doc fragments that mix top-level
-# decls with in-block code would otherwise fail to compile.
-if grep -q 'TOP_LIFT_MARKER' /opt/hello-haskell/app/Main.hs; then
+# If the staged Main.hs uses the haskell-syntax-only scaffold's body
+# marker pair, lift top-level constructs out of the body region. The
+# scaffold places the body inside a `_wrappee = do` block, so any
+# body line at column 0 that is `import`/`data`/`type`/`newtype`/
+# `class`/`instance` or matches a `name :: ...` / `name = ...`
+# top-level binding shape gets relocated to the TOP_LIFT_TARGET marker
+# at module scope. Body lines that aren't top-level shape stay in
+# place but get indented two spaces so they sit inside the do-block.
+# The scaffold's own bindings live above BODY_BEGIN and aren't touched.
+if grep -qF -- '--TOP_LIFT_TARGET--' /opt/hello-haskell/app/Main.hs; then
     awk '
-    BEGIN { state = "head"; }
-    /TOP_LIFT_MARKER/ {
-        # Buffer everything after the marker, then re-emit with lifted
-        # lines moved above the marker.
-        marker = NR;
-        print;
-        state = "body";
+    BEGIN { in_body = 0; target_seen = 0; body_done = 0; }
+    /^--TOP_LIFT_TARGET--$/ {
+        target_seen = 1;
+        pre[++npre] = $0;
+        target_index = npre;
         next;
     }
-    state == "head" { print; next; }
-    state == "body" {
-        # First column non-whitespace and matches a top-level keyword?
-        if (match($0, /^(import |data |type |newtype |class |instance )/) ||
-            match($0, /^[A-Za-z_][A-Za-z0-9_'\'']*[[:space:]]+(::|=)/)) {
-            top[++ntop] = $0;
+    /^--BODY_BEGIN--$/ {
+        in_body = 1;
+        next;
+    }
+    /^--BODY_END--$/ {
+        in_body = 0;
+        body_done = 1;
+        next;
+    }
+    {
+        if (in_body) {
+            if ($0 ~ /^(import |data |type |newtype |class |instance )/ ||
+                $0 ~ /^[A-Za-z_][A-Za-z0-9_'\'']*[ \t]+(::|=)/) {
+                lift[++nlift] = $0;
+            } else if ($0 ~ /^[^ \t]/ && length($0) > 0) {
+                rest[++nrest] = "  " $0;
+            } else {
+                rest[++nrest] = $0;
+            }
+        } else if (body_done) {
+            post[++npost] = $0;
+        } else if (target_seen) {
+            mid[++nmid] = $0;
         } else {
-            rest[++nrest] = $0;
+            pre[++npre] = $0;
         }
     }
     END {
-        for (i = 1; i <= ntop; i++) print top[i];
+        for (i = 1; i <= npre; i++) {
+            print pre[i];
+            if (target_seen && i == target_index) {
+                for (j = 1; j <= nlift; j++) print lift[j];
+            }
+        }
+        for (i = 1; i <= nmid; i++) print mid[i];
         for (i = 1; i <= nrest; i++) print rest[i];
+        for (i = 1; i <= npost; i++) print post[i];
     }
     ' /opt/hello-haskell/app/Main.hs > /tmp/Main.hs.lifted
     mv /tmp/Main.hs.lifted /opt/hello-haskell/app/Main.hs

--- a/snippets/validators/languages/jvm/Dockerfile
+++ b/snippets/validators/languages/jvm/Dockerfile
@@ -1,5 +1,12 @@
 FROM maven:3.9-eclipse-temurin-17
 
+# python3 is used by the harness's import-lift pre-step (see run.sh)
+# to hoist `import …;` lines out of the doc-fragment body before
+# javac runs — Java forbids imports inside method bodies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /work
 
 COPY shared /harness-shared

--- a/snippets/validators/languages/jvm/harness/run.sh
+++ b/snippets/validators/languages/jvm/harness/run.sh
@@ -27,6 +27,39 @@ if [ ! -f "$appfile" ]; then
     exit 1
 fi
 
+# If the staged file contains the IMPORT_LIFT_MARKER comment, lift any
+# `import …;` lines that appear after it (i.e. inside the wrappee body)
+# up to the marker line. Java doesn't permit imports inside method
+# bodies, so doc fragments that show install-time imports would
+# otherwise fail compilation. The lift is line-based and idempotent.
+if grep -q 'IMPORT_LIFT_MARKER' "$appfile"; then
+    python3 - "$appfile" <<'PYEOF'
+import sys
+fp = sys.argv[1]
+with open(fp) as f:
+    lines = f.read().splitlines()
+marker_idx = next((i for i, l in enumerate(lines) if 'IMPORT_LIFT_MARKER' in l), None)
+if marker_idx is None:
+    sys.exit(0)
+# Walk from marker downwards, collect any line whose lstrip() begins
+# with `import ` (and ends with `;` to avoid pulling Python-style
+# `import_x` identifiers). Replace each with a blank line in the body
+# and inject a deduplicated block above the marker.
+imports = []
+for i in range(marker_idx + 1, len(lines)):
+    stripped = lines[i].lstrip()
+    if stripped.startswith('import ') and stripped.rstrip().endswith(';'):
+        imp = stripped.rstrip()
+        if imp not in imports:
+            imports.append(imp)
+        lines[i] = ''
+if imports:
+    lines = lines[:marker_idx] + imports + lines[marker_idx:]
+with open(fp, 'w') as f:
+    f.write('\n'.join(lines) + '\n')
+PYEOF
+fi
+
 if ! head -1 "$appfile" | grep -q '^package '; then
     # Bodies that don't declare a package are presumed to want the
     # tutorial layout — same as before.


### PR DESCRIPTION
## Summary

Bind validators to **137 of 219** unbound `sdk-docs` snippets across 24 SDKs (skipping `react-client-sdk` per separate work), and document the remaining 82 in `_sdk-docs-port-notes.md` with structural reasons they can't validate against the current toolchain.

## Per-SDK before / after binding counts

| SDK | Before | After (bound) | Bucket C |
|---|---|---|---|
| python-server-sdk | 4 | 12 | 3 |
| node-server-sdk | 2 | 8 | 0 |
| node-client-sdk | 0 | 6 | 0 |
| go-server-sdk | 0 | 11 | 0 |
| java-server-sdk | 0 | 3 | 2 |
| ruby-server-sdk | 2 | 13 | 0 |
| php-server-sdk | 2 | 4 | 1 |
| lua-server-sdk | 2 | 4 | 0 |
| haskell-server-sdk | 0 | 4 | 0 |
| rust-server-sdk | 0 | 14 | 0 |
| flutter-client-sdk | 0 | 11 | 1 |
| electron-client-sdk | 0 | 8 | 0 |
| vue-client-sdk | 0 | 6 | 0 |
| js-client-sdk | 0 | 7 | 8 |
| dotnet-server-sdk | 0 | 6 | 2 |
| dotnet-client-sdk | 0 | 5 | 4 |
| cpp-client-sdk | 0 | 15 | 8 |
| cpp-server-sdk | 0 | 17 | 4 |
| ios-client-sdk | 0 | 7 | 10 |
| android-client-sdk | 0 | 0 | 10 |
| apex-server-sdk | 0 | 0 | 3 |
| erlang-server-sdk | 0 | 0 | 7 |
| react-native-client-sdk | 0 | 0 | 2 |
| roku-client-sdk | 0 | 0 | 5 |

## Scaffold extensions (per language)

- **node-server / node-client / vue / electron**: `node --check fragment.mjs` for ESM-aware parse-only with a small TS-erasure pass for `as Type` and `: Type =` decorations.
- **go-server**: in-process `go/parser.ParseFile` with a top-level / function-body splitter so doc fragments that mix `import (...)` with statement bodies validate.
- **haskell-server**: `TOP_LIFT_MARKER` + awk pre-step that hoists `import`, `data`, `class`, type sigs above the wrappee `do` block.
- **java-server, dotnet-server, dotnet-client**: `IMPORT_LIFT_MARKER` / `USING_LIFT_MARKER` + Python pre-step that lifts `import …;` / `using …;` lines out of the method body. Required `python3` in the JVM, dotnet-server, and dotnet-client Docker images.
- **dotnet-server, dotnet-client**: stub `client` typed as `dynamic` so doc fragments that call across SDK versions compile.
- **cpp-client, cpp-server**: wrappee is now a never-instantiated template so most type-checks defer to instantiation; SDK headers pulled at file scope.
- **ios-client**: rewritten swift-syntax-only to output `AppDelegate.swift` (matching the validator's hard-coded copy paths) with a new `swift-syntax-only-viewcontroller` companion.
- **flutter-client**: rewritten to render the EXAM-HELLO text as a real `Text` widget so the playwright DOM check sees it.

## Bug fixes (combined per repo convention)

- `go-server-sdk/sdk-docs/initialize-the-client-go-sdk-using-ldclient` and `…-using-ldscopedclient`: trailing-comma bug in `[]ldplugins.Plugin{ NewObservabilityPlugin() }`.
- `cpp-client-sdk/sdk-docs/initialize-the-client-c-sdk-v3-0-c-binding-4`: missing `}` before `else`.
- cpp-client and cpp-server namespace fragments: `# omitted` --> `// omitted` (C++ comment syntax).
- `python-server-sdk/sdk-docs/evaluate-a-context-python-sdk-v8-0`: empty if/else need `pass`.
- `rust-server-sdk/sdk-docs/evaluate-a-context-rust`: `# application code` --> `// application code`.

## CI matrix

Added rows for `cpp-client-sdk`, `cpp-server-sdk`, `electron-client-sdk`, `flutter-client-sdk`, `haskell-server-sdk`, `rust-server-sdk`. Existing rows preserved.

## Notable Bucket C reasons (full details in `_sdk-docs-port-notes.md`)

- **Apex / Roku**: no validator infrastructure; declarative non-executable fragments.
- **Android**: jvm validator pulls `launchdarkly-java-server-sdk` (server, not android-client which lives in Google Maven as an aar). A separate `android-client-validator` Docker image would be needed.
- **Erlang**: harness expects a gen_server module shape; syntax-only scaffold synthesizes a different module. Plus 3 of 7 fragments are mistagged (rebar.config / .app.src / Elixir).
- **React Native**: harness hard-codes a 2-file shape (App.tsx + src/welcome.tsx) baked into the prebuilt jest project; sdk-docs fragments don't match.
- **C++ v2.x**: Dockerfile pins cpp-sdks v3 (the v2 branch was deleted upstream); v2.x identifiers don't link.
- **iOS Objective-C / package manifests**: swift-syntax-only is Swift-only; Cartfile/Podfile/Package.swift are declarative.
- **JS multi-style imports**: `install-the-sdk-javascript-and-typescript-js-sdk-v3-7` shows three parallel import styles (CommonJS / ESM / TS) in one body that redeclare `LDClient`.
- **HTML script tags**: declarative loaders, not JS.
- **Shell exports / multi-line pip**: doesn't fit the package-manager-sniff contract.
- **ASP.NET Core / Framework C# fragments**: rely on Program.cs / Global.asax hosting context the syntax-only scaffold doesn't reproduce.
- **dotnet-client v3.x init**: `LdClient.Init(string, ...)` overload removed in v4; pinning v3 in parallel would diverge from the canonical "what should I install" guidance.

## Test plan

- [ ] CI: every matrix row passes (the syntax-only-bound rows don't need a real LD env, but the harness uniformly requires the env var)
- [ ] `go test ./...` passes (verified locally)
- [ ] Spot-check Bucket C entries: each has either a `# Bucket C: …` comment in the snippet's frontmatter referring to `_sdk-docs-port-notes.md`, or no `validation:` block at all
- [ ] Verify the existing CI rows (sdk-info init/install) still pass with no regressions from the scaffold changes

## Post-merge fix pass (commit `befd431`)

CI on the initial commit failed in 9 SDKs that had landed cleanly during the
agent's local smoke test. Root causes and fixes:

| SDK | What was failing | Fix |
|---|---|---|
| rust-server-sdk | `evaluate-a-context-rust` body missing `?` after `.build()`; one v1.0 private-attribute body missing `;`; v0.x / beta `User::*` and `EventProcessorBuilder` API shapes | Content fixes for the missing punctuation; Bucket C the v0.x / beta / EventProcessorBuilder fragments |
| haskell-server-sdk | TOP_LIFT_MARKER lifted the scaffold's own `main` and `_wrappee` bindings, breaking the do-block; eval bodies reference a free `client` ident that conflicts with the init snippet's top-level `client = makeClient $ …` | Replace marker with explicit `--TOP_LIFT_TARGET--` / `--BODY_BEGIN--` / `--BODY_END--` that scopes the lift to body content; re-indent body residue into the do-block; Bucket C the two evaluate-a-context fragments |
| js-client-sdk | Top-level `await` in 6 sdk-docs bodies broke tsdown parsing | Wrap wrappee in async IIFE with `if (false)` guard |
| flutter-client-sdk | `late final` stub locals were unassigned; v1.x / v2.x / v3.x init bodies reference removed identifiers; install-the-sdk-dart imports inside function body | Initialize stubs; nest body in inner block to allow re-declaration; add `IMPORT_LIFT_TARGET` pre-step in harness; Bucket C the v1-v3 init fragments |
| go-server-sdk | https-proxy fragment is a 2-line struct-field assignment that the splitter wrongly groups as a single top-level decl | Bucket C — would need a wrapper-function variant of the syntax-only scaffold |
| vue-client-sdk | Scaffold staged `src/snippet.js` but Vite project entrypoint is `src/main.js` (placeholder rendered "placeholder"); SFC bodies aren't valid JS | New `vue-sfc-syntax-only` scaffold writes `src/App.vue`, ships a stub `main.js` companion that emits the success line; updated `vue-syntax-only` writes `src/main.js` directly with App.vue companion. Bucket C the `@launchdarkly/observability` fragment (extra package not in Dockerfile) |
| electron-client-sdk | Scaffold staged `index.js` but the js-client harness only copies `src/*.ts` | Stage as `src/app.ts`, wrap in async IIFE |
| cpp-client-sdk / cpp-server-sdk | `client.X()` (native API) vs `LDClientSDK_X(client, …)` (C-binding) need different `client` types in the same scaffold; `ConfigBuilder` not in the included headers; bodies reference undeclared `config` / `maxwait` | Polymorphic `_AnyClient` stub with conversion operator + member templates; add `using namespace launchdarkly[::client_side\|::server_side]` inside wrappee; declare `config`, polymorphic `maxwait` (uint / chrono); pull in `config_builder.hpp`, `bindings/c/context*`, `chrono` / `future` / `string` / `value.hpp`. Content fix: cpp-server c-binding init used client-API `LDClient*` names, renamed to `LDServer*`. Content fix: cpp-server c-binding-4 missing `}` before `else` |
| ios-client-sdk install row | The install row had `snippet_skip: …/init` but no group filter, so it tried to validate the 7 newly-bound iOS sdk-docs fragments without macOS toolchain awareness | Add `--group=<sdk-info\|sdk-docs>` flag to `snippets validate`; split the iOS row into install (group=sdk-info, skip=init), init (snippet=init), and sdk-docs (group=sdk-docs) on macos-latest |

### New Bucket C entries (documented in `_sdk-docs-port-notes.md`)

- Haskell evaluate-a-context (v3.x and v4.0): free `client` ident conflicts with init snippet's top-level redeclaration
- Flutter v1.x / v2.x / v3.x init fragments: removed APIs (LDUser, LDConfigBuilder, LDClient.start, AutoEnvAttributes.Enabled)
- Rust v0.x / beta / v1.0 fragments: User::with_key, hashmap! macro, EventProcessorBuilder signature, &YOUR_SDK_KEY placeholder, fresh `async fn main`
- Vue main.js with `@launchdarkly/observability`: extra package not in vue-client validator's Dockerfile
- Go HTTPS-proxy: 2-line struct-field assignment isn't a complete unit for the syntax-only splitter

### Judgement calls
- Three new Vue scaffolds (`vue-syntax-only` rewrite, `vue-syntax-only-app` companion, `vue-sfc-syntax-only` + `vue-sfc-syntax-only-main` companion) instead of unbinding the SFC fragments. The SFC validation surface is a real win and the scaffold pair is small.
- Cpp polymorphic `_AnyClient` stub is heavier than a typedef but lets one scaffold cover both native and C-binding API styles.
- Did not rebuild cpp-sdks-v2 in a parallel docker image; the v2.x cpp fragments stay in Bucket C as documented.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI validation matrix behavior and multiple language harness/scaffold implementations, which could cause widespread CI failures or false positives/negatives in snippet validation.
> 
> **Overview**
> Adds a `--group` filter to `snippets validate` and updates the GitHub Actions matrix to split iOS validation (`sdk-info` vs `sdk-docs`) and run additional SDK rows that validate bound `sdk-docs` snippets.
> 
> Wires validation for many `sdk-docs` snippets by adding/adjusting syntax-only scaffolds and harness pre-processing (notably import/using lifting, ESM `node --check` parsing with minimal TS erasure, Go `go/parser` parsing with top-level splitting, Haskell body lifting, Flutter import lifting, and C++ never-instantiated template stubs), plus a few small snippet content fixes to make fragments compile/parse.
> 
> Introduces `_sdk-docs-port-notes.md` and annotates remaining unvalidated `sdk-docs` snippets with “Bucket C” reasons where the current toolchain can’t exercise them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50aa08968e43e4dcfaaff104b7dabf7b31db7436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->