### PR TITLE
feat(snippets): port AI Configs setup snippets from gonfalon

### DIFF
--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/context.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/context.snippet.md
@@ -1,0 +1,17 @@
+---
+id: dotnet-server-sdk/ai-configs/context
+sdk: dotnet-server-sdk
+kind: context
+lang: csharp
+file: dotnet-server-sdk/ai-configs/context.txt
+description: Build an evaluation context for dotnet-server-sdk AI Configs.
+---
+
+```csharp
+var context = Context.Builder("context-key-123abc")
+  .Name("Sandy")
+  .LastName("Smith")
+  .Email("sandy@example.com")
+  .Groups(["Google", "Microsoft"])
+  .Build();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -14,7 +14,7 @@ var fallbackConfig = LdAiConfig.New()
   .AddMessage("", Role.system)
   .SetModelProviderName("my-default-provider")
   .SetEnabled(true)
-  .Build()
+  .Build();
 
 var tracker = aiClient.Config(
   "{{configKey}}",

--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -1,0 +1,27 @@
+---
+id: dotnet-server-sdk/ai-configs/implementation
+sdk: dotnet-server-sdk
+kind: implementation
+lang: csharp
+file: dotnet-server-sdk/ai-configs/implementation.txt
+description: Resolve an AI Config with a fallback for dotnet-server-sdk.
+---
+
+```csharp
+var fallbackConfig = LdAiConfig.New()
+  .SetModelName("my-default-model")
+  .SetModelParam("temperature", LdValue.Of(0.8))
+  .AddMessage("", Role.system)
+  .SetModelProviderName("my-default-provider")
+  .SetEnabled(true)
+  .Build()
+
+var tracker = aiClient.Config(
+  "{{configKey}}",
+  context,
+  fallbackConfig,
+  new Dictionary<string, object> {
+    { "exampleCustomVariable", "exampleCustomValue" }
+  }
+);
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/import.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/import.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-server-sdk/ai-configs/import
+sdk: dotnet-server-sdk
+kind: import
+lang: csharp
+file: dotnet-server-sdk/ai-configs/import.txt
+description: Using statements for dotnet-server-sdk AI Configs.
+---
+
+```csharp
+using LaunchDarkly.Sdk.Server.Ai;
+using LaunchDarkly.Sdk.Server.Ai.Adapters;
+using LaunchDarkly.Sdk.Server.Ai.Config;
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/initialize.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/initialize.snippet.md
@@ -1,0 +1,16 @@
+---
+id: dotnet-server-sdk/ai-configs/initialize
+sdk: dotnet-server-sdk
+kind: initialize
+lang: csharp
+file: dotnet-server-sdk/ai-configs/initialize.txt
+description: Initialize the LaunchDarkly client and AI Configs client for dotnet-server-sdk.
+---
+
+```csharp
+var baseClient = new LdClient(Configuration.Builder(
+      "{{sdkkey}}"
+    )
+    .StartWaitTime(TimeSpan.FromSeconds(5)).Build());
+var aiClient = new LdAiClient(new LdClientAdapter(baseClient));
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/install.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/install.snippet.md
@@ -1,0 +1,13 @@
+---
+id: dotnet-server-sdk/ai-configs/install
+sdk: dotnet-server-sdk
+kind: install
+lang: shell
+file: dotnet-server-sdk/ai-configs/install.txt
+description: NuGet install commands for dotnet-server-sdk and the AI Configs add-on.
+---
+
+```shell
+Install-Package LaunchDarkly.ServerSdk
+Install-Package LaunchDarkly.ServerSdk.Ai
+```

--- a/snippets/sdks/go-server-sdk/snippets/ai-configs/context.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/ai-configs/context.snippet.md
@@ -1,0 +1,18 @@
+---
+id: go-server-sdk/ai-configs/context
+sdk: go-server-sdk
+kind: context
+lang: go
+file: go-server-sdk/ai-configs/context.txt
+description: Build an evaluation context for go-server-sdk AI Configs.
+---
+
+```go
+context := ldcontext.NewBuilder("context-key-123abc").
+    Kind("user").
+    Name("Sandy Smith").
+    SetString("email", "sandy@example.com").
+    SetValue("groups", ldvalue.ArrayOf(
+      ldvalue.String("Google"), ldvalue.String("Microsoft"))).
+    Build()
+```

--- a/snippets/sdks/go-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -1,0 +1,20 @@
+---
+id: go-server-sdk/ai-configs/implementation
+sdk: go-server-sdk
+kind: implementation
+lang: go
+file: go-server-sdk/ai-configs/implementation.txt
+description: Resolve an AI Config with a fallback for go-server-sdk.
+---
+
+```go
+fallbackValue := NewConfig().
+  Enable().
+  WithModelName("my-default-model").
+  WithModelParam("temperature", ldvalue.Float64(0.8)).
+  WithMessage("", datamodel.System).
+  WithProviderName("my-default-provider").
+  Build()
+
+cfg, tracker := aiClient.Config("{{configKey}}", context, fallbackValue, map[string]interface{}{"exampleCustomVariable": "exampleCustomValue"})
+```

--- a/snippets/sdks/go-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -8,7 +8,7 @@ description: Resolve an AI Config with a fallback for go-server-sdk.
 ---
 
 ```go
-fallbackValue := NewConfig().
+fallbackValue := ldai.NewConfig().
   Enable().
   WithModelName("my-default-model").
   WithModelParam("temperature", ldvalue.Float64(0.8)).

--- a/snippets/sdks/go-server-sdk/snippets/ai-configs/import.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/ai-configs/import.snippet.md
@@ -9,7 +9,12 @@ description: Import block for go-server-sdk AI Configs.
 
 ```go
 import (
+  "time"
+
+  "github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+  "github.com/launchdarkly/go-sdk-common/v3/ldvalue"
   ld "github.com/launchdarkly/go-server-sdk/v7"
   "github.com/launchdarkly/go-server-sdk/ldai"
+  "github.com/launchdarkly/go-server-sdk/ldai/datamodel"
 )
 ```

--- a/snippets/sdks/go-server-sdk/snippets/ai-configs/import.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/ai-configs/import.snippet.md
@@ -1,0 +1,15 @@
+---
+id: go-server-sdk/ai-configs/import
+sdk: go-server-sdk
+kind: import
+lang: go
+file: go-server-sdk/ai-configs/import.txt
+description: Import block for go-server-sdk AI Configs.
+---
+
+```go
+import (
+  ld "github.com/launchdarkly/go-server-sdk/v7"
+  "github.com/launchdarkly/go-server-sdk/ldai"
+)
+```

--- a/snippets/sdks/go-server-sdk/snippets/ai-configs/initialize.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/ai-configs/initialize.snippet.md
@@ -1,0 +1,13 @@
+---
+id: go-server-sdk/ai-configs/initialize
+sdk: go-server-sdk
+kind: initialize
+lang: go
+file: go-server-sdk/ai-configs/initialize.txt
+description: Initialize the LaunchDarkly client and AI Configs client for go-server-sdk.
+---
+
+```go
+client, _ := ld.MakeClient("{{sdkkey}}", 5*time.Second) // This is your SDK key
+aiClient, _ := ldai.NewClient(client)
+```

--- a/snippets/sdks/go-server-sdk/snippets/ai-configs/install.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/ai-configs/install.snippet.md
@@ -1,0 +1,13 @@
+---
+id: go-server-sdk/ai-configs/install
+sdk: go-server-sdk
+kind: install
+lang: shell
+file: go-server-sdk/ai-configs/install.txt
+description: go get commands for go-server-sdk and the AI Configs add-on.
+---
+
+```shell
+go get github.com/launchdarkly/go-server-sdk/v7
+go get github.com/launchdarkly/go-server-sdk/ldai
+```

--- a/snippets/sdks/node-server-sdk/snippets/ai-configs/context.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/ai-configs/context.snippet.md
@@ -1,0 +1,19 @@
+---
+id: node-server-sdk/ai-configs/context
+sdk: node-server-sdk
+kind: context
+lang: javascript
+file: node-server-sdk/ai-configs/context.txt
+description: Build an evaluation context for node-server-sdk AI Configs.
+---
+
+```javascript
+const context = {
+  kind: 'user',
+  key: 'user-key-123abc',
+  firstName: 'Sandy',
+  lastName: 'Smith',
+  email: 'sandy@example.com',
+  groups: ['Google', 'Microsoft'],
+};
+```

--- a/snippets/sdks/node-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -1,0 +1,27 @@
+---
+id: node-server-sdk/ai-configs/implementation
+sdk: node-server-sdk
+kind: implementation
+lang: javascript
+file: node-server-sdk/ai-configs/implementation.txt
+description: Resolve an AI Config with a fallback for node-server-sdk.
+---
+
+```javascript
+const fallbackConfig = {
+  model: {
+    name: 'my-default-model',
+    parameters: { temperature: 0.8 }
+  },
+  messages: [ { role: 'system', content: '' } ],
+  provider: { name: 'my-default-provider' },
+  enabled: true,
+};
+
+const aiConfig: LDAIConfig = aiClient.config(
+  '{{configKey}}',
+  context,
+  fallbackConfig,
+  { 'exampleCustomVariable': 'exampleCustomValue' },
+);
+```

--- a/snippets/sdks/node-server-sdk/snippets/ai-configs/import.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/ai-configs/import.snippet.md
@@ -8,6 +8,6 @@ description: Import statements for node-server-sdk AI Configs.
 ---
 
 ```javascript
-import { init, LDContext } from '@launchdarkly/node-server-sdk';
+import { init, LDClient } from '@launchdarkly/node-server-sdk';
 import { initAi, LDAIClient, LDAIConfig } from '@launchdarkly/server-sdk-ai';
 ```

--- a/snippets/sdks/node-server-sdk/snippets/ai-configs/import.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/ai-configs/import.snippet.md
@@ -1,0 +1,13 @@
+---
+id: node-server-sdk/ai-configs/import
+sdk: node-server-sdk
+kind: import
+lang: javascript
+file: node-server-sdk/ai-configs/import.txt
+description: Import statements for node-server-sdk AI Configs.
+---
+
+```javascript
+import { init, LDContext } from '@launchdarkly/node-server-sdk';
+import { initAi, LDAIClient, LDAIConfig } from '@launchdarkly/server-sdk-ai';
+```

--- a/snippets/sdks/node-server-sdk/snippets/ai-configs/initialize.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/ai-configs/initialize.snippet.md
@@ -1,0 +1,19 @@
+---
+id: node-server-sdk/ai-configs/initialize
+sdk: node-server-sdk
+kind: initialize
+lang: javascript
+file: node-server-sdk/ai-configs/initialize.txt
+description: Initialize the LaunchDarkly client and AI Configs client for node-server-sdk.
+---
+
+```javascript
+const ldClient: LDClient = init('{{sdkkey}}');
+try {
+await ldClient.waitForInitialization({ timeout: 10 });
+    // initialization complete
+} catch (error) {
+    // timeout or SDK failed to initialize
+}
+const aiClient: LDAIClient = initAi(ldClient);
+```

--- a/snippets/sdks/node-server-sdk/snippets/ai-configs/initialize.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/ai-configs/initialize.snippet.md
@@ -10,7 +10,7 @@ description: Initialize the LaunchDarkly client and AI Configs client for node-s
 ```javascript
 const ldClient: LDClient = init('{{sdkkey}}');
 try {
-await ldClient.waitForInitialization({ timeout: 10 });
+    await ldClient.waitForInitialization({ timeout: 10 });
     // initialization complete
 } catch (error) {
     // timeout or SDK failed to initialize

--- a/snippets/sdks/node-server-sdk/snippets/ai-configs/install.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/ai-configs/install.snippet.md
@@ -1,0 +1,13 @@
+---
+id: node-server-sdk/ai-configs/install
+sdk: node-server-sdk
+kind: install
+lang: shell
+file: node-server-sdk/ai-configs/install.txt
+description: npm install commands for node-server-sdk and the AI Configs add-on.
+---
+
+```shell
+npm install @launchdarkly/node-server-sdk
+npm install @launchdarkly/server-sdk-ai
+```

--- a/snippets/sdks/python-server-sdk/snippets/ai-configs/context.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/ai-configs/context.snippet.md
@@ -1,0 +1,17 @@
+---
+id: python-server-sdk/ai-configs/context
+sdk: python-server-sdk
+kind: context
+lang: python
+file: python-server-sdk/ai-configs/context.txt
+description: Build an evaluation context for python-server-sdk AI Configs.
+---
+
+```python
+context = Context.builder("context-key-123abc")
+    .set("firstName", "Sandy")
+    .set("lastName", "Smith")
+    .set("email", "sandy@example.com")
+    .set("groups", ["Google", "Microsoft"])
+    .build()
+```

--- a/snippets/sdks/python-server-sdk/snippets/ai-configs/context.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/ai-configs/context.snippet.md
@@ -8,10 +8,12 @@ description: Build an evaluation context for python-server-sdk AI Configs.
 ---
 
 ```python
-context = Context.builder("context-key-123abc")
+context = (
+    Context.builder("context-key-123abc")
     .set("firstName", "Sandy")
     .set("lastName", "Smith")
     .set("email", "sandy@example.com")
     .set("groups", ["Google", "Microsoft"])
     .build()
+)
 ```

--- a/snippets/sdks/python-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -1,0 +1,22 @@
+---
+id: python-server-sdk/ai-configs/implementation
+sdk: python-server-sdk
+kind: implementation
+lang: python
+file: python-server-sdk/ai-configs/implementation.txt
+description: Resolve an AI Config with a fallback for python-server-sdk.
+---
+
+```python
+fallback_value = AIConfig(
+  enabled=True,
+  model=ModelConfig(
+      name="my-default-model",
+      parameters={"temperature": 0.8},
+  ),
+  messages=[LDMessage(role="system", content="")],
+  provider=ProviderConfig(name="my-default-provider"),
+)
+
+config, tracker = aiclient.config('{{configKey}}', context, fallback_value, { 'example_custom_variable': 'example_custom_value'})
+```

--- a/snippets/sdks/python-server-sdk/snippets/ai-configs/import.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/ai-configs/import.snippet.md
@@ -1,0 +1,15 @@
+---
+id: python-server-sdk/ai-configs/import
+sdk: python-server-sdk
+kind: import
+lang: python
+file: python-server-sdk/ai-configs/import.txt
+description: Import statements for python-server-sdk AI Configs.
+---
+
+```python
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+from ldai.client import LDAIClient, AIConfig, ModelConfig, LDMessage, ProviderConfig
+```

--- a/snippets/sdks/python-server-sdk/snippets/ai-configs/initialize.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/ai-configs/initialize.snippet.md
@@ -1,0 +1,13 @@
+---
+id: python-server-sdk/ai-configs/initialize
+sdk: python-server-sdk
+kind: initialize
+lang: python
+file: python-server-sdk/ai-configs/initialize.txt
+description: Initialize the LaunchDarkly client and AI Configs client for python-server-sdk.
+---
+
+```python
+ldclient.set_config(Config("{{sdkkey}}"))
+aiclient = LDAIClient(ldclient.get())
+```

--- a/snippets/sdks/python-server-sdk/snippets/ai-configs/install.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/ai-configs/install.snippet.md
@@ -1,0 +1,13 @@
+---
+id: python-server-sdk/ai-configs/install
+sdk: python-server-sdk
+kind: install
+lang: shell
+file: python-server-sdk/ai-configs/install.txt
+description: pip install commands for python-server-sdk and the AI Configs add-on.
+---
+
+```shell
+pip install launchdarkly-server-sdk
+pip install launchdarkly-server-sdk-ai
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/ai-configs/context.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/ai-configs/context.snippet.md
@@ -1,0 +1,19 @@
+---
+id: ruby-server-sdk/ai-configs/context
+sdk: ruby-server-sdk
+kind: context
+lang: ruby
+file: ruby-server-sdk/ai-configs/context.txt
+description: Build an evaluation context for ruby-server-sdk AI Configs.
+---
+
+```ruby
+context = LaunchDarkly::LDContext.create({
+  key: 'context-key-123abc',
+  kind: 'user',
+  firstName: 'Sandy',
+  lastName: 'Smith',
+  email: 'sandy@example.com',
+  groups: ['Google', 'Microsoft']
+})
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -1,0 +1,22 @@
+---
+id: ruby-server-sdk/ai-configs/implementation
+sdk: ruby-server-sdk
+kind: implementation
+lang: ruby
+file: ruby-server-sdk/ai-configs/implementation.txt
+description: Resolve an AI Config with a fallback for ruby-server-sdk.
+---
+
+```ruby
+fallback_value = LaunchDarkly::AI::AIConfig.new(
+  enabled: true,
+  model: LaunchDarkly::AI::ModelConfig.new(
+    name: 'my-default-model',
+    parameters: { 'temperature' => 0.8 }
+  ),
+  messages: [{ role: 'system', content: '' }],
+  provider: { name: 'my-default-provider' }
+)
+
+ai_config = ai_client.config('{{configKey}}', context, fallback_value, { 'example_custom_variable' => 'example_custom_value' })
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/ai-configs/import.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/ai-configs/import.snippet.md
@@ -1,0 +1,13 @@
+---
+id: ruby-server-sdk/ai-configs/import
+sdk: ruby-server-sdk
+kind: import
+lang: ruby
+file: ruby-server-sdk/ai-configs/import.txt
+description: Require statements for ruby-server-sdk AI Configs.
+---
+
+```ruby
+require 'launchdarkly-server-sdk'
+require 'launchdarkly-server-sdk-ai'
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/ai-configs/initialize.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/ai-configs/initialize.snippet.md
@@ -1,0 +1,13 @@
+---
+id: ruby-server-sdk/ai-configs/initialize
+sdk: ruby-server-sdk
+kind: initialize
+lang: ruby
+file: ruby-server-sdk/ai-configs/initialize.txt
+description: Initialize the LaunchDarkly client and AI Configs client for ruby-server-sdk.
+---
+
+```ruby
+ld_client = LaunchDarkly::LDClient.new("{{sdkkey}}")
+ai_client = LaunchDarkly::AI::LDAIClient.new(ld_client)
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/ai-configs/install.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/ai-configs/install.snippet.md
@@ -1,0 +1,13 @@
+---
+id: ruby-server-sdk/ai-configs/install
+sdk: ruby-server-sdk
+kind: install
+lang: shell
+file: ruby-server-sdk/ai-configs/install.txt
+description: gem install commands for ruby-server-sdk and the AI Configs add-on.
+---
+
+```shell
+gem install launchdarkly-server-sdk
+gem install launchdarkly-server-sdk-ai
+```


### PR DESCRIPTION
## Summary

**Sibling PR (consumer adoption):** [launchdarkly/gonfalon#62560](https://github.com/launchdarkly/gonfalon/pull/62560).

Imports the per-SDK AI Configs setup content currently maintained inline in gonfalon's [`static/ld/components/AiConfigs/sdks/<lang>.tsx`](https://github.com/launchdarkly/gonfalon/tree/main/static/ld/components/AiConfigs/sdks) files into the canonical snippet store.

5 SDKs × 5 fragments = **25 files** under `snippets/sdks/<sdk-id>/snippets/ai-configs/`:

| SDK | gonfalon source | sdk-meta target |
|---|---|---|
| `dotnet-server-sdk` | `AiConfigs/sdks/dotnet.tsx` | `dotnet-server-sdk/snippets/ai-configs/` |
| `go-server-sdk` | `AiConfigs/sdks/go.tsx` | `go-server-sdk/snippets/ai-configs/` |
| `node-server-sdk` | `AiConfigs/sdks/nodejs.tsx` | `node-server-sdk/snippets/ai-configs/` |
| `python-server-sdk` | `AiConfigs/sdks/python.tsx` | `python-server-sdk/snippets/ai-configs/` |
| `ruby-server-sdk` | `AiConfigs/sdks/ruby.tsx` | `ruby-server-sdk/snippets/ai-configs/` |

Each SDK gets the same five fragments matching the gonfalon `SDKContentDefinition.instructions` shape:

- `install` — package-manager install commands for the base + AI SDK
- `import` — language-specific import / using / require statements
- `initialize` — \`LDClient\` + \`LDAIClient\` initialization
- `implementation` — fallback config + \`aiClient.config(...)\` resolution
- \`context\` — \`Context.builder(...)\` / equivalent example

## Validation deferred

**No \`validation:\` block on any of the new snippets.** This PR is the move-only step. Harness work for AI Configs lands in a follow-up:

- New per-SDK \`ai-init-runner\` scaffolds (or extension of existing \`init-runner\`) that pull in the AI SDK package alongside the base SDK.
- AI Config key wiring in CI (currently \`verify-hello-app\` only injects \`LAUNCHDARKLY_SDK_KEY\` + \`LAUNCHDARKLY_FLAG_KEY\` from SSM).
- Success criteria for AI Configs (e.g., \"got a non-fallback \`AIConfig\` back\" rather than the EXAM-HELLO line).
- Composition primitive: each SDK's 5 fragments compose into a single runnable program; the existing \`validation.companions\` field is the right tool but hasn't been exercised this way yet.

The schema already supports unverified snippets — the \`Validation\` struct's comment in \`internal/model/model.go\` explicitly notes \"absence means 'no validation for this snippet.'\" The dispatcher's \`isValidatable\` check (\`v.Runtime != \"\" || v.Entrypoint != \"\" || v.Scaffold != \"\"\`) skips them cleanly. Confirmed locally — \`go run ./cmd/snippets validate --sdk=python-server-sdk\` parses all new files and skips them as non-validatable.

## Placeholders

Body content preserves gonfalon's existing template placeholders (\`{{sdkkey}}\`, \`{{configKey}}\`) verbatim. These are consumer-side runtime substitution markers, not validation env-var mappings — when the harness PR adds \`validation.placeholders\`, those will translate to standard \`LAUNCHDARKLY_SDK_KEY\` / \`LAUNCHDARKLY_AI_CONFIG_KEY\` mappings and the bodies will be rewritten to use the existing \`'YOUR_SDK_KEY'\` convention used elsewhere in sdk-info snippets.

## Out of scope (follow-up)

[\`static/ld/components/AiConfigs/AiConfigOnboarding/agentIntegrationSnippets.ts\`](https://github.com/launchdarkly/gonfalon/blob/main/static/ld/components/AiConfigs/AiConfigOnboarding/agentIntegrationSnippets.ts) is **not** in this PR. That file carries 4 agent integrations × 4 model providers of runtime parameterization (per-provider default model id, per-provider langchain install variants) beyond standard \`{{sdkkey}}\`/\`{{configKey}}\` substitution. Modeling it as static \`.snippet.md\` needs a placeholder/defaults convention we should align on first — likely a separate small PR after this one merges.

## Test plan

- [x] All 25 files parse under \`KnownFields(true)\` (verified by \`go run ./cmd/snippets validate --sdk=<each>\` proceeding past the parse phase).
- [x] \`go test ./...\` passes.
- [ ] Reviewer: confirm the kind values (\`install\`, \`import\`, \`initialize\`, \`implementation\`, \`context\`) match what we want long-term, or if any should be renamed before downstream consumers (gonfalon \`extract.yaml\`, ld-docs, etc.) start referencing them.
- [ ] Reviewer: gonfalon-side adoption PR is **not** part of this change — it lives at [launchdarkly/gonfalon#62560](https://github.com/launchdarkly/gonfalon/pull/62560) and needs to wait for a \`snippets/v*\` release containing this content before its sync workflow becomes effective.

## Follow-ups (separate PRs)

1. **\`agentIntegrationSnippets.ts\` port** — once placeholder convention is decided.
2. **AI Configs harness** — \`ai-init-runner\` scaffolds, AI SDK package deps, AI-config-key CI wiring, fragment composition via \`validation.companions\`.
3. **Gonfalon adoption** — open as a draft at [launchdarkly/gonfalon#62560](https://github.com/launchdarkly/gonfalon/pull/62560). Adds the \`extract.yaml\` manifest + sync workflow for the AI Configs files and replaces the hand-maintained \`AiConfigs/sdks/<lang>.tsx\` strings with rendered \`.txt\` imports. Becomes effective on its first sync run after a \`snippets/v*\` release ships this content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation snippet files only; no runtime code or validation harness changes, so the main risk is incorrect/outdated example content for the SDKs.
> 
> **Overview**
> Ports AI Configs onboarding content into the snippet store by adding **25 new `.snippet.md` files** across `dotnet`, `go`, `node`, `python`, and `ruby` server SDKs under `snippets/.../ai-configs/`.
> 
> Each SDK now has `install`, `import`, `initialize`, `context`, and `implementation` fragments showing package install, client initialization, context construction, and resolving an AI Config with a fallback (using `{{sdkkey}}`/`{{configKey}}` placeholders).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e7de4ae96da8a17fda6cfceb14fe23bb52bbcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->