### PR TITLE
feat(snippets): port observability setup snippets from gonfalon

### DIFF
--- a/snippets/sdks/js-client-sdk/snippets/observability/import.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/observability/import.snippet.md
@@ -1,0 +1,14 @@
+---
+id: js-client-sdk/observability/import
+sdk: js-client-sdk
+kind: import
+lang: javascript
+file: js-client-sdk/observability/import.txt
+description: Import statements for js-client-sdk observability + session replay plugins.
+---
+
+```javascript
+import { LDClient } from 'launchdarkly-js-client-sdk'
+import Observability, { LDObserve } from '@launchdarkly/observability'
+import SessionReplay, { LDRecord } from '@launchdarkly/session-replay'
+```

--- a/snippets/sdks/js-client-sdk/snippets/observability/initialize.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/observability/initialize.snippet.md
@@ -1,0 +1,26 @@
+---
+id: js-client-sdk/observability/initialize
+sdk: js-client-sdk
+kind: initialize
+lang: javascript
+file: js-client-sdk/observability/initialize.txt
+description: Initialize js-client-sdk with observability + session replay plugins.
+---
+
+```javascript
+const client = LDClient.initialize('SDK_KEY', {
+  // … your existing config, if relevant
+  plugins: [
+    new Observability({
+      networkRecording: {
+        enabled: true,
+        recordHeadersAndBody: true
+      }
+    }),
+    new SessionReplay({
+      // Options: 'strict', 'default', 'none'
+      privacySetting: 'strict'
+    })
+  ],
+});
+```

--- a/snippets/sdks/js-client-sdk/snippets/observability/install-npm.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/observability/install-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: js-client-sdk/observability/install-npm
+sdk: js-client-sdk
+kind: install
+lang: shell
+file: js-client-sdk/observability/install-npm.txt
+description: npm install commands for js-client-sdk observability + session replay plugins.
+---
+
+```shell
+npm install launchdarkly-js-client-sdk
+npm install @launchdarkly/session-replay
+npm install @launchdarkly/observability
+```

--- a/snippets/sdks/js-client-sdk/snippets/observability/install-yarn.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/observability/install-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: js-client-sdk/observability/install-yarn
+sdk: js-client-sdk
+kind: install
+lang: shell
+file: js-client-sdk/observability/install-yarn.txt
+description: yarn install commands for js-client-sdk observability + session replay plugins.
+---
+
+```shell
+yarn add launchdarkly-js-client-sdk
+yarn add @launchdarkly/session-replay
+yarn add @launchdarkly/observability
+```

--- a/snippets/sdks/node-server-sdk/snippets/observability/import.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/observability/import.snippet.md
@@ -1,0 +1,13 @@
+---
+id: node-server-sdk/observability/import
+sdk: node-server-sdk
+kind: import
+lang: javascript
+file: node-server-sdk/observability/import.txt
+description: Import statements for node-server-sdk observability plugin.
+---
+
+```javascript
+import { init } from '@launchdarkly/node-server-sdk';
+import { Observability, LDObserve } from '@launchdarkly/observability-node';
+```

--- a/snippets/sdks/node-server-sdk/snippets/observability/initialize.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/observability/initialize.snippet.md
@@ -1,0 +1,20 @@
+---
+id: node-server-sdk/observability/initialize
+sdk: node-server-sdk
+kind: initialize
+lang: javascript
+file: node-server-sdk/observability/initialize.txt
+description: Initialize node-server-sdk with observability plugin.
+---
+
+```javascript
+const ldClient = init('SDK_KEY',
+  // … your existing config, if relevant
+  {
+  plugins: [
+    new Observability({
+      service: 'my-service-name',
+    }),
+  ],
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/observability/install-npm.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/observability/install-npm.snippet.md
@@ -1,0 +1,13 @@
+---
+id: node-server-sdk/observability/install-npm
+sdk: node-server-sdk
+kind: install
+lang: shell
+file: node-server-sdk/observability/install-npm.txt
+description: npm install commands for node-server-sdk observability plugin.
+---
+
+```shell
+npm install @launchdarkly/node-server-sdk
+npm install @launchdarkly/observability-node
+```

--- a/snippets/sdks/node-server-sdk/snippets/observability/install-yarn.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/observability/install-yarn.snippet.md
@@ -1,0 +1,13 @@
+---
+id: node-server-sdk/observability/install-yarn
+sdk: node-server-sdk
+kind: install
+lang: shell
+file: node-server-sdk/observability/install-yarn.txt
+description: yarn install commands for node-server-sdk observability plugin.
+---
+
+```shell
+yarn add @launchdarkly/node-server-sdk
+yarn add @launchdarkly/observability-node
+```

--- a/snippets/sdks/python-server-sdk/snippets/observability/import.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/observability/import.snippet.md
@@ -8,6 +8,8 @@ description: Import statements for python-server-sdk observability plugin.
 ---
 
 ```python
+import logging
+
 import ldclient
 from ldclient.config import Config
 from ldobserve import ObservabilityConfig, ObservabilityPlugin, observe

--- a/snippets/sdks/python-server-sdk/snippets/observability/import.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/observability/import.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/observability/import
+sdk: python-server-sdk
+kind: import
+lang: python
+file: python-server-sdk/observability/import.txt
+description: Import statements for python-server-sdk observability plugin.
+---
+
+```python
+import ldclient
+from ldclient.config import Config
+from ldobserve import ObservabilityConfig, ObservabilityPlugin, observe
+```

--- a/snippets/sdks/python-server-sdk/snippets/observability/initialize.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/observability/initialize.snippet.md
@@ -1,0 +1,31 @@
+---
+id: python-server-sdk/observability/initialize
+sdk: python-server-sdk
+kind: initialize
+lang: python
+file: python-server-sdk/observability/initialize.txt
+description: Initialize python-server-sdk with observability plugin and emit a sample log/span.
+---
+
+```python
+ldclient.set_config(Config(
+    'SDK_KEY',
+    # ... all existing options
+    plugins=[
+        ObservabilityPlugin(
+            ObservabilityConfig(
+                service_name="my-service-name",
+                service_version="1.0.0",
+            )
+        )
+    ]
+))
+
+# Record a log
+observe.record_log("Custom log message", logging.INFO, {"custom": "value"})
+
+# Start a span
+with observe.start_span("operation-name", attributes={"custom": "value"}) as span:
+    span.set_attribute("my-attribute", "my-value")
+    # Your code here
+```

--- a/snippets/sdks/python-server-sdk/snippets/observability/install-pip.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/observability/install-pip.snippet.md
@@ -1,0 +1,13 @@
+---
+id: python-server-sdk/observability/install-pip
+sdk: python-server-sdk
+kind: install
+lang: shell
+file: python-server-sdk/observability/install-pip.txt
+description: pip install commands for python-server-sdk observability plugin.
+---
+
+```shell
+pip install launchdarkly-server-sdk
+pip install launchdarkly-observability
+```

--- a/snippets/sdks/react-client-sdk/snippets/observability/import.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/observability/import.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-client-sdk/observability/import
+sdk: react-client-sdk
+kind: import
+lang: javascript
+file: react-client-sdk/observability/import.txt
+description: Import statements for react-client-sdk observability + session replay plugins.
+---
+
+```javascript
+import { withLDProvider } from 'launchdarkly-react-client-sdk';
+import Observability, { LDObserve } from '@launchdarkly/observability'
+import SessionReplay, { LDRecord } from '@launchdarkly/session-replay'
+```

--- a/snippets/sdks/react-client-sdk/snippets/observability/initialize.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/observability/initialize.snippet.md
@@ -9,7 +9,7 @@ description: Initialize react-client-sdk via withLDProvider with observability +
 
 ```javascript
 const LDProvider = withLDProvider({
-  clientSideId: 'SDK_KEY',
+  clientSideID: 'SDK_KEY',
   // … your existing config, if relevant
   options: {
     plugins: [

--- a/snippets/sdks/react-client-sdk/snippets/observability/initialize.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/observability/initialize.snippet.md
@@ -1,0 +1,29 @@
+---
+id: react-client-sdk/observability/initialize
+sdk: react-client-sdk
+kind: initialize
+lang: javascript
+file: react-client-sdk/observability/initialize.txt
+description: Initialize react-client-sdk via withLDProvider with observability + session replay plugins.
+---
+
+```javascript
+const LDProvider = withLDProvider({
+  clientSideId: 'SDK_KEY',
+  // … your existing config, if relevant
+  options: {
+    plugins: [
+      new Observability({
+        networkRecording: {
+          enabled: true,
+          recordHeadersAndBody: true
+        }
+      }),
+      new SessionReplay({
+        // Options: 'strict', 'default', 'none'
+        privacySetting: 'strict'
+      })
+    ]
+  }
+});
+```

--- a/snippets/sdks/react-client-sdk/snippets/observability/install-npm.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/observability/install-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-client-sdk/observability/install-npm
+sdk: react-client-sdk
+kind: install
+lang: shell
+file: react-client-sdk/observability/install-npm.txt
+description: npm install commands for react-client-sdk observability + session replay plugins.
+---
+
+```shell
+npm install launchdarkly-react-client-sdk
+npm install @launchdarkly/session-replay
+npm install @launchdarkly/observability
+```

--- a/snippets/sdks/react-client-sdk/snippets/observability/install-yarn.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/observability/install-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-client-sdk/observability/install-yarn
+sdk: react-client-sdk
+kind: install
+lang: shell
+file: react-client-sdk/observability/install-yarn.txt
+description: yarn install commands for react-client-sdk observability + session replay plugins.
+---
+
+```shell
+yarn add launchdarkly-react-client-sdk
+yarn add @launchdarkly/session-replay
+yarn add @launchdarkly/observability
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/observability/import.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/observability/import.snippet.md
@@ -1,0 +1,13 @@
+---
+id: react-native-client-sdk/observability/import
+sdk: react-native-client-sdk
+kind: import
+lang: javascript
+file: react-native-client-sdk/observability/import.txt
+description: Import statements for react-native-client-sdk observability plugin.
+---
+
+```javascript
+import { ReactNativeLDClient, AutoEnvAttributes } from '@launchdarkly/react-native-client-sdk';
+import { Observability } from '@launchdarkly/observability-react-native';
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/observability/initialize.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/observability/initialize.snippet.md
@@ -1,0 +1,24 @@
+---
+id: react-native-client-sdk/observability/initialize
+sdk: react-native-client-sdk
+kind: initialize
+lang: javascript
+file: react-native-client-sdk/observability/initialize.txt
+description: Initialize react-native-client-sdk with observability plugin.
+---
+
+```javascript
+const client = new ReactNativeLDClient(
+    'SDK_KEY',
+    // … your existing config, if relevant
+    AutoEnvAttributes.Enabled,
+    {
+      plugins: [
+        new Observability({
+          serviceName: 'example-service',
+          serviceVersion: 'example-sha'
+        })
+      ],
+    }
+);
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/observability/install-npm.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/observability/install-npm.snippet.md
@@ -1,0 +1,13 @@
+---
+id: react-native-client-sdk/observability/install-npm
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/observability/install-npm.txt
+description: npm install commands for react-native-client-sdk observability plugin.
+---
+
+```shell
+npm install @launchdarkly/react-native-client-sdk
+npm install @launchdarkly/observability-react-native
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/observability/install-yarn.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/observability/install-yarn.snippet.md
@@ -1,0 +1,13 @@
+---
+id: react-native-client-sdk/observability/install-yarn
+sdk: react-native-client-sdk
+kind: install
+lang: shell
+file: react-native-client-sdk/observability/install-yarn.txt
+description: yarn install commands for react-native-client-sdk observability plugin.
+---
+
+```shell
+yarn add @launchdarkly/react-native-client-sdk
+yarn add @launchdarkly/observability-react-native
+```

--- a/snippets/sdks/vue-client-sdk/snippets/observability/import.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/observability/import.snippet.md
@@ -1,0 +1,16 @@
+---
+id: vue-client-sdk/observability/import
+sdk: vue-client-sdk
+kind: import
+lang: javascript
+file: vue-client-sdk/observability/import.txt
+description: Import statements for vue-client-sdk observability + session replay plugins.
+---
+
+```javascript
+import { createApp } from 'vue'
+import App from './App.vue'
+import { LDPlugin } from 'launchdarkly-vue-client-sdk'
+import Observability, { LDObserve } from '@launchdarkly/observability'
+import SessionReplay, { LDRecord } from '@launchdarkly/session-replay'
+```

--- a/snippets/sdks/vue-client-sdk/snippets/observability/initialize.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/observability/initialize.snippet.md
@@ -1,0 +1,31 @@
+---
+id: vue-client-sdk/observability/initialize
+sdk: vue-client-sdk
+kind: initialize
+lang: javascript
+file: vue-client-sdk/observability/initialize.txt
+description: Initialize vue-client-sdk with observability + session replay plugins.
+---
+
+```javascript
+const app = createApp(App)
+app.use(LDPlugin, {
+  clientSideID: 'SDK_KEY',
+  deferInitialization: true,
+  options: {
+    plugins: [
+      new Observability({
+        networkRecording: {
+          enabled: true,
+          recordHeadersAndBody: true
+        }
+      }),
+      new SessionReplay({
+        // Options: 'strict', 'default', 'none'
+        privacySetting: 'strict'
+      })
+    ]
+  }
+})
+app.mount('#app')
+```

--- a/snippets/sdks/vue-client-sdk/snippets/observability/install-npm.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/observability/install-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vue-client-sdk/observability/install-npm
+sdk: vue-client-sdk
+kind: install
+lang: shell
+file: vue-client-sdk/observability/install-npm.txt
+description: npm install commands for vue-client-sdk observability + session replay plugins.
+---
+
+```shell
+npm install launchdarkly-vue-client-sdk
+npm install @launchdarkly/session-replay
+npm install @launchdarkly/observability
+```

--- a/snippets/sdks/vue-client-sdk/snippets/observability/install-yarn.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/observability/install-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vue-client-sdk/observability/install-yarn
+sdk: vue-client-sdk
+kind: install
+lang: shell
+file: vue-client-sdk/observability/install-yarn.txt
+description: yarn install commands for vue-client-sdk observability + session replay plugins.
+---
+
+```shell
+yarn add launchdarkly-vue-client-sdk
+yarn add @launchdarkly/session-replay
+yarn add @launchdarkly/observability
+```


### PR DESCRIPTION
## Summary

**Sibling PR (consumer adoption):** [launchdarkly/gonfalon#62557](https://github.com/launchdarkly/gonfalon/pull/62557).

Imports the per-SDK observability + session replay setup snippets currently maintained as hand-edited `.txt` files under [`packages/observability/src/components/ObservabilitySetupInstructions/assetSource/`](https://github.com/launchdarkly/gonfalon/tree/main/packages/observability/src/components/ObservabilitySetupInstructions/assetSource) in gonfalon.

6 SDKs × 3-4 fragments = **23 files** under `snippets/sdks/<sdk-id>/snippets/observability/`:

| SDK | gonfalon source dir | sdk-meta target | files |
|---|---|---|---|
| `js-client-sdk` | `assetSource/javascript/` | `js-client-sdk/snippets/observability/` | import, initialize, install-npm, install-yarn |
| `node-server-sdk` | `assetSource/nodejs/` | `node-server-sdk/snippets/observability/` | import, initialize, install-npm, install-yarn |
| `python-server-sdk` | `assetSource/python/` | `python-server-sdk/snippets/observability/` | import, initialize, install-pip |
| `react-native-client-sdk` | `assetSource/reactNative/` | `react-native-client-sdk/snippets/observability/` | import, initialize, install-npm, install-yarn |
| `react-client-sdk` | `assetSource/reactWeb/` | `react-client-sdk/snippets/observability/` | import, initialize, install-npm, install-yarn |
| `vue-client-sdk` | `assetSource/vue/` | `vue-client-sdk/snippets/observability/` | import, initialize, install-npm, install-yarn |

The shape is structurally identical to what sdk-info had pre-port (hand-maintained `.txt` imported via Vite's `?raw` pattern). The port is mechanical: gonfalon's `assetSource/<lang>/<kind><Lang>O11y.txt` maps 1:1 to `snippets/sdks/<sdk-id>/snippets/observability/<kind>.snippet.md` with the body wrapped in a fenced code block and frontmatter added.

## Validation deferred

**No \`validation:\` block on any of the new snippets.** This PR is the move-only step. Harness work for observability lands in a follow-up:

- Per-SDK \`o11y-init-runner\` scaffolds that pull in \`@launchdarkly/observability\` + \`@launchdarkly/session-replay\` (or per-language equivalents — \`@launchdarkly/observability-node\`, \`launchdarkly-observability\` for Python, \`@launchdarkly/observability-react-native\`).
- Success-criteria decision: cheap path is \"init didn't throw\" (works under existing docker harnesses); rigorous path is \"an OTLP span was actually emitted\" (requires a fake collector in the docker network).
- Browser-context validation for js-client / react-client / vue-client may need a real headless browser if we want to exercise plugin features that depend on browser APIs (\`PerformanceObserver\`, network capture). \"Init didn't throw\" doesn't need this.

The schema already supports unverified snippets — \`Validation\`'s docstring in \`internal/model/model.go\` notes \"absence means 'no validation for this snippet.'\" The dispatcher's \`isValidatable\` check (\`v.Runtime != \"\" || v.Entrypoint != \"\" || v.Scaffold != \"\"\`) skips them. Confirmed locally — \`go run ./cmd/snippets validate --sdk=js-client-sdk\` parses all new files and skips them as non-validatable; \`go test ./...\` passes.

## Placeholders

The SDK key placeholder is preserved verbatim as the literal \`'SDK_KEY'\` string the gonfalon files already use. When the harness lands it becomes a \`validation.placeholders\` mapping to \`LAUNCHDARKLY_SDK_KEY\` (server-key SDKs) / \`LAUNCHDARKLY_CLIENT_SIDE_ID\` (browser/Vue/React) / \`LAUNCHDARKLY_MOBILE_KEY\` (React Native) per SDK.

## Test plan

- [x] All 23 files parse under \`KnownFields(true)\` (verified by \`go run ./cmd/snippets validate --sdk=<each>\` proceeding past the parse phase).
- [x] \`go test ./...\` passes.
- [ ] Reviewer: confirm the kind values (\`import\`, \`initialize\`, \`install\`) and naming convention (\`install-npm\` / \`install-yarn\` / \`install-pip\` to match existing sdk-info pattern) are what we want long-term, before downstream consumers start referencing them.
- [ ] Reviewer: gonfalon-side adoption PR is **not** part of this change — it lives at [launchdarkly/gonfalon#62557](https://github.com/launchdarkly/gonfalon/pull/62557) and needs to wait for a \`snippets/v*\` release containing this content before its sync workflow becomes effective.

## Follow-ups (separate PRs)

1. **Observability harness** — \`o11y-init-runner\` scaffolds, plugin package deps, success-criteria decision (init-only vs OTLP collector). Composition for the multi-fragment shape via existing \`validation.companions\` field.
2. **Gonfalon adoption** — open as a draft at [launchdarkly/gonfalon#62557](https://github.com/launchdarkly/gonfalon/pull/62557). Adds the \`extract.yaml\` manifest mapping these snippet IDs back to the existing \`packages/observability/.../assetSource/<lang>/*.txt\` paths so the existing \`?raw\` imports keep working transparently. Becomes effective on its first sync run after a \`snippets/v*\` release ships this content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new documentation snippet files only (no runtime code changes), so risk is limited to potential snippet metadata/content errors impacting downstream rendering or validation expectations.
> 
> **Overview**
> Adds a new set of `observability` snippet fragments across six SDKs (JS client, React, Vue, Node, React Native, Python) covering **package install**, **imports**, and **initialization** examples (plus session replay where applicable).
> 
> Each snippet is introduced as a `.snippet.md` with frontmatter (`id`, `sdk`, `kind`, `lang`, `file`, `description`) and a fenced code block, expanding the repository’s snippet catalog for observability setup guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4bd294fa57f69e4f882bac13ab0f30d46f695b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->