### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Every run of the `Lint PR title` workflow on this repo has hit `startup_failure` since 2026-05-07 16:46 UTC — across `metadata-update`, `release-please--branches--main`, `skz/react-snippet`, and now `rlamb/aiconfig-observability-validation`. Example: https://github.com/launchdarkly/sdk-meta/actions/runs/25569345111

## Root cause

The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml` was updated in launchdarkly/gh-actions#86 to declare `permissions: pull-requests: read` at the job level. A reusable workflow can only request a subset of the permissions the caller has granted, so when the caller declares no `permissions` block at all, the called job fails to start.

This caller (`.github/workflows/lint-pr-title.yml`) had no top-level `permissions`, so the reusable workflow's permission request couldn't be satisfied → `startup_failure` on every run.

## Fix

Add `permissions: pull-requests: read` at the workflow level so the reusable workflow can acquire it. Same scope the reusable workflow itself declares — no extra surface granted.

## Test plan

- [ ] Workflow run on this PR exits `success` rather than `startup_failure`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts GitHub Actions permissions to allow a reusable workflow to start; no product code or data paths are affected.
> 
> **Overview**
> Fixes `Lint PR title` workflow `startup_failure` by explicitly granting **`pull-requests: read`** at the workflow level, satisfying the permission requirements of the reused `launchdarkly/gh-actions` lint workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d4968bc63448ce1473ea6307bae5df76af2aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->