### PR TITLE
feat(snippets): add dotnet-server-sdk/sdk-docs/install-the-sdk-shell canonical

### DIFF
--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,12 @@
+---
+id: dotnet-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: dotnet-server-sdk
+kind: reference
+lang: shell
+description: "Shell in section \"Install the SDK\""
+---
+
+```shell
+Install-Package LaunchDarkly.ServerSdk
+dotnet add package LaunchDarkly.Observability
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert a `SDK_SNIPPET:RENDER` marker pointing at this canonical.

## Snippet

Path: `snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md`
ID: `dotnet-server-sdk/sdk-docs/install-the-sdk-shell`

Body (verbatim from `fern/topics/sdk/server-side/dotnet/index.mdx` line 80-83):

```shell
Install-Package LaunchDarkly.ServerSdk
dotnet add package LaunchDarkly.Observability
```

## Where the marker lands

After this merges, ld-docs PR #7592 inserts a marker before the existing `<CodeBlock title='Shell'>` at `fern/topics/sdk/server-side/dotnet/index.mdx` line 78.

No `validation:` block: this is a shell/manifest fragment, runtime validation isn't required and would need shell-install harness work that's out of scope for this PR (see #423/#428).