### PR TITLE
feat(snippets): add java-server-sdk/sdk-docs/install-the-sdk-gradle canonical

### DIFF
--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-gradle.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-gradle.snippet.md
@@ -1,0 +1,11 @@
+---
+id: java-server-sdk/sdk-docs/install-the-sdk-gradle
+sdk: java-server-sdk
+kind: reference
+lang: groovy
+description: "Gradle in section \"Install the SDK\""
+---
+
+```groovy
+implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.0.0'
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert a `SDK_SNIPPET:RENDER` marker pointing at this canonical.

## Snippet

Path: `snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-gradle.snippet.md`
ID: `java-server-sdk/sdk-docs/install-the-sdk-gradle`

Body (verbatim from `fern/topics/sdk/server-side/java/index.mdx` line 91):

```groovy
implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.0.0'
```

## Where the marker lands

After this merges, ld-docs PR #7592 inserts a marker before the existing `<CodeBlock title='Gradle'>` at `fern/topics/sdk/server-side/java/index.mdx` line 88. The XML sibling on line 77 is already mapped on main as `java-server-sdk/sdk-docs/install-the-sdk-xml`.

No `validation:` block: this is a Gradle DSL fragment, runtime validation isn't required and would need build-system harness work that's out of scope for this PR (see #423/#428).