### PR TITLE
feat(snippets): add node-server-sdk/sdk-docs/install-the-sdk-shell canonical

### DIFF
--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: node-server-sdk
+kind: reference
+lang: shell
+description: "shell in section \"Install the SDK\""
+---
+
+```shell
+npm install @launchdarkly/node-server-sdk
+
+# optional observability plugin, requires Node.js (server-side) SDK v9.10+
+npm install @launchdarkly/observability-node
+
+# In earlier versions, the package name was launchdarkly-node-server-sdk or ldclient-node
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert a `SDK_SNIPPET:RENDER` marker pointing at this canonical.

## Snippet

Path: `snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md`
ID: `node-server-sdk/sdk-docs/install-the-sdk-shell`

Body (verbatim from `fern/topics/sdk/server-side/node/index.mdx` lines 73-79):

```shell
npm install @launchdarkly/node-server-sdk

# optional observability plugin, requires Node.js (server-side) SDK v9.10+
npm install @launchdarkly/observability-node

# In earlier versions, the package name was launchdarkly-node-server-sdk or ldclient-node
```

## Where the marker lands

After this merges, ld-docs PR #7592 inserts a marker before the existing `<CodeBlock title='shell'>` at `fern/topics/sdk/server-side/node/index.mdx` line 70.

No `validation:` block: this is a shell install fragment, runtime validation isn't required and would need shell-install harness work that's out of scope for this PR (see #423/#428).