### PR TITLE
feat(snippets): add php-server-sdk/sdk-docs/install-the-sdk-shell canonical

### DIFF
--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,13 @@
+---
+id: php-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: php-server-sdk
+kind: reference
+lang: shell
+description: "Shell in section \"Install the SDK\""
+---
+
+```shell
+php composer.phar require launchdarkly/server-sdk
+
+# In earlier versions, this was "launchdarkly/launchdarkly-php"
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert a `SDK_SNIPPET:RENDER` marker pointing at this canonical.

## Snippet

Path: `snippets/sdks/php-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md`
ID: `php-server-sdk/sdk-docs/install-the-sdk-shell`

Body (verbatim from `fern/topics/sdk/server-side/php/index.mdx` lines 73-75):

```shell
php composer.phar require launchdarkly/server-sdk

# In earlier versions, this was "launchdarkly/launchdarkly-php"
```

## Where the marker lands

After this merges, ld-docs PR #7592 inserts a marker before the existing `<CodeBlock title='Shell'>` at `fern/topics/sdk/server-side/php/index.mdx` line 70.

No `validation:` block: this is a shell install fragment, runtime validation isn't required and would need shell-install harness work that's out of scope for this PR (see #423/#428).