### PR TITLE
feat(snippets): add rust-server-sdk/sdk-docs/install-the-sdk-shell canonical

### DIFF
--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,11 @@
+---
+id: rust-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: rust-server-sdk
+kind: reference
+lang: shell
+description: "Shell in section \"Install the SDK\""
+---
+
+```shell
+cargo add launchdarkly-server-sdk
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert a `SDK_SNIPPET:RENDER` marker pointing at this canonical.

## Snippet

Path: `snippets/sdks/rust-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md`
ID: `rust-server-sdk/sdk-docs/install-the-sdk-shell`

Body (verbatim from `fern/topics/sdk/server-side/rust/index.mdx` line 69):

```shell
cargo add launchdarkly-server-sdk
```

## Where the marker lands

After this merges, ld-docs PR #7592 inserts a marker before the existing `<CodeBlock title='Shell'>` at `fern/topics/sdk/server-side/rust/index.mdx` line 66.

No `validation:` block: this is a shell install fragment, runtime validation isn't required and would need shell-install harness work that's out of scope for this PR (see #423/#428).