### PR TITLE
feat(snippets): add node-client-sdk/sdk-docs install-the-sdk npm + yarn canonicals

### DIFF
--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
@@ -1,0 +1,11 @@
+---
+id: node-client-sdk/sdk-docs/install-the-sdk-installing-with-npm
+sdk: node-client-sdk
+kind: reference
+lang: shell
+description: "Installing with npm in section \"Install the SDK\""
+---
+
+```shell
+npm install launchdarkly-node-client-sdk
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
@@ -1,0 +1,11 @@
+---
+id: node-client-sdk/sdk-docs/install-the-sdk-installing-with-yarn
+sdk: node-client-sdk
+kind: reference
+lang: shell
+description: "Installing with yarn in section \"Install the SDK\""
+---
+
+```shell
+yarn add launchdarkly-node-client-sdk
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert `SDK_SNIPPET:RENDER` markers pointing at these canonicals.

## Snippets

Two reference fragments under `snippets/sdks/node-client-sdk/snippets/sdk-docs/`:

### `install-the-sdk-installing-with-npm.snippet.md`

Body (verbatim from `fern/topics/sdk/client-side/node-js/index.mdx` line 75):

```shell
npm install launchdarkly-node-client-sdk
```

### `install-the-sdk-installing-with-yarn.snippet.md`

Body (verbatim from `fern/topics/sdk/client-side/node-js/index.mdx` line 82):

```shell
yarn add launchdarkly-node-client-sdk
```

## Where the markers land

After this merges, ld-docs PR #7592 inserts markers before the existing `<CodeBlock title='Installing with npm'>` (line 72) and `<CodeBlock title='Installing with yarn'>` (line 79) at `fern/topics/sdk/client-side/node-js/index.mdx`.

No `validation:` blocks: shell install fragments, runtime validation isn't required and would need shell-install harness work that's out of scope for this PR (see #423/#428).