### PR TITLE
feat(snippets): add react-native-client-sdk/sdk-docs install-the-sdk shell canonicals

### DIFF
--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-adding-the-async-storage-dependency.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-adding-the-async-storage-dependency.snippet.md
@@ -1,0 +1,11 @@
+---
+id: react-native-client-sdk/sdk-docs/install-the-sdk-adding-the-async-storage-dependency
+sdk: react-native-client-sdk
+kind: reference
+lang: shell
+description: "Adding the async storage dependency in section \"Install the SDK\""
+---
+
+```shell
+  yarn add @react-native-async-storage/async-storage
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-installing-react-native-sdk-v10.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-installing-react-native-sdk-v10.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-native-client-sdk/sdk-docs/install-the-sdk-installing-react-native-sdk-v10
+sdk: react-native-client-sdk
+kind: reference
+lang: shell
+description: "Installing, React Native SDK v10 in section \"Install the SDK\""
+---
+
+```shell
+  yarn add @launchdarkly/react-native-client-sdk
+
+  # optional observability plugin, requires React Native SDK v10.10+
+  yarn add @launchdarkly/observability-react-native
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert `SDK_SNIPPET:RENDER` markers pointing at these canonicals.

## Snippets

Two reference fragments under `snippets/sdks/react-native-client-sdk/snippets/sdk-docs/`. Both bodies preserve the 2-space leading indentation of their MDX context (the parent ordered list inside `### Install the SDK`).

### `install-the-sdk-installing-react-native-sdk-v10.snippet.md`

Body (verbatim from `fern/topics/sdk/client-side/react/react-native/index.mdx` lines 118-121):

```shell
  yarn add @launchdarkly/react-native-client-sdk

  # optional observability plugin, requires React Native SDK v10.10+
  yarn add @launchdarkly/observability-react-native
```

### `install-the-sdk-adding-the-async-storage-dependency.snippet.md`

Body (verbatim from `fern/topics/sdk/client-side/react/react-native/index.mdx` line 136):

```shell
  yarn add @react-native-async-storage/async-storage
```

## Where the markers land

After this merges, ld-docs PR #7592 inserts markers before the existing `<CodeBlock title='Installing, React Native SDK v10'>` (line 115) and `<CodeBlock title='Adding the async storage dependency'>` (line 133) at `fern/topics/sdk/client-side/react/react-native/index.mdx`.

No `validation:` blocks: shell install fragments, runtime validation isn't required and would need shell-install harness work that's out of scope for this PR (see #423/#428).