### PR TITLE
feat(snippets): add vue-client-sdk/sdk-docs install-the-sdk npm + yarn canonicals

### DIFF
--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
@@ -1,0 +1,13 @@
+---
+id: vue-client-sdk/sdk-docs/install-the-sdk-installing-with-npm
+sdk: vue-client-sdk
+kind: reference
+lang: shell
+description: "Installing with npm in section \"Install the SDK\""
+---
+
+```shell
+npm install --save launchdarkly-vue-client-sdk
+npm install @launchdarkly/observability # optional observability plugin
+npm install @launchdarkly/session-replay # optional session replay plugin
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
@@ -1,0 +1,13 @@
+---
+id: vue-client-sdk/sdk-docs/install-the-sdk-installing-with-yarn
+sdk: vue-client-sdk
+kind: reference
+lang: shell
+description: "Installing with yarn in section \"Install the SDK\""
+---
+
+```shell
+yarn add launchdarkly-vue-client-sdk
+yarn add @launchdarkly/observability # optional observability plugin
+yarn add @launchdarkly/session-replay # optional session replay plugin
+```


### PR DESCRIPTION
One of 9 stacked sdk-meta PRs that unblock [ld-docs-private PR #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592). Once this lands, #7592 gets updated to insert `SDK_SNIPPET:RENDER` markers pointing at these canonicals.

## Snippets

Two reference fragments under `snippets/sdks/vue-client-sdk/snippets/sdk-docs/`:

### `install-the-sdk-installing-with-npm.snippet.md`

Body (verbatim from `fern/topics/sdk/client-side/vue/index.mdx` lines 80-82):

```shell
npm install --save launchdarkly-vue-client-sdk
npm install @launchdarkly/observability # optional observability plugin
npm install @launchdarkly/session-replay # optional session replay plugin
```

### `install-the-sdk-installing-with-yarn.snippet.md`

Body (verbatim from `fern/topics/sdk/client-side/vue/index.mdx` lines 89-91):

```shell
yarn add launchdarkly-vue-client-sdk
yarn add @launchdarkly/observability # optional observability plugin
yarn add @launchdarkly/session-replay # optional session replay plugin
```

## Where the markers land

After this merges, ld-docs PR #7592 inserts markers before the existing `<CodeBlock title='Installing with npm'>` (line 77) and `<CodeBlock title='Installing with yarn'>` (line 86) at `fern/topics/sdk/client-side/vue/index.mdx`.

No `validation:` blocks: shell install fragments, runtime validation isn't required and would need shell-install harness work that's out of scope for this PR (see #423/#428).