### PR TITLE
feat(snippets): add sdk-docs install canonicals for 9 SDKs

### DIFF
--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,15 @@
+---
+id: dotnet-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: dotnet-server-sdk
+kind: reference
+lang: shell
+file: dotnet-server-sdk/sdk-docs/install-the-sdk-shell.sh
+description: "Shell in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+Install-Package LaunchDarkly.ServerSdk
+dotnet add package LaunchDarkly.Observability
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-gradle.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/install-the-sdk-gradle.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/install-the-sdk-gradle
+sdk: java-server-sdk
+kind: reference
+lang: groovy
+file: java-server-sdk/sdk-docs/install-the-sdk-gradle.gradle
+description: "Gradle in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```groovy
+implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.0.0'
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-client-sdk/sdk-docs/install-the-sdk-installing-with-npm
+sdk: node-client-sdk
+kind: reference
+lang: shell
+file: node-client-sdk/sdk-docs/install-the-sdk-installing-with-npm.sh
+description: "Installing with npm in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+npm install launchdarkly-node-client-sdk
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-client-sdk/sdk-docs/install-the-sdk-installing-with-yarn
+sdk: node-client-sdk
+kind: reference
+lang: shell
+file: node-client-sdk/sdk-docs/install-the-sdk-installing-with-yarn.sh
+description: "Installing with yarn in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+yarn add launchdarkly-node-client-sdk
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,19 @@
+---
+id: node-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: node-server-sdk
+kind: reference
+lang: shell
+file: node-server-sdk/sdk-docs/install-the-sdk-shell.sh
+description: "shell in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+npm install @launchdarkly/node-server-sdk
+
+# optional observability plugin, requires Node.js (server-side) SDK v9.10+
+npm install @launchdarkly/observability-node
+
+# In earlier versions, the package name was launchdarkly-node-server-sdk or ldclient-node
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,16 @@
+---
+id: php-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: php-server-sdk
+kind: reference
+lang: shell
+file: php-server-sdk/sdk-docs/install-the-sdk-shell.sh
+description: "Shell in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+php composer.phar require launchdarkly/server-sdk
+
+# In earlier versions, this was "launchdarkly/launchdarkly-php"
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-adding-the-async-storage-dependency.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-adding-the-async-storage-dependency.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-native-client-sdk/sdk-docs/install-the-sdk-adding-the-async-storage-dependency
+sdk: react-native-client-sdk
+kind: reference
+lang: shell
+file: react-native-client-sdk/sdk-docs/install-the-sdk-adding-the-async-storage-dependency.sh
+description: "Adding the async storage dependency in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+  yarn add @react-native-async-storage/async-storage
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-installing-react-native-sdk-v10.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/install-the-sdk-installing-react-native-sdk-v10.snippet.md
@@ -1,0 +1,17 @@
+---
+id: react-native-client-sdk/sdk-docs/install-the-sdk-installing-react-native-sdk-v10
+sdk: react-native-client-sdk
+kind: reference
+lang: shell
+file: react-native-client-sdk/sdk-docs/install-the-sdk-installing-react-native-sdk-v10.sh
+description: "Installing, React Native SDK v10 in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+  yarn add @launchdarkly/react-native-client-sdk
+
+  # optional observability plugin, requires React Native SDK v10.10+
+  yarn add @launchdarkly/observability-react-native
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ruby-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: ruby-server-sdk
+kind: reference
+lang: shell
+file: ruby-server-sdk/sdk-docs/install-the-sdk-shell.sh
+description: "Shell in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+gem install launchdarkly-server-sdk
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/install-the-sdk-shell.snippet.md
@@ -1,0 +1,14 @@
+---
+id: rust-server-sdk/sdk-docs/install-the-sdk-shell
+sdk: rust-server-sdk
+kind: reference
+lang: shell
+file: rust-server-sdk/sdk-docs/install-the-sdk-shell.sh
+description: "Shell in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+cargo add launchdarkly-server-sdk
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-npm.snippet.md
@@ -1,0 +1,16 @@
+---
+id: vue-client-sdk/sdk-docs/install-the-sdk-installing-with-npm
+sdk: vue-client-sdk
+kind: reference
+lang: shell
+file: vue-client-sdk/sdk-docs/install-the-sdk-installing-with-npm.sh
+description: "Installing with npm in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+npm install --save launchdarkly-vue-client-sdk
+npm install @launchdarkly/observability # optional observability plugin
+npm install @launchdarkly/session-replay # optional session replay plugin
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-docs/install-the-sdk-installing-with-yarn.snippet.md
@@ -1,0 +1,16 @@
+---
+id: vue-client-sdk/sdk-docs/install-the-sdk-installing-with-yarn
+sdk: vue-client-sdk
+kind: reference
+lang: shell
+file: vue-client-sdk/sdk-docs/install-the-sdk-installing-with-yarn.sh
+description: "Installing with yarn in section \"Install the SDK\""
+validation:
+  runtime: shell-install
+---
+
+```shell
+yarn add launchdarkly-vue-client-sdk
+yarn add @launchdarkly/observability # optional observability plugin
+yarn add @launchdarkly/session-replay # optional session replay plugin
+```

--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -1,12 +1,12 @@
 # Build context is `validators/`. See validators/languages/python/Dockerfile
 # for the rationale.
 #
-# Multi-toolchain image: each sdk-info / observability / ai-configs
-# install snippet uses one of npm / pnpm / yarn / pip / go-get / gem.
-# The harness sniffs the staged body and runs the appropriate package
-# manager. We base on node:20 (Debian bookworm) and layer Python, Go,
-# and Ruby on top so a single image covers every Linux install command
-# we ship today.
+# Multi-toolchain image: each sdk-info / observability / ai-configs / sdk-docs
+# install snippet uses one of npm / pnpm / yarn / pip / go-get / gem /
+# cargo / composer / dotnet (CLI) / gradle. The harness sniffs the staged
+# body's leading token and runs the appropriate package manager. Image is
+# intentionally fat (~2 GB) — a CI-only artifact, cached per matrix cell
+# after the first build, so the size pays for itself quickly.
 FROM node:20-bookworm-slim
 
 # pnpm + yarn come via corepack (node 20 ships it). Python provides the
@@ -55,6 +55,54 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable \
  && corepack prepare pnpm@9 --activate \
  && corepack prepare yarn@1 --activate
+
+# Rust toolchain for `cargo add` / `cargo init` install snippets. Use the
+# rustup minimal profile to avoid pulling docs and component metadata we
+# don't need at runtime.
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:$PATH
+RUN curl -fsSL https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+
+# PHP + composer.phar for `php composer.phar require …` install snippets.
+# composer.phar lands at /opt/composer.phar; the harness symlinks it into
+# the working dir before running the body so the body's literal
+# `composer.phar` reference resolves.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        php-cli \
+        php-zip \
+        php-curl \
+        php-mbstring \
+        unzip \
+ && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://getcomposer.org/download/latest-stable/composer.phar -o /opt/composer.phar \
+ && chmod +x /opt/composer.phar
+
+# .NET SDK for `dotnet add package` install snippets. The Microsoft apt
+# feed serves a .deb that wires up the package source for us.
+RUN curl -fsSL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
+        -o /tmp/packages-microsoft-prod.deb \
+ && dpkg -i /tmp/packages-microsoft-prod.deb \
+ && rm /tmp/packages-microsoft-prod.deb \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends dotnet-sdk-8.0 \
+ && rm -rf /var/lib/apt/lists/*
+
+# OpenJDK + Gradle for `implementation group: …` Gradle DSL install
+# snippets. The harness wraps the body in a minimal build.gradle and
+# runs `gradle dependencies` to confirm the artifact resolves. Pin
+# Gradle to a recent version (Debian's apt package lags by years).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-17-jdk-headless \
+ && rm -rf /var/lib/apt/lists/*
+ENV GRADLE_VERSION=8.10.2
+RUN curl -fsSL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+        -o /tmp/gradle.zip \
+ && unzip -q /tmp/gradle.zip -d /opt \
+ && ln -s "/opt/gradle-${GRADLE_VERSION}/bin/gradle" /usr/local/bin/gradle \
+ && rm /tmp/gradle.zip
 
 WORKDIR /work
 

--- a/snippets/validators/languages/shell-install/harness/run.sh
+++ b/snippets/validators/languages/shell-install/harness/run.sh
@@ -19,6 +19,22 @@
 #                        bower_components dir exists.
 #   gem install …      — route gems to a per-run GEM_HOME (so we don't
 #                        need root), then assert by walking that dir.
+#   cargo add …        — `cargo init`, then run body, then grep Cargo.toml.
+#   php composer.phar
+#     require …        — symlink /opt/composer.phar into $WORK, init a
+#                        minimal composer project, run body, check vendor/.
+#   dotnet add
+#     package …        — `dotnet new console`, then run body, then grep
+#                        the generated .csproj for <PackageReference>.
+#   Install-Package …  — legacy NuGet PowerShell. Stripped from multi-line
+#                        bodies (we keep validating the dotnet CLI variant
+#                        in the same body); causes a hard error if it's
+#                        the only line.
+#   implementation
+#     group: …         — Gradle DSL fragment. Wrapped in a minimal
+#                        build.gradle's dependencies block; `gradle
+#                        dependencies` resolves and we grep the output
+#                        for the artifact name.
 #
 # Any unrecognized leading token is a hard error: a new install style means
 # the harness needs to learn it, not silently no-op.
@@ -52,6 +68,18 @@ fi
 # Body is one (sometimes few) shell command lines. Read them all so a
 # multi-line install (e.g. `cd … && npm i …`) still works.
 COMMAND=$(cat "$BODY")
+
+# Drop legacy NuGet PowerShell `Install-Package` lines. The cmdlet only
+# exists in PowerShell with the NuGet PackageManagement module — not in
+# our toolchain. Snippets that show both the legacy `Install-Package`
+# and the modern `dotnet add package` forms (for backward-compat
+# documentation) get the dotnet variant validated; the Install-Package
+# variant is structurally unrunnable on Linux. Bodies whose only line is
+# Install-Package fall through to the `*` case below and fail loudly.
+if printf '%s' "$COMMAND" | grep -q '^[[:space:]]*Install-Package'; then
+    COMMAND=$(printf '%s' "$COMMAND" | sed '/^[[:space:]]*Install-Package/d')
+fi
+
 # Sniff the leading non-whitespace token to pick a strategy.
 LEAD=$(printf '%s' "$COMMAND" | awk 'NF{print $1; exit}')
 SUB=$(printf '%s' "$COMMAND" | awk 'NF{print $2; exit}')
@@ -75,6 +103,12 @@ run_in_log() {
 # is printed, so the assertion targets the last package the body installs.
 last_pkg() {
     printf '%s' "$1" | awk '
+        {
+            # Strip inline shell comments so trailing `# foo bar` annotations
+            # in multi-line install bodies do not get picked up as package names.
+            sub(/[ \t]*#.*$/, "", $0);
+            $0 = $0;  # force re-split into $1..$NF after the substitution
+        }
         NF >= 3 {
             for (i = 3; i <= NF; i++) {
                 if ($i ~ /^-/) continue;
@@ -183,6 +217,75 @@ case "$LEAD" in
             echo "validator: ok — $pkg installed in $GEM_HOME"
         else
             fail_with_log "$LOG" "expected gem $pkg to be installed under $GEM_HOME/gems"
+        fi
+        ;;
+    cargo)
+        if [ "$SUB" != "add" ]; then
+            fail_with_log "$LOG" "unrecognized cargo subcommand for install snippet: $SUB"
+        fi
+        cargo init --quiet --name install-sanity --vcs none . >/dev/null 2>&1
+        run_in_log
+        pkg=$(last_pkg "$COMMAND")
+        if grep -q "$pkg" Cargo.toml; then
+            echo "validator: ok — $pkg present in Cargo.toml"
+        else
+            fail_with_log "$LOG" "expected $pkg in Cargo.toml after cargo add"
+        fi
+        ;;
+    php)
+        # Body shape: `php composer.phar require …`. Stage composer.phar
+        # alongside the body so the literal reference resolves, then
+        # initialize a minimal composer project so `require` has somewhere
+        # to write.
+        if [ "$SUB" != "composer.phar" ]; then
+            fail_with_log "$LOG" "unrecognized php install shape: php $SUB"
+        fi
+        cp /opt/composer.phar ./composer.phar
+        php composer.phar init --quiet --name=example/sanity --no-interaction >/dev/null 2>&1
+        run_in_log
+        pkg=$(last_pkg "$COMMAND")
+        if [ -d "vendor/$pkg" ]; then
+            echo "validator: ok — $pkg present under vendor/"
+        else
+            fail_with_log "$LOG" "expected vendor/$pkg to exist after composer require"
+        fi
+        ;;
+    dotnet)
+        if [ "$SUB" != "add" ]; then
+            fail_with_log "$LOG" "unrecognized dotnet subcommand for install snippet: $SUB"
+        fi
+        dotnet new console -n InstallSanity --force >/dev/null 2>&1
+        cd InstallSanity
+        run_in_log
+        pkg=$(last_pkg "$COMMAND")
+        if grep -q "<PackageReference Include=\"$pkg\"" InstallSanity.csproj; then
+            echo "validator: ok — $pkg in InstallSanity.csproj"
+        else
+            fail_with_log "$LOG" "expected <PackageReference Include=\"$pkg\"…> in InstallSanity.csproj"
+        fi
+        ;;
+    implementation)
+        # Gradle DSL fragment — wrap in a minimal build.gradle's
+        # dependencies block and run `gradle dependencies` to confirm
+        # the artifact resolves from mavenCentral. We grep the
+        # dependency-tree output for the artifact name (the snippet's
+        # `name: '…'` field).
+        cat > build.gradle <<'EOF'
+plugins { id 'java' }
+repositories { mavenCentral() }
+dependencies {
+EOF
+        printf '%s\n' "$COMMAND" >> build.gradle
+        echo '}' >> build.gradle
+        cat > settings.gradle <<'EOF'
+rootProject.name = 'install-sanity'
+EOF
+        gradle --no-daemon --quiet dependencies >"$LOG" 2>&1
+        artifact=$(printf '%s' "$COMMAND" | sed -n "s/.*name:[[:space:]]*'\([^']*\)'.*/\1/p")
+        if [ -n "$artifact" ] && grep -q "$artifact" "$LOG"; then
+            echo "validator: ok — $artifact resolved by gradle"
+        else
+            fail_with_log "$LOG" "expected gradle dependencies output to mention artifact"
         fi
         ;;
     *)


### PR DESCRIPTION
## Summary

**Stacked on [#428](https://github.com/launchdarkly/sdk-meta/pull/428)**, which lands the `shell-install` validator infrastructure (with `gem` support and the multi-line `last_pkg` extractor). Adds 12 canonical `.snippet.md` files for the install / manifest `<CodeBlock>` regions in ld-docs's top-level reference pages that the original auto-port ([#414](https://github.com/launchdarkly/sdk-meta/pull/414)) skipped per [SDK-2300](https://launchdarkly.atlassian.net/browse/SDK-2300). **All 12 get end-to-end shell-install validation** against the real package registry.

Unblocks the corresponding marker insertions on [ld-docs-private #7592](https://github.com/launchdarkly/ld-docs-private/pull/7592).

## Per-SDK file list + validation status

| SDK | New snippet IDs | Validation |
|---|---|---|
| `node-server-sdk` | `install-the-sdk-shell` | ✅ shell-install (npm) |
| `node-client-sdk` | `install-the-sdk-installing-with-npm`, `…with-yarn` | ✅ shell-install (npm + yarn) |
| `react-native-client-sdk` | `install-the-sdk-installing-react-native-sdk-v10`, `…adding-the-async-storage-dependency` | ✅ shell-install (yarn × 2) |
| `ruby-server-sdk` | `install-the-sdk-shell` | ✅ shell-install (gem) |
| `vue-client-sdk` | `install-the-sdk-installing-with-npm`, `…with-yarn` | ✅ shell-install (npm + yarn) |
| `dotnet-server-sdk` | `install-the-sdk-shell` | ✅ shell-install (dotnet CLI; `Install-Package` legacy line stripped) |
| `java-server-sdk` | `install-the-sdk-gradle` | ✅ shell-install (gradle DSL fragment in synthesized build.gradle) |
| `php-server-sdk` | `install-the-sdk-shell` | ✅ shell-install (composer) |
| `rust-server-sdk` | `install-the-sdk-shell` | ✅ shell-install (cargo) |

`go-server-sdk` is intentionally not included — the "Shell install" mention in PR #7592's per-SDK table refers to a prose backtick quote of `go get …`, not an MDX CodeBlock.

## Validator extensions (Dockerfile + harness)

The shell-install image grew from a node + python + go + ruby base to also include rust toolchain, php + composer, .NET SDK 8, and OpenJDK 17 + Gradle 8.10. Image is now ~2 GB — a CI-only artifact, cached per matrix cell, so the size pays for itself after the first build.

New harness LEAD cases:

- **`cargo`** — `cargo init` in a clean dir, run body, grep `Cargo.toml` for the package name.
- **`php`** — symlinks `/opt/composer.phar` into the working dir so the body's literal `php composer.phar require …` resolves; `composer init`; run body; check `vendor/<pkg>/`.
- **`dotnet`** — `dotnet new console -n InstallSanity`, cd in, run body, grep `<PackageReference Include="…">` from the generated csproj.
- **`Install-Package` strip** — multi-line bodies that show the legacy NuGet PowerShell `Install-Package` form alongside the modern `dotnet add package` CLI form (for backward-compat documentation) get the legacy line stripped before LEAD detection. The dotnet CLI line is then validated via the case above.
- **`implementation`** (Gradle DSL fragment) — synthesizes a minimal `build.gradle` (`plugins { id 'java' }`, `mavenCentral()`, the body inserted in `dependencies { … }`); runs `gradle dependencies`; greps the dependency-tree output for the artifact name extracted from the body's `name: '…'` field.

## Bug found + fixed inline

`shell-install`'s `last_pkg` extractor was picking up trailing inline `# comment` text as a package name. Multi-line bodies like vue's `npm install --save launchdarkly-vue-client-sdk\nnpm install @launchdarkly/observability # optional observability plugin\nnpm install @launchdarkly/session-replay # optional session replay plugin` extracted `plugin` as the last package and then failed `assert_node_modules` looking for `node_modules/plugin/`. Fixed by stripping inline shell comments before field-splitting in awk. Benefits any sdk-info or observability install body with comments too.

## Body fidelity

Each `.snippet.md` body is a byte-verbatim copy of what's in ld-docs today. Verified by running `snippets render --target=ld-docs` after a synthetic marker insertion and confirming the diff is exactly the marker comment — zero body bytes change.

## Test plan

- [x] `go test ./...` (from `snippets/`) passes.
- [x] All 12 bindable snippets validate green locally against real package registries (npm × 4, yarn × 3, gem × 1, cargo × 1, composer × 1, dotnet CLI × 1, gradle × 1).
- [x] Existing pre-#439 shell-install bindings (sdk-info installs, observability installs from #428) still pass — the comment-strip fix in `last_pkg` is a strict improvement.

[SDK-2300]: https://launchdarkly.atlassian.net/browse/SDK-2300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation snippets and CI-only validator changes; no production runtime or security-sensitive application code.
> 
> **Overview**
> Adds **12 canonical install snippets** for nine SDK reference pages (npm/yarn/gem/cargo/composer/dotnet/gradle), each tagged with **`runtime: shell-install`** so CI can resolve packages against real registries.
> 
> The **shell-install validator** is extended to cover those ecosystems: the Docker image now includes Rust, PHP/Composer, .NET SDK 8, and Gradle; **`run.sh`** gains branches for **`cargo add`**, **`php composer.phar require`**, **`dotnet add package`**, and Gradle **`implementation`** lines, plus stripping legacy **`Install-Package`** lines when paired with **`dotnet add`**. **`last_pkg`** now ignores inline **`#` comments** so multi-line npm/yarn bodies with optional-plugin notes assert the correct package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01bf3fa75ae7ca538a76137aa28527b093ae1266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->