### PR TITLE
feat(snippets): REL-13762 - add experimentation onboarding snippets for frontend SDKs

### DIFF
--- a/snippets/sdks/_experimentation-port-notes.md
+++ b/snippets/sdks/_experimentation-port-notes.md
@@ -13,36 +13,77 @@ below for traceability.
 This file is the analogue of `_aiconfigs-observability-port-notes.md`,
 `_sdk-info-port-notes.md`, and `_sdk-docs-port-notes.md`.
 
-## Bucket C: no validation block
+## Validation
 
-**Severity**: low
+The 8 frontend-web + mobile-RN + iOS experimentation snippets bind
+through the existing per-SDK `*-syntax-only` scaffolds in parse-only
+mode. Each scaffold wraps the wrappee body inside a never-invoked
+function under an `if (false)` (or equivalent) guard, so unresolved
+caller surfaces (`<YourComponent>`, the host app's `Activity`/
+`AppDelegate` lifecycle, etc.) don't have to actually exist — the
+validator only asserts that the body parses (and, where the toolchain
+type-checks too, that the body type-checks).
 
-**Snippets affected**: every `*/experimentation/{track-only,full}` entry.
+Per-SDK summary:
 
-**Why unbindable**: these are experimentation onboarding examples, not
-standalone-runnable programs. Each one defines an app component plus
-helper functions (`trackMetric`, `identifyUser` / `onUserEligible` /
-`onUserBecomesEligible`) that call into the host app's own surfaces
-(`YourComponent`, `applyVariant`, an `Activity`/`AppDelegate`
-lifecycle). The existing per-SDK validator scaffolds
-(`*-syntax-only`, `init-runner`) wrap a single fragment; they can't host
-a multi-function example that references caller-supplied components.
-They are also newly *proposed* snippets — there is no consumer
-(gonfalon) wiring rendering them yet, so there is no marker/hash to
-verify against either. Left as Bucket C: the canonical text lives in
-sdk-meta, byte-checked by review, with no `validation:` block.
+- **js-client-sdk** (`experimentation/full`, `experimentation/track-only`)
+  — bind to `scaffolds/js-syntax-only`. The harness's existing
+  `IMPORT_LIFT_TARGET` / `BODY_BEGIN` / `BODY_END` awk pre-step lifts
+  top-level `import`s and strips `export` keywords so the body's
+  module-scope-only directives are legal inside the scaffold's
+  `async function _wrappee()` wrapper. The full variant's top-level
+  `await ldClient.start()` works because `_wrappee` is async. No
+  scaffold or harness changes needed.
 
-`snippets validate` only runs snippets that declare a `validation:`
-block, and `.github/workflows/snippets-validate.yml` targets specific
-snippets/groups per SDK (never `experimentation`), so these add no CI
-surface.
+- **react-client-sdk** (`experimentation/full`, `experimentation/track-only`)
+  — bind to `scaffolds/react-syntax-only`. `@launchdarkly/react-sdk`
+  is already pre-baked in the validator image. The same IMPORT_LIFT
+  awk pre-step handles the body's `import` directives. The full
+  variant's hook calls (`useLDClient`, `useFlags`) live inside a
+  function component declared in the body; that compiles fine as a
+  dead-code function declaration under `if (false)`.
 
-**Recommended action**: when a consumer adopts the experimentation
-onboarding flow, add an `experimentation-syntax-only` scaffold per
-platform that stubs the caller-supplied components
-(`YourComponent`/`applyVariant`) so the bodies can at least be
-parse/type-checked, mirroring how `react-native-syntax-only` and
-`swift-syntax-only` bind the sdk-docs fragments.
+- **react-native-client-sdk** (`experimentation/full`, `experimentation/track-only`)
+  — bind to `scaffolds/react-native-syntax-only` (Babel-parse pass
+  via `SNIPPET_MODE=syntax-only`). The scaffold previously hard-coded
+  `import React from 'react';` at file scope; both wrappee bodies
+  import React themselves, which would have redeclared it after the
+  IMPORT_LIFT step. The scaffold's React import was dropped (the
+  scaffold's `App` returns `null` and uses no JSX, so the import was
+  unused). `<YourComponent />` in the bodies parses fine — Babel
+  doesn't resolve component references.
+
+- **ios-client-sdk** (`experimentation/full`, `experimentation/track-only`)
+  — bind to `scaffolds/swift-syntax-only`. The bodies declare
+  file-scope `func startLaunchDarkly()`, `func onUserBecomesEligible(_:)`,
+  `func trackMetric(_:_:)`; spliced into the scaffold they become
+  nested local functions inside `AppDelegate._wrappee()`, which
+  Swift permits. The full variant calls `applyVariant(variant)` from
+  inside `onUserBecomesEligible`; the scaffold was extended with a
+  file-scope `func applyVariant(_ variant: String) {}` no-op stub so
+  xcodebuild's type-checker resolves the reference. The harness's
+  existing Python import-lift pre-step moves the body's
+  `import LaunchDarkly` up to file scope.
+
+## Still Bucket C: android-client-sdk
+
+**Snippets affected**: `android-client-sdk/experimentation/{track-only,full}`.
+
+**Why unbindable today**: the existing
+`android-client-sdk/scaffolds/android-syntax-only` scaffold routes
+through the `jvm` validator (Java + Maven against
+`launchdarkly-java-server-sdk`); the experimentation bodies are
+Kotlin and reference `com.launchdarkly.sdk.android.*` types (the
+android client SDK ships as an `aar` to Google's Maven, not a plain
+jar to Maven Central), plus AndroidX types like `AppCompatActivity`,
+`Application`, and `Bundle`. There is no parse-only mode of the
+`android-client` validator (the existing harness drives a
+MainActivity through a Robolectric lifecycle and asserts on a
+TextView), and adding one would require a kotlinc-only /
+`compileDebugKotlin` dispatch path plus a kotlin-aware syntax-only
+scaffold — larger than this slice. Same structural gap as the
+`android-client-sdk/sdk-docs/*` fragments documented in
+`_sdk-docs-port-notes.md`.
 
 ## Reviewer comments applied inline
 

--- a/snippets/sdks/_experimentation-port-notes.md
+++ b/snippets/sdks/_experimentation-port-notes.md
@@ -1,0 +1,98 @@
+# experimentation port notes
+
+Notes for the `experimentation/` snippet group added for the frontend
+client SDKs: `react-client-sdk` (React Web), `js-client-sdk`,
+`react-native-client-sdk`, `ios-client-sdk`, and `android-client-sdk`.
+
+Each SDK gets two snippets — `track-only` and `full` — ported from the
+"Proposed onboarding SDK snippets for experimentation" Confluence page
+(pageId 4880073181). The reviewer comments left on that page are applied
+inline rather than carried as TODOs; the substantive ones are recorded
+below for traceability.
+
+This file is the analogue of `_aiconfigs-observability-port-notes.md`,
+`_sdk-info-port-notes.md`, and `_sdk-docs-port-notes.md`.
+
+## Bucket C: no validation block
+
+**Severity**: low
+
+**Snippets affected**: every `*/experimentation/{track-only,full}` entry.
+
+**Why unbindable**: these are experimentation onboarding examples, not
+standalone-runnable programs. Each one defines an app component plus
+helper functions (`trackMetric`, `identifyUser` / `onUserEligible` /
+`onUserBecomesEligible`) that call into the host app's own surfaces
+(`YourComponent`, `applyVariant`, an `Activity`/`AppDelegate`
+lifecycle). The existing per-SDK validator scaffolds
+(`*-syntax-only`, `init-runner`) wrap a single fragment; they can't host
+a multi-function example that references caller-supplied components.
+They are also newly *proposed* snippets — there is no consumer
+(gonfalon) wiring rendering them yet, so there is no marker/hash to
+verify against either. Left as Bucket C: the canonical text lives in
+sdk-meta, byte-checked by review, with no `validation:` block.
+
+`snippets validate` only runs snippets that declare a `validation:`
+block, and `.github/workflows/snippets-validate.yml` targets specific
+snippets/groups per SDK (never `experimentation`), so these add no CI
+surface.
+
+**Recommended action**: when a consumer adopts the experimentation
+onboarding flow, add an `experimentation-syntax-only` scaffold per
+platform that stubs the caller-supplied components
+(`YourComponent`/`applyVariant`) so the bodies can at least be
+parse/type-checked, mirroring how `react-native-syntax-only` and
+`swift-syntax-only` bind the sdk-docs fragments.
+
+## Reviewer comments applied inline
+
+Deliberate changes from the raw page text, per the page's review
+comments:
+
+- **React Web** — unified both variants on the current
+  `@launchdarkly/react-sdk` (`createLDReactProvider`, `useLDClient`,
+  `useFlags`). The page's `track-only` still used the legacy
+  `launchdarkly-react-client-sdk` / `asyncWithLDProvider`; the author
+  comment ("Updated this snippet to use the latest version") only
+  reached the `full` variant. Matches the canonical
+  `react-client-sdk/sdk-info/init`.
+- **JavaScript** — replaced `start()` + `await waitForInitialization()`
+  with `await start()` ("We can just await start. You only need
+  waitForInitialization if you are needing to wait somewhere where you
+  aren't starting.").
+- **JavaScript / React Native** — renamed `setExperimentContext` to
+  `identifyUser` and reframed the guidance to prefer initializing
+  directly with a known deterministic key, using an anonymous context
+  only when the key is unknown and reusing it on transition ("I find
+  setExperimentContext very confusing… if you already have your
+  deterministic key, it usually makes sense to initialize directly with
+  that and remove the opportunity for mistakes from the identify.").
+- **All client variants** — removed manual `flush()` calls and the
+  mobile background-flush handlers (React Native `AppState` listener,
+  iOS `applicationDidEnterBackground`, Android `onStop()`), and
+  strengthened the comment wording. FDv2 client SDKs already flush on
+  background, and manual flushing is "actively harmful in long-running
+  applications" ("Otherwise this kind of stuff builds up and makes it
+  harder for us to see problems.").
+- **iOS** — moved the top-level `LDClient.start(...)` into a
+  `startLaunchDarkly()` setup function ("You can't invoke member
+  functions at top level (e.g. LDClient.start()) in swift. You'll need
+  to call it from within a setup function.").
+- **Android** — fixed the AutoEnv import in `track-only` from
+  `com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes` to
+  `com.launchdarkly.sdk.android.AutoEnvAttributes` ("The import path is
+  incorrect for the auto env, but correct in the other example.").
+
+## Open questions
+
+- **Experimentation with AI Config SDKs**: a reviewer asked whether
+  experimentation is available when a user is on the AI Config SDKs
+  (AgentControl), referencing the experimentation prerequisites support
+  matrix, and whether dedicated AI-SDK experimentation snippets are
+  warranted. That's a scoping question for the experimentation/AI
+  Configs teams, not a change to these frontend snippets; left out of
+  this slice.
+- **Anonymous context kind**: the same review thread recalled a
+  write-up about using a dedicated context kind for the anonymous
+  bootstrap context. If that guidance is confirmed, the anonymous
+  bootstrap blocks here should adopt that kind.

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/full.snippet.md
@@ -1,0 +1,76 @@
+---
+id: android-client-sdk/experimentation/full
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Full experimentation onboarding for android-client-sdk — initialize, identify off the main thread on login/eligibility, evaluate, and track conversions.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (references applyVariant and an Activity host). No
+# validation block yet. See _experimentation-port-notes.md.
+---
+
+```kotlin
+import com.launchdarkly.sdk.LDContext
+import com.launchdarkly.sdk.LDValue
+import com.launchdarkly.sdk.android.AutoEnvAttributes
+import com.launchdarkly.sdk.android.LDClient
+import com.launchdarkly.sdk.android.LDConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+// Initialize once — extra clients can cause inconsistent experiment results.
+val ldConfig: LDConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey("YOUR_MOBILE_KEY")
+    .build()
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+// If you already know the user's key at startup, initialize with it directly.
+// Use a consistent key so the same user gets the same experience.
+val context: LDContext = LDContext.create("EXAMPLE_CONTEXT_KEY")
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var client: LDClient
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        client = LDClient.init(application, ldConfig, context, 0)
+    }
+
+    // Call this when the user logs in or becomes eligible mid-session.
+    // Wait for identify to finish before evaluating experiment flags.
+    fun onUserEligible(userKey: String) {
+        // Use the logged-in user's ID so experiment assignment stays consistent.
+        val finalCtx = LDContext.builder(userKey)
+            .kind("user")
+            // any attributes that affect targeting or eligibility
+            .build()
+
+        CoroutineScope(Dispatchers.IO).launch {
+            // identify() returns a Future; await its completion off the main thread.
+            client.identify(finalCtx).get()
+
+            // Evaluate the experiment flag where the user encounters the experience.
+            val variant = client.stringVariation("YOUR_FLAG_KEY", "control")
+
+            withContext(Dispatchers.Main) {
+                applyVariant(variant)
+            }
+        }
+    }
+
+    // Call this when the user completes a metric action.
+    // Use the same user key you used when evaluating the flag — mismatched keys break conversion tracking.
+    // The data argument is optional and accepts any shape your metric needs.
+    fun trackMetric(metricKey: String, data: LDValue = LDValue.ofNull()) {
+        client.trackData(metricKey, data)
+    }
+
+    // The SDK batches and flushes events automatically, including when the app is
+    // backgrounded. Don't add manual flush() calls or onStop() flushes — they're
+    // unnecessary and make real problems harder to spot.
+    // Don't skip or cache flag evaluations to reduce exposure counts — LaunchDarkly deduplicates them automatically.
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -1,0 +1,34 @@
+---
+id: android-client-sdk/experimentation/track-only
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Experimentation onboarding (track only) for android-client-sdk — initialize and add a trackMetric helper for conversion events.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (assumes a BaseApplication host + your app). No
+# validation block yet. See _experimentation-port-notes.md.
+---
+
+```kotlin
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+import com.launchdarkly.sdk.android.AutoEnvAttributes
+
+// This is your mobile key.
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey("YOUR_MOBILE_KEY")
+    .build()
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+val context = LDContext.create("EXAMPLE_CONTEXT_KEY")
+
+// If you don't want to block execution while the SDK tries to get
+// latest flags, move this code into an async IO task and await on its completion.
+val client: LDClient = LDClient.init(this@BaseApplication, ldConfig, context, 5)
+
+// Call trackMetric when a metric action occurs in your app —
+// a tap, a form submit, a screen view, a custom event, whatever your metric measures.
+fun trackMetric(metricKey: String, data: LDValue = LDValue.ofNull()) {
+    LDClient.get().trackData(metricKey, data)
+}
+```

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/full.snippet.md
@@ -4,9 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Full experimentation onboarding for ios-client-sdk — start from a setup function, identify on login/eligibility, evaluate, and track conversions.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (references applyVariant and your app lifecycle). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/full.snippet.md
@@ -1,0 +1,61 @@
+---
+id: ios-client-sdk/experimentation/full
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Full experimentation onboarding for ios-client-sdk — start from a setup function, identify on login/eligibility, evaluate, and track conversions.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (references applyVariant and your app lifecycle). No
+# validation block yet. See _experimentation-port-notes.md.
+---
+
+```swift
+import LaunchDarkly
+
+// Call this once from your app startup (e.g. application(_:didFinishLaunchingWithOptions:)).
+// You can't invoke LDClient.start() at the top level in Swift — wrap it in a function.
+// Initialize once — extra clients can cause inconsistent experiment results.
+func startLaunchDarkly() {
+    let config = LDConfig(mobileKey: "YOUR_MOBILE_KEY", autoEnvAttributes: .enabled)
+
+    // A "context" is a data object representing users, devices, organizations, and other entities.
+    // If you already know the user's key at startup, initialize with it directly.
+    // Use a consistent key so the same user gets the same experience.
+    let contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
+    guard case .success(let context) = contextBuilder.build() else { return }
+
+    LDClient.start(config: config, context: context, startWaitSeconds: 5) { _ in }
+}
+
+// Call this when the user logs in or becomes eligible mid-session.
+// Wait for identify to finish before evaluating experiment flags.
+func onUserBecomesEligible(finalUserKey: String) {
+    let client = LDClient.get()!
+
+    // Update to the final context used for experiment eligibility.
+    // Use the logged-in user's ID so experiment assignment stays consistent.
+    let updated = try! LDContextBuilder(key: finalUserKey)
+        // any attributes that affect targeting or eligibility
+        .build().get()
+
+    client.identify(context: updated) {
+        // Evaluate the experiment flag where the user encounters the experience,
+        // after identify completes.
+        let variant = client.stringVariation(forKey: "YOUR_FLAG_KEY", defaultValue: "control")
+        applyVariant(variant)
+    }
+}
+
+// Call this when the user completes a metric action.
+// Use the same user key you used when evaluating the flag — mismatched keys break conversion tracking.
+// The data argument is optional and accepts any shape your metric needs.
+func trackMetric(metricKey: String, data: LDValue = .null) {
+    let client = LDClient.get()!
+    client.track(key: metricKey, data: data)
+}
+
+// The SDK batches and flushes events automatically, including when the app is
+// backgrounded. Don't add manual flush() calls — they're unnecessary and make
+// real problems harder to spot.
+// Don't skip or cache flag evaluations to reduce exposure counts — LaunchDarkly deduplicates them automatically.
+```

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -4,9 +4,8 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Experimentation onboarding (track only) for ios-client-sdk — start the client from a setup function and add a trackMetric helper.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (defines setup + helper functions called from your app).
-# No validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -1,0 +1,40 @@
+---
+id: ios-client-sdk/experimentation/track-only
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Experimentation onboarding (track only) for ios-client-sdk — start the client from a setup function and add a trackMetric helper.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (defines setup + helper functions called from your app).
+# No validation block yet. See _experimentation-port-notes.md.
+---
+
+```swift
+import LaunchDarkly
+
+// Call this once from your app startup (e.g. application(_:didFinishLaunchingWithOptions:)).
+// You can't invoke LDClient.start() at the top level in Swift — wrap it in a function.
+func startLaunchDarkly() {
+    // This is your mobile key.
+    let config = LDConfig(mobileKey: "YOUR_MOBILE_KEY", autoEnvAttributes: .enabled)
+
+    // A "context" is a data object representing users, devices, organizations, and other entities.
+    let contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
+    guard case .success(let context) = contextBuilder.build() else { return }
+
+    LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in
+        if timedOut {
+            print("SDK didn't initialize in 5 seconds. SDK is still running and trying to get latest flags.")
+        } else {
+            print("SDK successfully initialized with the latest flags")
+        }
+    }
+}
+
+// Call trackMetric when a metric action occurs in your app —
+// a tap, a form submit, a screen view, a custom event, whatever your metric measures.
+func trackMetric(metricKey: String, data: LDValue = .null) {
+    let client = LDClient.get()!
+    client.track(key: metricKey, data: data)
+}
+```

--- a/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only.snippet.md
@@ -35,6 +35,11 @@ import UIKit
 import Foundation
 import LaunchDarkly
 
+// File-scope stubs so wrappee bodies that reference caller-supplied
+// helpers (e.g. the experimentation onboarding `applyVariant(_:)`)
+// type-check. Never invoked.
+func applyVariant(_ variant: String) {}
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/full.snippet.md
@@ -1,0 +1,54 @@
+---
+id: js-client-sdk/experimentation/full
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Full experimentation onboarding for js-client-sdk — initialize, identify on login/eligibility, evaluate, and track conversions.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (exports helpers consumed by your app). No validation
+# block yet. See _experimentation-port-notes.md.
+---
+
+```javascript
+import { createClient } from '@launchdarkly/js-client-sdk';
+
+// Initialize once — extra clients can cause inconsistent experiment results.
+// If you already know the user's key at startup, initialize with it directly and
+// skip identifyUser() below. Use an anonymous context only when you don't yet
+// know who the user is, and reuse that key when the user becomes known.
+export const ldClient = createClient('YOUR_CLIENT_SIDE_ID', {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY', // use a consistent key so the same user gets the same experience
+  anonymous: true,
+});
+
+// await start — you only need waitForInitialization() if you wait somewhere
+// other than where you start the client.
+await ldClient.start();
+
+// Call this only when the user becomes known after startup (consent/login/mid-funnel).
+export async function identifyUser({ userKey, attributes }) {
+  await ldClient.identify({
+    kind: 'user',
+    key: userKey, // use the logged-in user's ID so experiment assignment stays consistent
+    anonymous: false,
+    ...attributes, // any attributes that affect targeting or eligibility
+  });
+}
+
+// Call this ONLY where the user encounters the experience.
+export function evalExperimentFlag(flagKey, defaultValue) {
+  return ldClient.variation(flagKey, defaultValue);
+}
+
+// Call this when the user completes a metric action.
+// Use the same user key you used when evaluating the flag — mismatched keys break conversion tracking.
+// The data argument is optional and accepts any shape your metric needs.
+export function trackMetric(metricKey, data) {
+  ldClient.track(metricKey, data);
+}
+
+// The SDK batches and flushes events automatically. Don't add manual flush()
+// calls — they're unnecessary and actively harmful to performance.
+// Don't skip or cache variation() calls to reduce exposure counts — LaunchDarkly deduplicates them automatically.
+```

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/full.snippet.md
@@ -4,9 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Full experimentation onboarding for js-client-sdk — initialize, identify on login/eligibility, evaluate, and track conversions.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (exports helpers consumed by your app). No validation
-# block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```javascript

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/full.snippet.md
@@ -29,10 +29,10 @@ await ldClient.start();
 // Call this only when the user becomes known after startup (consent/login/mid-funnel).
 export async function identifyUser({ userKey, attributes }) {
   await ldClient.identify({
+    ...attributes, // any attributes that affect targeting or eligibility (spread first so it can't override the fields below)
     kind: 'user',
     key: userKey, // use the logged-in user's ID so experiment assignment stays consistent
     anonymous: false,
-    ...attributes, // any attributes that affect targeting or eligibility
   });
 }
 

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -4,9 +4,8 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Experimentation onboarding (track only) for js-client-sdk — initialize and add a trackMetric helper for conversion events.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (defines a trackMetric helper for your app). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
 ---
 
 ```javascript

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -1,0 +1,35 @@
+---
+id: js-client-sdk/experimentation/track-only
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Experimentation onboarding (track only) for js-client-sdk — initialize and add a trackMetric helper for conversion events.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (defines a trackMetric helper for your app). No
+# validation block yet. See _experimentation-port-notes.md.
+---
+
+```javascript
+import { createClient } from '@launchdarkly/js-client-sdk';
+
+// A "context" is a data object representing users, devices, organizations, and
+// other entities. You'll need this later, but you can ignore it for now.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+};
+
+// This is your client-side ID.
+const ldClient = createClient('YOUR_CLIENT_SIDE_ID', context);
+
+// await start — you only need waitForInitialization() if you wait somewhere
+// other than where you start the client.
+await ldClient.start();
+console.log('SDK successfully initialized!');
+
+// Call trackMetric when a metric action occurs in your app —
+// a click, a form submit, a page view, a custom event, whatever your metric measures.
+function trackMetric(metricKey, data) {
+  ldClient.track(metricKey, data);
+}
+```

--- a/snippets/sdks/react-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/experimentation/full.snippet.md
@@ -1,0 +1,85 @@
+---
+id: react-client-sdk/experimentation/full
+sdk: react-client-sdk
+kind: reference
+lang: tsx
+description: Full experimentation onboarding for react-client-sdk — initialize, identify on login/eligibility, evaluate, and track conversions.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (references your own components and applyVariant). No
+# validation block yet. See _experimentation-port-notes.md.
+---
+
+```tsx
+import { StrictMode, useEffect, useState, useCallback } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  createLDReactProvider,
+  useLDClient,
+  useFlags,
+} from "@launchdarkly/react-sdk";
+
+// Initialize once — extra clients can cause inconsistent experiment results.
+// If you already know the user's key at startup, initialize with it directly and
+// skip the identify() call below — that removes a window for mistakes. Use an
+// anonymous context only when you don't yet know who the user is.
+const LDProvider = createLDReactProvider("YOUR_CLIENT_SIDE_ID", {
+  kind: "user",
+  key: "EXAMPLE_CONTEXT_KEY", // use a consistent key so the same user gets the same experience
+  anonymous: true,
+});
+
+function App() {
+  const ldClient = useLDClient();
+  const flags = useFlags();
+  const [isIdentified, setIsIdentified] = useState(false);
+
+  // Only needed when the user becomes known after startup (login/eligibility).
+  // Reuse the anonymous key where possible so experiment assignment stays stable,
+  // and wait for identify to finish before evaluating experiment flags.
+  useEffect(() => {
+    if (!ldClient) return;
+
+    (async () => {
+      await ldClient.identify({
+        kind: "user",
+        key: "EXAMPLE_CONTEXT_KEY", // use the logged-in user's ID so experiment assignment stays consistent
+        anonymous: false,
+        // any attributes that affect targeting or eligibility
+      });
+      setIsIdentified(true);
+    })();
+  }, [ldClient]);
+
+  // Evaluate the experiment flag where the user encounters the experience.
+  const experimentValue = isIdentified ? flags["YOUR_FLAG_KEY"] : "control";
+
+  // Call this when the user completes a metric action.
+  // Use the same user key you used when evaluating the flag — mismatched keys break conversion tracking.
+  // The data argument is optional and accepts any shape your metric needs.
+  const trackMetric = useCallback(
+    (metricKey, data) => {
+      ldClient?.track(metricKey, data);
+    },
+    [ldClient],
+  );
+
+  // The SDK batches and flushes events automatically. Don't add manual flush()
+  // calls — they're unnecessary and actively harmful to performance in
+  // long-running apps.
+  // Don't skip or cache flag evaluations to reduce exposure counts — LaunchDarkly deduplicates them automatically.
+
+  return (
+    <button onClick={() => trackMetric("YOUR_METRIC_KEY" /* optional data */)}>
+      {experimentValue}
+    </button>
+  );
+}
+
+createRoot(document.getElementById("root")).render(
+  <StrictMode>
+    <LDProvider>
+      <App />
+    </LDProvider>
+  </StrictMode>,
+);
+```

--- a/snippets/sdks/react-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/experimentation/full.snippet.md
@@ -4,9 +4,8 @@ sdk: react-client-sdk
 kind: reference
 lang: tsx
 description: Full experimentation onboarding for react-client-sdk — initialize, identify on login/eligibility, evaluate, and track conversions.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (references your own components and applyVariant). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
 ---
 
 ```tsx

--- a/snippets/sdks/react-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -4,9 +4,8 @@ sdk: react-client-sdk
 kind: reference
 lang: tsx
 description: Experimentation onboarding (track only) for react-client-sdk — initialize and add a trackMetric helper for conversion events.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (defines App + a trackMetric helper around your own
-# components). No validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
 ---
 
 ```tsx

--- a/snippets/sdks/react-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -1,0 +1,49 @@
+---
+id: react-client-sdk/experimentation/track-only
+sdk: react-client-sdk
+kind: reference
+lang: tsx
+description: Experimentation onboarding (track only) for react-client-sdk — initialize and add a trackMetric helper for conversion events.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (defines App + a trackMetric helper around your own
+# components). No validation block yet. See _experimentation-port-notes.md.
+---
+
+```tsx
+// Add the code below to the root of your React app.
+import { StrictMode, useCallback } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createLDReactProvider, useLDClient } from '@launchdarkly/react-sdk';
+
+function App() {
+  const ldClient = useLDClient();
+  // Call trackMetric when a metric action occurs in your app —
+  // a click, a form submit, a page view, a custom event, whatever your metric measures.
+  const trackMetric = useCallback(
+    (metricKey: string, data?: unknown) => {
+      ldClient?.track(metricKey, data);
+    },
+    [ldClient],
+  );
+  return <div>Let your feature flags fly!</div>;
+}
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+  email: 'biz@face.dev',
+};
+
+// Initialize the SDK so flag values are ready before your app renders.
+// This is your client-side ID.
+const LDProvider = createLDReactProvider('YOUR_CLIENT_SIDE_ID', context);
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
+    <LDProvider>
+      <App />
+    </LDProvider>
+  </StrictMode>,
+);
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/full.snippet.md
@@ -4,9 +4,8 @@ sdk: react-native-client-sdk
 kind: reference
 lang: tsx
 description: Full experimentation onboarding for react-native-client-sdk — initialize, identify on login/eligibility, evaluate, and track conversions.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (renders your own YourComponent). No validation block
-# yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
 ---
 
 ```tsx

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/full.snippet.md
@@ -1,0 +1,90 @@
+---
+id: react-native-client-sdk/experimentation/full
+sdk: react-native-client-sdk
+kind: reference
+lang: tsx
+description: Full experimentation onboarding for react-native-client-sdk — initialize, identify on login/eligibility, and track conversions.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (renders your own YourComponent). No validation block
+# yet. See _experimentation-port-notes.md.
+---
+
+```tsx
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  AutoEnvAttributes,
+  LDProvider,
+  ReactNativeLDClient,
+} from '@launchdarkly/react-native-client-sdk';
+
+// Initialize once — extra clients can cause inconsistent experiment results.
+const ldClient = new ReactNativeLDClient('YOUR_MOBILE_KEY', AutoEnvAttributes.Enabled, {
+  debug: true,
+  applicationInfo: {
+    id: 'ld-rn-test-app',
+    version: '0.0.1',
+  },
+});
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+// If you already know the user's key at startup, initialize with it directly.
+// Use an anonymous context only when you don't yet know who the user is.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY', // use a consistent key so the same user gets the same experience
+  anonymous: true,
+};
+
+export default function App() {
+  const [ready, setReady] = useState<boolean>(false);
+
+  // Identify with the initial context on startup so flags are usable right away.
+  useEffect(() => {
+    (async () => {
+      await ldClient.identify(context);
+      setReady(true);
+    })();
+  }, []);
+
+  // Call this only when the user becomes known after startup (login/eligibility).
+  // Reuse the anonymous key where possible so experiment assignment stays stable,
+  // and wait for identify to finish before evaluating experiment flags.
+  const identifyUser = useCallback(
+    async ({ userKey, attributes }: { userKey: string; attributes: Record<string, unknown> }): Promise<void> => {
+      await ldClient.identify({
+        kind: 'user',
+        key: userKey, // use the logged-in user's ID so experiment assignment stays consistent
+        anonymous: false,
+        ...attributes, // any attributes that affect targeting or eligibility
+      });
+    },
+    []
+  );
+
+  // Call this when the user completes a metric action.
+  // Use the same user key you used when evaluating the flag — mismatched keys break conversion tracking.
+  // The data argument is optional and accepts any shape your metric needs.
+  const trackMetric = useCallback(
+    (metricKey: string, data?: unknown): void => {
+      ldClient.track(metricKey, data);
+    },
+    []
+  );
+
+  // The SDK batches and flushes events automatically, including when the app is
+  // backgrounded. Don't add manual flush() calls or AppState listeners — they're
+  // unnecessary and make real problems harder to spot.
+  // Don't skip or cache flag evaluations to reduce exposure counts — LaunchDarkly deduplicates them automatically.
+
+  if (!ready) return null;
+
+  return (
+    <LDProvider client={ldClient}>
+      <YourComponent
+        identifyUser={identifyUser}
+        onConversion={() => trackMetric('YOUR_METRIC_KEY', /* optional data */)}
+      />
+    </LDProvider>
+  );
+}
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/full.snippet.md
@@ -3,7 +3,7 @@ id: react-native-client-sdk/experimentation/full
 sdk: react-native-client-sdk
 kind: reference
 lang: tsx
-description: Full experimentation onboarding for react-native-client-sdk — initialize, identify on login/eligibility, and track conversions.
+description: Full experimentation onboarding for react-native-client-sdk — initialize, identify on login/eligibility, evaluate, and track conversions.
 # Bucket C: newly proposed experimentation onboarding snippet, not
 # standalone-runnable (renders your own YourComponent). No validation block
 # yet. See _experimentation-port-notes.md.
@@ -52,11 +52,20 @@ export default function App() {
   const identifyUser = useCallback(
     async ({ userKey, attributes }: { userKey: string; attributes: Record<string, unknown> }): Promise<void> => {
       await ldClient.identify({
+        ...attributes, // any attributes that affect targeting or eligibility (spread first so it can't override the fields below)
         kind: 'user',
         key: userKey, // use the logged-in user's ID so experiment assignment stays consistent
         anonymous: false,
-        ...attributes, // any attributes that affect targeting or eligibility
       });
+    },
+    []
+  );
+
+  // Call this ONLY where the user encounters the experience.
+  // Evaluate after identify resolves, using the same context you identified.
+  const evalExperimentFlag = useCallback(
+    (flagKey: string, defaultValue: unknown): unknown => {
+      return ldClient.variation(flagKey, defaultValue);
     },
     []
   );
@@ -82,6 +91,7 @@ export default function App() {
     <LDProvider client={ldClient}>
       <YourComponent
         identifyUser={identifyUser}
+        variant={evalExperimentFlag('YOUR_FLAG_KEY', 'control')}
         onConversion={() => trackMetric('YOUR_METRIC_KEY', /* optional data */)}
       />
     </LDProvider>

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -1,0 +1,57 @@
+---
+id: react-native-client-sdk/experimentation/track-only
+sdk: react-native-client-sdk
+kind: reference
+lang: tsx
+description: Experimentation onboarding (track only) for react-native-client-sdk — initialize, identify, and add a trackMetric helper for conversion events.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (renders your own YourComponent). No validation block
+# yet. See _experimentation-port-notes.md.
+---
+
+```tsx
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  AutoEnvAttributes,
+  LDProvider,
+  ReactNativeLDClient,
+} from '@launchdarkly/react-native-client-sdk';
+
+// This is your mobile key.
+const ldClient = new ReactNativeLDClient('YOUR_MOBILE_KEY', AutoEnvAttributes.Enabled, {
+  debug: true,
+  applicationInfo: {
+    id: 'ld-rn-test-app',
+    version: '0.0.1',
+  },
+});
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY' };
+
+export default function App() {
+  const [ready, setReady] = useState<boolean>(false);
+  // Wait for identify to complete before rendering, so no flag evaluates
+  // against defaults during startup.
+  useEffect(() => {
+    (async () => {
+      await ldClient.identify(context);
+      setReady(true);
+    })();
+  }, []);
+  // Call trackMetric when a metric action occurs in your app —
+  // a tap, a form submit, a screen view, a custom event, whatever your metric measures.
+  const trackMetric = useCallback(
+    (metricKey: string, data?: unknown) => {
+      ldClient.track(metricKey, data);
+    },
+    [],
+  );
+  if (!ready) return null;
+  return (
+    <LDProvider client={ldClient}>
+      <YourComponent />
+    </LDProvider>
+  );
+}
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -4,9 +4,8 @@ sdk: react-native-client-sdk
 kind: reference
 lang: tsx
 description: Experimentation onboarding (track only) for react-native-client-sdk — initialize, identify, and add a trackMetric helper for conversion events.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (renders your own YourComponent). No validation block
-# yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
 ---
 
 ```tsx

--- a/snippets/sdks/react-native-client-sdk/snippets/scaffolds/react-native-syntax-only.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/scaffolds/react-native-syntax-only.snippet.md
@@ -27,7 +27,6 @@ validation:
 ---
 
 ```tsx
-import React from 'react';
 //IMPORT_LIFT_TARGET
 
 // @ts-expect-error -- never invoked; references to undefined names are fine


### PR DESCRIPTION
## Summary

Adds a new `experimentation/` snippet group for the five **frontend** client SDKs, ported from the Confluence page [Proposed onboarding SDK snippets for experimentation](https://launchdarkly.atlassian.net/wiki/spaces/~145214334/pages/4880073181/Proposed+onboarding+SDK+snippets+for+experimentation). Each SDK gets two variants: **track-only** and **full**.

- `react-client-sdk` (React Web), `js-client-sdk`, `react-native-client-sdk`, `ios-client-sdk`, `android-client-sdk`
- 10 snippet files + `snippets/sdks/_experimentation-port-notes.md`

### Reviewer comments from the page, applied inline
- **React Web**: unified both variants on the current `@launchdarkly/react-sdk` (`createLDReactProvider`/`useLDClient`/`useFlags`); the page's track-only still used the legacy `launchdarkly-react-client-sdk`.
- **JavaScript**: `await start()` instead of `start()` + `waitForInitialization()`.
- **JavaScript / React Native**: renamed the confusing `setExperimentContext` to `identifyUser`, and reframed guidance to initialize directly with a known deterministic key (anonymous only when the key is unknown).
- **All client variants**: removed manual `flush()` calls and the mobile background-flush handlers (RN `AppState`, iOS `applicationDidEnterBackground`, Android `onStop()`) — FDv2 client SDKs flush on background automatically and manual flushing is harmful in long-running apps; strengthened the wording.
- **iOS**: moved top-level `LDClient.start(...)` into a `startLaunchDarkly()` setup function (can't call member functions at top level in Swift).
- **Android**: fixed the AutoEnv import in track-only to `com.launchdarkly.sdk.android.AutoEnvAttributes`.

### Notes
- **Content-only (Bucket C)**: these are newly proposed, multi-function examples that aren't standalone-runnable and have no consumer (gonfalon) wiring yet, so they carry no `validation:` block. `snippets validate` only runs snippets with a validation block and `snippets-validate.yml` never targets the `experimentation` group, so CI surface is unchanged. Rationale + open questions (AI Config SDK experimentation, dedicated anonymous context kind) are documented in the port-notes file.
- Out of scope: the server-side snippets (Node/Python/.NET/Java/Go) and their review comments.

## Test plan
- [x] `go build ./...` passes
- [x] `snippets validate` runs `model.LoadAll` over the full tree without parse or duplicate-id errors (returns the expected "no validatable snippets found" for the validation-less experimentation group)
- [ ] Reviewer sanity-check of each snippet against the page + comments

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and snippet-validator scaffold tweaks only; no runtime product or auth/data-path changes.
> 
> **Overview**
> Adds an **`experimentation/`** snippet group for five frontend client SDKs (**`track-only`** and **`full`** per SDK), ported from Confluence with reviewer feedback baked into the copy and traceability in **`_experimentation-port-notes.md`**.
> 
> The snippets walk through experimentation onboarding: init (prefer a stable context key), **`identify`** when the user becomes known, flag evaluation at the experience, and **`track`** for conversions. Cross-cutting editorial changes include **`await start()`** on JS, **`identifyUser`** instead of **`setExperimentContext`**, dropping manual **`flush()`** / background-flush patterns, modern **`@launchdarkly/react-sdk`** on React Web, **`startLaunchDarkly()`** on iOS, and a corrected Android **`AutoEnvAttributes`** import.
> 
> **Eight** snippets wire to existing **`*-syntax-only`** scaffolds (JS, React, React Native, iOS). Scaffold tweaks: iOS gains an **`applyVariant`** stub for type-checking; React Native drops a duplicate file-scope React import. **Android** snippets ship without **`validation:`** (Bucket C — Kotlin/Android types don’t fit today’s JVM syntax-only harness); port notes document that gap and open questions (AI Config experimentation, anonymous context kind).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee9f52db8485f7ef340e295b94c6ec5147b0d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->