### PR TITLE
docs(snippets): add CLAUDE.md authoring guide + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent guide — launchdarkly/sdk-meta
+
+This repo is a monorepo. For most work the first thing to read is the per-subtree guide, not this file.
+
+## Where to start
+
+- **Snippets work** (authoring `.snippet.md` files, adding scaffolds, extending validators, editing the CI matrix): read `snippets/CLAUDE.md`. It's auto-loaded when your cwd is under `snippets/`. Don't author snippet content in consumer repos (gonfalon, ld-docs) — those only carry markers that point back here.
+- **Non-snippets work**: read `CLAUDE.md` at the repo root if it exists. Otherwise read the README under the relevant subtree.
+
+## Top-level surfaces
+
+| Path | Purpose |
+|---|---|
+| `snippets/` | Canonical home of every SDK snippet body, plus the CLI (`cmd/snippets`), per-language validator harnesses (`validators/`), and the validation CI workflow. **See `snippets/CLAUDE.md`.** |
+| `api/` | OpenAPI specs and generated artifacts (Go side). |
+| `api-js/` | JS/TS package built from the API specs. Released by release-please alongside `snippets`. |
+| `metadata/` | SDK metadata source (versions, support matrix, end-of-life dates). |
+| `products/` | Generated product/SDK-info JSON consumed by docs and the LD dashboard. |
+| `backfill/` | One-off scripts for back-filling historical metadata. |
+| `schemas/` | JSON schemas for the metadata + products outputs. |
+| `scripts/` | Repo-level shell tooling. |
+| `tool/` | Go tooling for metadata generation. |
+| `.github/workflows/` | CI — `snippets-validate.yml` (snippets matrix), `release-please.yml` (monorepo releases). |
+
+## Conventions across the repo
+
+- Conventional Commits with a scope: `feat(snippets): …`, `fix(metadata): …`, `chore: …`. release-please drives changelogs and version bumps from these.
+- Two release-please packages: `api-js` and `snippets`. Each ships its own tag (`api-js/vX.Y.Z`, `snippets/vX.Y.Z`) and changelog.
+- For snippet PRs: branch `rlamb/sdk-NNNN/desc`, ticket in branch + PR body (not PR title), sequential PRs, base on `main` once predecessor has merged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,3 @@ This repo is a monorepo. For most work the first thing to read is the per-subtre
 
 - Conventional Commits with a scope: `feat(snippets): …`, `fix(metadata): …`, `chore: …`. release-please drives changelogs and version bumps from these.
 - Two release-please packages: `api-js` and `snippets`. Each ships its own tag (`api-js/vX.Y.Z`, `snippets/vX.Y.Z`) and changelog.
-- For snippet PRs: branch `rlamb/sdk-NNNN/desc`, ticket in branch + PR body (not PR title), sequential PRs, base on `main` once predecessor has merged.

--- a/snippets/CLAUDE.md
+++ b/snippets/CLAUDE.md
@@ -1,0 +1,649 @@
+# Snippets system — agent guide
+
+Auto-loaded by Claude Code when an agent's cwd is anywhere under `snippets/`. Read this before authoring snippets, scaffolds, validators, or CI rows. This document describes the system **as it is** — not as it might become.
+
+## Don't author snippet content in unrelated repos
+
+This repo (`launchdarkly/sdk-meta`) is the **canonical home** of every snippet body. Consumers (`gonfalon`, `ld-docs-private`, `ld-docs`) only carry **markers** that point back here:
+
+- `ld-docs` / `ld-docs-private` — `<!-- SDK_SNIPPET:RENDER id="..." -->` markers in MDX. The `snippets render --target=ld-docs` adapter rewrites the fenced code block underneath each marker.
+- `gonfalon` (ld-application) — `SDK_SNIPPET:RENDER` markers around JSX components; `snippets render --target=ld-application` rewrites the children.
+- `gonfalon` raw-file consumers (e.g. `packages/sdk-info/`) — Vite `?raw` imports of files emitted by `snippets render --target=raw-files` from a YAML manifest.
+
+If you find yourself editing snippet content in a consumer repo, **stop**. The change belongs here as a `.snippet.md` edit; the consumer either picks it up via `snippets render` (CI / sync action) or by re-imported raw files. The only things that legitimately live downstream are the markers themselves and the manifest YAMLs (for raw-files consumers).
+
+## Repo layout
+
+Everything in this guide is relative to `snippets/` (this directory).
+
+```
+snippets/
+  cmd/snippets/         # CLI entry point (main.go); render | verify | validate | version
+  internal/
+    model/              # Frontmatter schema + loader (model.go: Frontmatter, Input, Validation, ParseFile, LoadAll)
+    render/             # Templating DSL (template.go) + RenderRuntime / RenderForLDApplicationTemplate / RenderForJSXText (render.go)
+    adapters/
+      ldapplication/    # JSX-marker rewrite for gonfalon
+      lddocs/           # MDX-marker rewrite for ld-docs
+      rawfiles/         # Manifest-driven file emitter
+    validate/           # validate.Run; stages snippets, builds/runs harnesses
+    version/            # Version stamped by release-please ldflags
+  embedded.go           # Embeds sdks/** into the binary; snippets.SDKsFS() returns the snapshot
+  sdks/
+    _shared/snippets/<group>/...      # Cross-SDK snippets (no sdk: frontmatter field)
+    <sdk-name>/snippets/<group>/...   # Per-SDK snippets
+  validators/
+    shared/lib.sh                     # require_env, await_success_line, dump_redacted, fail_with_log
+    languages/<runtime>/              # Per-language harness
+      runner.yaml                     # mode, runs-on, image-prefix
+      Dockerfile                      # docker mode only; build context is validators/
+      harness/run.sh                  # entrypoint
+      scaffold/ or test/              # Optional: pre-built project or driver code
+  docs/AUTHORING.md     # Older authoring doc; partly stale (older kind values), DSL section still accurate
+```
+
+Top-level workflows that touch this tree:
+
+- `.github/workflows/snippets-validate.yml` — fans the matrix across SDKs and runs `snippets validate`.
+- `.github/workflows/release-please.yml` — cuts the `snippets/vX.Y.Z` release.
+
+## Snippet file format
+
+A snippet lives at `sdks/<sdk>/snippets/<group>/<name>.snippet.md` (or `sdks/_shared/snippets/<group>/<name>.snippet.md` for cross-SDK snippets). The parser expects:
+
+1. YAML frontmatter fenced by `---` lines at the top of the file.
+2. Exactly **one** fenced code block somewhere after the frontmatter; only the FIRST block is captured as the body. Prose between frontmatter and fence is ignored.
+3. `KnownFields(true)` decoding — unknown frontmatter keys are a parse error. Typos (`Description:`, `entrypiont:`) fail loudly.
+4. Globally unique `id` across the whole tree; collisions error at load.
+
+The parsed `Snippet{Path, Frontmatter, CodeLang, CodeBody}` is what every downstream tool consumes.
+
+### Top-level frontmatter fields
+
+Every key the parser models. Adding a new key requires editing `internal/model/model.go`.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Globally unique. Convention: `<sdk>/<group>/<name>`. `_shared` snippets drop the sdk prefix (e.g. `id: cursor-prompt`). |
+| `sdk` | string | – | Matches a directory under `sdks/`. Omit for `_shared/` snippets. |
+| `kind` | string | yes | Categorical label. Live values: `install`, `init`, `initialize`, `import`, `context`, `implementation`, `flag-eval`, `reference`, `scaffold`. |
+| `lang` | string | yes | Fenced-code language tag. Also the default `validation.runtime` when that field is empty. |
+| `file` | string | – | Relative path consumers see and the validator writes the rendered body to. Omitted on `kind: reference` (the wrapping scaffold owns the path). |
+| `description` | string | recommended | One-liner. Supports YAML `|` block scalars for multi-paragraph rationale (scaffolds). |
+| `inputs` | map | – | Declared templating inputs. Each entry: `type` (e.g. `string`, `flag-key`), `description`, optional `runtime-default`. Use `inputs: {}` for scaffolds that take no parameters. |
+| `validation` | map | – | Absence means "don't run through the validator." See below. |
+
+### `validation.*` fields
+
+| Field | Notes |
+|---|---|
+| `runtime` | Picks a harness under `validators/languages/<runtime>/`. Falls back to `lang:` if empty. Set explicitly when `lang` and runtime differ (e.g. `lang: javascript` + `runtime: node`; `lang: ts` + `runtime: js-client`). |
+| `entrypoint` | File the harness invokes inside the staging dir. Defaults to `file:`. |
+| `requirements` | Runtime-specific dependency descriptor. Python → `requirements.txt` contents (use `|`). Node → top-level dep name. .NET → NuGet package id. Other languages ship deps via a companion manifest scaffold. |
+| `companions` | List of snippet IDs staged alongside; each is rendered with the same inputs and written to its own `file:`. Used for multi-file projects. |
+| `scaffold` | ID of a `kind: scaffold` snippet to wrap this body in. **Mutually exclusive** with `runtime` / `entrypoint` / `requirements` / `companions` — those come from the scaffold. |
+| `scaffold-inputs` | Map of named values passed into the scaffold's template beyond the implicit `body`. Lets one scaffold serve wrappees with slightly different setup. |
+| `env` | Literal `KEY: VALUE` pairs forwarded into the harness process. No substitution. Used as a harness-side discriminator (e.g. `INSTALL_KIND: podfile`, `SNIPPET_MODE: flag-eval`). |
+| `placeholders` | Literal source-text fragments **inside the rendered body** → env-var names. After rendering and scaffold composition, the dispatcher string-replaces each key with the named env var's value. Only the EXAM-HELLO allow-list is honored: `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, `LAUNCHDARKLY_MOBILE_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID`. |
+
+Merge order for the harness env: scaffold's `validation.env` first, then wrappee's `validation.env` overrides. `requireEnvForInputs` walks the entrypoint + companions before any Docker build and fails fast if a placeholder's mapped env var is unset.
+
+### Templating DSL
+
+Defined in `internal/render/template.go` and `render.go`. Intentionally tiny:
+
+- `{{ name }}` — substitute the value of a declared input. Names match `[a-zA-Z][a-zA-Z0-9_]*`. Whitespace inside the braces is flexible; the parser captures the exact source form so foreign-template syntax round-trips byte-identically.
+- `{{ name | filter }}` — substitute with a filter. The only filter today is `camelCase` (react-client-sdk uses it so `useFlags()` destructuring works on a kebab-cased flag key). Any other filter is a parse error.
+- `{{ if name }}…{{ end }}` — emit the inner content only if `name` resolves to non-empty. Conditionals do not nest; the inner content may still contain `{{ name }}` substitutions. The conditional's `name` must be a declared input — undeclared names in a conditional are a render error.
+- **Foreign-template passthrough**: any `{{ name }}` whose name is NOT in the declared inputs map is emitted verbatim, preserving surrounding whitespace. This is what lets Vue's mustache syntax and `_shared/cursor-prompt`'s literal `{{SDK_NAME}}` (no inner whitespace — gonfalon's runtime regex requires exactly that form) survive validation untouched.
+- `{{ body }}` slot in scaffolds is just `{{ name }}` where `name == "body"`. The scaffold declares `inputs: { body: { type: string, description: ... } }` and the validator substitutes the wrappee's rendered body at that point.
+
+The same body renders three ways without authors picking a mode:
+
+- `RenderRuntime` — concrete values for the validator.
+- `RenderForLDApplicationTemplate` — JS template-literal with `${name}` interpolations and `${name ? \`…\` : ''}` ternaries (gonfalon).
+- `RenderForJSXText` — same as ld-application for JSX text contexts.
+
+The `verify` pass renders identically to `ld-application` and compares byte-for-byte against the consumer file.
+
+### Common shapes
+
+**Install (shell-install runtime)**:
+
+```markdown
+---
+id: react-client-sdk/sdk-info/install-yarn
+sdk: react-client-sdk
+kind: install
+lang: shell
+file: react-client-sdk/install-yarn.txt
+description: Install command for react-client-sdk (yarn).
+validation:
+  runtime: shell-install
+---
+
+```shell
+yarn add @launchdarkly/react-sdk
+```
+```
+
+The `ios-install` variant carries an `env:` discriminator because Podfile / Cartfile / Package.swift fragments aren't shell-sniffable:
+
+```yaml
+validation:
+  runtime: ios-install
+  env:
+    INSTALL_KIND: podfile
+```
+
+**Reference (wrapped by a scaffold)**: no `file:`, no runtime/entrypoint/requirements/companions — the scaffold owns those.
+
+```markdown
+---
+id: ios-client-sdk/sdk-docs/evaluate-a-flag-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: 'Swift in section "Evaluate a flag"'
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+---
+
+```swift
+let client = LDClient.get()!
+```
+```
+
+**Runnable init (scaffold + placeholders)**: body is unchanged from what consumers see; substitution happens at validate time only.
+
+```markdown
+---
+id: ios-client-sdk/sdk-info/init
+sdk: ios-client-sdk
+kind: init
+lang: swift
+file: ios-client-sdk/init.txt
+description: Client initialization snippet for ios-client-sdk.
+validation:
+  scaffold: ios-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_MOBILE_KEY: LAUNCHDARKLY_MOBILE_KEY
+---
+
+```swift
+import LaunchDarkly
+
+let config = LDConfig(mobileKey: "YOUR_MOBILE_KEY", autoEnvAttributes: .enabled)
+// ...
+LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in
+    // ...
+}
+```
+```
+
+## Snippet groups (categories)
+
+Every snippet sits in one group folder. The group is the middle segment of the `id` and is what `--group` filters on.
+
+- `sdk-info` — install commands and the canonical init snippet. Consumed by gonfalon's sdk-info panels and ld-docs's quickstart pages. Typically `kind: install` or `kind: init`.
+- `sdk-docs` — fragments referenced from ld-docs MDX pages. Mostly `kind: reference` snippets wrapped by syntax-only scaffolds, plus some `kind: flag-eval` runners.
+- `observability` — `import` / `initialize` / `install` snippets for the LaunchDarkly observability plugins. Validated through `init-runner-observability` scaffolds that hand-supply the imports normally provided by the matching `observability/import` snippet.
+- `ai-configs` — `install` / `context` / `implementation` snippets for AI Configs. Currently node-server-sdk only.
+- `experimentation` — experimentation-specific fragments (where present).
+- `scaffolds` — `kind: scaffold` snippets only. Not consumed by docs; only by the validator (via wrappees' `validation.scaffold`).
+- `_shared/snippets/<group>/` — cross-SDK snippets whose `id` does not carry a sdk prefix. Example: `_shared/snippets/sdk-info/cursor-prompt.snippet.md`.
+
+## Scaffolds
+
+A scaffold is a `kind: scaffold` snippet whose body wraps a wrappee body via a `{{ body }}` slot. The scaffold owns the runtime, entrypoint, requirements, and companions; the wrappee just declares `validation.scaffold: <id>` (and, optionally, `placeholders:` and `scaffold-inputs:`).
+
+### Composition order (validate.stageSnippet)
+
+1. Resolve the wrappee's effective validation snippet via `validation.scaffold:`. Without a scaffold, the snippet renders itself.
+2. Render the wrappee body with its own runtime inputs.
+3. Apply `validation.placeholders` to that rendered body — literal source-text keys replaced with the value of the named env var (allow-list only).
+4. Build the scaffold's input map: scaffold's env-typed inputs + wrappee `scaffold-inputs:` + the special `body` slot set to the substituted wrappee body.
+5. Render the scaffold and write to `stageDir/<scaffold.file>`.
+6. Stage every companion (from the scaffold) at its own `file:`.
+
+### init-runner + companion pairs
+
+When a runtime needs more than one file at staging time, the scaffold uses `companions:` to point at sibling `kind: scaffold` snippets.
+
+- **Go**: `go-server-sdk/scaffolds/init-runner` has `file: wrappee/init.go` and body `{{ body }}` only; `entrypoint: main.go`; `companions: [go-server-sdk/scaffolds/init-runner-main]`. The companion ships the runner `main.go` that `exec.Command("go", "run", "wrappee/init.go")`s the wrappee, asserts its success line, then emits EXAM-HELLO. Two `package main` files in separate dirs are legal under a single `go.mod` at staging root.
+- **iOS**: `ios-client-sdk/scaffolds/init-runner` writes `AppDelegate.swift`; companion `init-runner-viewcontroller` writes `ViewController.swift`. The harness's `cp $SNIPPET_DIR/ViewController.swift` step requires the file. Parallel pair for the syntax-only flavor (`swift-syntax-only` + `swift-syntax-only-viewcontroller`).
+- **.NET (server)**: `dotnet-server-sdk/scaffolds/init-runner` ships `Program.cs`; companion `init-runner-csproj` ships `HelloDotNet.csproj` with `Sdk="Microsoft.NET.Sdk.Web"` so `WebApplication.CreateBuilder` resolves.
+- **Vue / React Native**: pairs use `init-runner-app` / `init-runner-welcome` companions for the `App.vue` / welcome screens.
+
+### Syntax-only scaffolds and IMPORT_LIFT
+
+ESM and Swift forbid top-level `import` inside a function body; Go requires `import (...)` at file scope. Doc fragments routinely combine "add this import" with "call this method," so several scaffolds embed markers the harness rewrites before invoking the compiler.
+
+`react-client-sdk/scaffolds/react-syntax-only`, `js-client-sdk/scaffolds/js-syntax-only`, and `react-native-client-sdk/scaffolds/react-native-syntax-only` follow this shape:
+
+```
+//IMPORT_LIFT_TARGET
+
+async function _wrappee() {
+  if (false) {
+//BODY_BEGIN
+{{ body }}
+//BODY_END
+  }
+}
+```
+
+The matching `validators/languages/<runtime>/harness/run.sh` greps for `//IMPORT_LIFT_TARGET` and, when present, runs an awk pass that walks `//BODY_BEGIN` … `//BODY_END`, treats `import` lines (including multi-line `import { ... } from '...';` continuations) as lift candidates, strips `export default` / `export` prefixes, and emits lifted imports just after `//IMPORT_LIFT_TARGET` at module scope. The rest stays inside `_wrappee()`.
+
+Go solves the same problem differently: `go-syntax-only` splits the body into top-level decls (`import (…)`, `func`, `var/const/type/package`) vs function-body residue, splices top-level into a synthesized `package wrappee\n` file, wraps the rest in `func _wrappee()`, then runs `go/parser.ParseFile`. C# uses a `// USING_LIFT_MARKER` comment with a harness pre-stage rewrite to lift `using …;` directives.
+
+### Parse-only stub surfaces
+
+Syntax-only scaffolds typically never execute the body — they just want it to compile/parse. To make unqualified names like `client`, `context`, `config` resolve without a real SDK environment:
+
+- **C++** (`cpp-client/server-syntax-only`): wrappee is a `template <int = 0> void _wrappee()` that is never instantiated; both native and C-binding SDK headers are included at file scope; a polymorphic `struct _AnyClient` declares variadic-template members (`BoolVariation`, `Identify`, `StartAsync`, …) plus an `operator LDClientSDK() const` so the same `client` name resolves whether the body uses the native or C-binding API. `struct _Maxwait` exposes implicit conversions to `unsigned int`, `chrono::milliseconds`, and `chrono::seconds`. `using namespace launchdarkly; using namespace launchdarkly::client_side;` (or `::server_side`) lets unqualified names resolve.
+- **.NET** (`dotnet-server-sdk/scaffolds/csharp-syntax-only`): `private static dynamic client = null;` accepts both the v6 `User` API and v7+ `Context` API. Body lives inside `private void Wrappee()` wrapped in `try { … } catch (Exception) { /* never reached */ }`. Requirements pin both `LaunchDarkly.ServerSdk` and `LaunchDarkly.Observability`.
+- **iOS** (`swift-syntax-only`): stub `client: LDClient!` on AppDelegate; body lives inside `_wrappee()` (never invoked); AppDelegate prints EXAM-HELLO from `didFinishLaunching`.
+- **Python** (`python-syntax-only`): parses via `ast.parse` inside a raw triple-quoted string. No execution. Companion `with-test-data` initializes against `TestData.data_source()` with a pre-populated `your.feature.key=True` flag, exposes `client` and `context` to the body, then evaluates the flag for EXAM-HELLO.
+
+### Placeholders contract
+
+gonfalon ships init bodies with literal placeholders like `'YOUR_SDK_KEY'`, `'YOUR_MOBILE_KEY'`, `'YOUR_CLIENT_SIDE_ID'`, `'SDK_KEY'` that the human user is expected to swap. Rewriting the body to use `{{ name }}` markers would corrupt the rendered output the docs consume. Instead the wrappee carries:
+
+```yaml
+validation:
+  scaffold: react-native-client-sdk/scaffolds/init-runner-observability
+  placeholders:
+    SDK_KEY: LAUNCHDARKLY_MOBILE_KEY
+```
+
+The dispatcher does a literal string replace on the rendered wrappee body **before** splicing into the scaffold. Allow-list is exactly `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, `LAUNCHDARKLY_MOBILE_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID`; any other name is rejected.
+
+`validation.env:` is unrelated — it carries literal KEY=VALUE pairs to the harness process. No env lookup, no template substitution. Used to switch harness behavior per wrappee:
+
+- `ios-install`: each install snippet sets `INSTALL_KIND: swift-package | podfile | cartfile`.
+- `react-client/flag-eval-runner` and `react-native-client/syntax-only`: set `SNIPPET_MODE: flag-eval` or `syntax-only` so the same harness either Babel-parses or runs a full LD-backed render.
+
+### init-runner-observability scaffolds
+
+Six companion scaffolds (js-client, node-server, python-server, react-client, react-native-client, vue-client) solve the same problem: an `observability/initialize` body declares the LD client + observability plugin but assumes the matching `observability/import` snippet ran at module scope. Each scaffold hand-supplies that module-scope `import` block, splices `{{ body }}` at module scope (or inside an async IIFE for js-client), awaits init via the SDK's appropriate signal (`waitForInitialization`, `is_initialized()` polling, a `Sentinel` rendered inside the body's `LDProvider`, a DOM sentinel for Vue), then emits EXAM-HELLO. Best-effort `flush()` + `close()` after success (Node, Python). Vue / RN also use `companions:` for `init-runner-app` / `init-runner-welcome` screens.
+
+The PR that introduced these scaffolds also extended `js-syntax-only` and `react-native-syntax-only` with IMPORT_LIFT markers so observability `import` snippets — which carry top-level `import …;` directives — can pass the syntax-only path.
+
+### Adding a new scaffold (checklist)
+
+1. **Pick the runtime** — a directory under `validators/languages/<runtime>/` must already exist (with `Dockerfile`, `harness/run.sh`, `runner.yaml`) or you'll need to build it. Reuse where possible.
+2. **Single-file or paired** — if the runtime needs >1 file at staging time (manifest, view controller, app shell), make a companion scaffold and list its ID in `validation.companions:`. Set `validation.entrypoint:` on the parent if the entrypoint isn't its own `file:`.
+3. **Wire `{{ body }}`** — declare `inputs: { body: { type: string, description: ... } }` and embed `{{ body }}` once in the code block. For runtimes where the body language forbids imports inside functions, add the `//IMPORT_LIFT_TARGET` + `//BODY_BEGIN` / `//BODY_END` triad and either extend an existing awk lift pre-step or add one in `harness/run.sh`.
+4. **Stub the runtime surface for parse-only scaffolds** — declare stubs for `client`, `context`, `config` so the body's references resolve at compile/parse time without running.
+5. **Emit EXAM-HELLO** — end with the canonical success line (`feature flag evaluates to true` printed to stdout, or written into a known DOM node / `Tests` label). Gate the line on a real init signal (`waitForInitialization`, `is_initialized()`, sentinel render).
+6. **Use `placeholders:`, not template markers** — when the body should retain `'YOUR_SDK_KEY'`-style literals for docs rendering but use real keys at validate time, the **wrappee** (not the scaffold) declares `validation.placeholders:` and the dispatcher substitutes pre-splice.
+7. **Per-snippet env via `validation.env:`** — set literal KEY=VALUE there when one harness needs to switch behavior per wrappee, and have `harness/run.sh` dispatch on `$KEY`.
+8. **Requirements** — Python ships `validation.requirements: |` as the literal `requirements.txt`. Other languages ship a companion manifest scaffold.
+9. **Wrappee binding** — the wrappee declares `validation.scaffold: <sdk>/scaffolds/<name>` and, when needed, `validation.scaffold-inputs: { ... }`.
+
+## Validator harnesses
+
+Each language validator lives at `validators/languages/<runtime>/` with this skeleton:
+
+```
+runner.yaml      # mode, runs-on, image-prefix
+Dockerfile       # docker mode only; build context = validators/
+harness/run.sh   # entrypoint
+test/ or scaffold/   # optional driver code / pre-built project
+```
+
+Shared helpers: `validators/shared/lib.sh`.
+
+### runner.yaml
+
+```yaml
+mode: docker            # or: native
+runs-on: ubuntu-latest  # or: macos-latest
+image-prefix: sdk-snippets/python-validator   # docker mode only
+```
+
+- `mode: docker` — Go validator builds the Dockerfile, runs the container with `/snippet` bind-mounted to the staged snippet.
+- `mode: native` — Go validator execs `harness/run.sh` on the host and passes `$SNIPPET_DIR` plus the LD env vars. Used by `ios-client` (xcodebuild + Simulator can't run in Linux). No `image-prefix`.
+- `runs-on` — hint for the CI matrix; the Go validator itself does not read it.
+- `image-prefix` — required for docker mode; local image tag.
+
+### Dockerfile pattern
+
+1. `FROM` a runtime-appropriate base (`python:3.11-slim`, `node:20-bookworm-slim`, `node:22-bookworm`, `mcr.microsoft.com/playwright:v1.59.1-noble`, `eclipse-temurin:17-jdk-noble`).
+2. Install OS packages: `apt-get update ... && apt-get install ... && rm -rf /var/lib/apt/lists/*`. `android-client` uses `Acquire::Retries=5` and curl `--retry 3` for flaky noble mirrors.
+3. Layer additional toolchains as needed. `shell-install` adds Go via the upstream tarball, pip via `python3-pip`, and `corepack prepare pnpm@9 --activate` + a `yarn@1` pin compatible with Node 20.
+4. Pre-bake a project dir with the SDK and dev deps pre-installed so per-validate cycles stay fast. Examples:
+   - `js-client` writes `package.json` / `tsdown.config.ts` / `tsconfig.json` / placeholder `src/app.ts` + `index.html` under `/opt/hello-js`, then `npm install` and a pre-warm `npm run build`.
+   - `react-native-client` writes `package.json` / `babel.config.js` / `jest.setup.js` / `tsconfig.json` + placeholder `App.tsx` and `src/welcome.tsx` under `/opt/hello-react-native` and runs `npm install`.
+   - `android-client` clones `launchdarkly/hello-android` to `/opt/hello-android`, patches `app/build.gradle` (SDK version, Robolectric + junit + androidx test deps, `testOptions { unitTests.includeAndroidResources = true; all { testLogging { showStandardStreams = true } } }`), and copies in `HelloAppTest.kt`.
+5. Copy the shared lib and harness, then set the entrypoint:
+
+```dockerfile
+COPY shared /harness-shared
+COPY languages/<runtime>/harness /harness
+ENTRYPOINT ["/harness/run.sh"]
+```
+
+Build context is `validators/` (see the comment in `python/Dockerfile`), which is why paths are `shared/` and `languages/<runtime>/...`. Pin SDK + toolchain versions as `ARG`s (`LD_JS_CLIENT_SDK_VERSION`, `LD_RN_SDK_VERSION`, `LD_ANDROID_SDK_VERSION`, `CMDLINE_TOOLS_VERSION`, `ROBOLECTRIC_VERSION`, ...).
+
+### harness/run.sh contract
+
+Every harness starts with `set -eu`, sources `lib.sh`, then `require_env`s the inputs it needs. Inputs passed by the Go validator:
+
+- `SNIPPET_ENTRYPOINT` — path under `/snippet` (docker) or `$SNIPPET_DIR` (native) to the snippet's entry file.
+- `SNIPPET_DIR` — native-mode only.
+- `SNIPPET_MODE` — optional dispatch hint (e.g. `flag-eval`, `syntax-only`).
+- `INSTALL_KIND` — `ios-install`-specific discriminator (swift-package / podfile / cartfile).
+- `LAUNCHDARKLY_SDK_KEY` (server-side), `LAUNCHDARKLY_MOBILE_KEY` (mobile), `LAUNCHDARKLY_CLIENT_SIDE_ID` (browser), `LAUNCHDARKLY_FLAG_KEY` (everywhere except shell-install).
+
+**Success contract**: EXAM-HELLO hello-world snippets emit a line matching `feature flag evaluates to [Tt]rue` (Python prints `True`, others lowercase; quoting around the flag key varies). The harness either:
+
+- Backgrounds the snippet and calls `await_success_line "$LOG" "$PID" "$deadline"` (succeeds on first regex hit, SIGTERMs the process, prints the matched line), or
+- Waits for the runner to exit and `grep`s the captured log — used when the runner's output (jest, xcodebuild) already contains the regex verbatim and a false-positive on a failure printout would otherwise match.
+
+On failure: `fail_with_log "$LOG" "<message>"` prints the message + the redacted log and exits 1.
+
+**shell-install is the outlier**: no flag evaluation. Post-install assertions instead — `node_modules/<pkg>/`, `pip show <pkg>`, `grep <modpath> go.mod`, `bower_components/`.
+
+### shared/lib.sh helpers
+
+Source via `. /harness-shared/lib.sh` (docker) or relative path (native).
+
+- `require_env <NAME>...` — POSIX-shell loop; prints `<name> not set` to stderr and `exit 1` if any var is empty.
+- `await_success_line <log-file> <pid> <deadline-epoch>` — polls every 0.2s for the EXAM-HELLO regex. On match: SIGTERMs the pid, prints the matched line and `validator: ok`, returns 0. On pid-exit or deadline: returns 1.
+- `dump_redacted <log-file>` — substitutes `LAUNCHDARKLY_SDK_KEY` / `LAUNCHDARKLY_MOBILE_KEY` / `LAUNCHDARKLY_CLIENT_SIDE_ID` with `<REDACTED_<var>>` via a built sed program. `_sed_escape_pattern` backslash-escapes `][\.*^$|/&` so credentials containing regex metas or the `|` delimiter can't break out.
+- `fail_with_log <log-file> <message>` — prints `validator: <msg>` and `--- snippet output (keys redacted) ---` to stderr, calls `dump_redacted`, exits 1.
+
+### Per-harness shapes worth knowing
+
+- **shell-install** — single multi-toolchain image. `cat $BODY` → awk-extract the first token (`LEAD`) and second token (`SUB`) → `case` over `npm|pnpm|yarn|pip|pip3|go|bower`. Each branch sets up pre-state (`npm init -y`, `python3 -m venv .venv`, `go mod init`), runs the body, asserts post-state. Unknown leading tokens are a hard error so a new install style must teach the harness.
+- **js-client** — `npm run build` (tsdown bundles `src/app.ts` → `dist/app.js` with `platform: 'browser'`, `noExternal: ['@launchdarkly/js-client-sdk']` so the LD SDK is inlined). Then `node /harness/check.js` launches headless Chromium via Playwright, navigates to `file:///opt/hello-js/index.html`, mirrors console + pageerror to stdout, polls `page.textContent('body')` for the EXAM-HELLO regex.
+- **react-native-client** — `timeout --signal=TERM 180s npm test` (jest with `@react-native/jest-preset`). Pre-baked `App.test.tsx` mocks `@launchdarkly/react-native-client-sdk` to force `initialConnectionMode: 'polling'` (RN streaming needs `XMLHttpRequest` which doesn't exist in Node), renders `<App/>`, `waitFor`s a flattened body-text regex, logs the flat text. `jest.setup.js` pins `AppState.currentState = 'active'`. Greps `$LOG` after jest exits (jest's failure printout contains the regex verbatim, which would falsely match `await_success_line`).
+- **python** — `pip install --quiet -r requirements.txt` if present; then `PYTHONUNBUFFERED=1 timeout 30s python "$SNIPPET_ENTRYPOINT"` in background + `await_success_line` with a 25s deadline.
+- **ios-client** (native) — sources `lib.sh` via relative path. Copies `validators/languages/ios-client/scaffold/` into a `mktemp -d`, drops in `AppDelegate.swift` and `ViewController.swift`. A Python in-script pass lifts any `import` lines that ended up inside a function body back to file scope. `xcodegen generate` against `project.yml`, picks an iPhone simulator dynamically via `xcrun simctl list devices available --json`, then `xcodebuild test -destination "platform=iOS Simulator,name=$SIM_NAME" CODE_SIGNING_ALLOWED=NO`. Passes LD env into the simulator via `SIMCTL_CHILD_LAUNCHDARKLY_*` prefixes.
+- **android-client** — copies snippet `.kt` files into the pre-baked scaffold's package dir. A Python in-script pass lifts function-body `import` lines back to file scope and substitutes `BaseApplication` → `MainApplication` (snippet's literal Application class → the scaffold's class expected by `@Config(application = MainApplication::class)`). `timeout 600s ./gradlew --no-daemon testDebugUnitTest --tests='*HelloAppTest*' --console=plain` in background + `await_success_line` with a 590s deadline. Robolectric drives the activity lifecycle on the JVM (no emulator).
+
+### Adding a new language validator
+
+1. Create `validators/languages/<runtime>/runner.yaml` with `mode`, `runs-on`, and (docker only) `image-prefix`.
+2. For docker mode, write `Dockerfile` using `validators/` as the build context. Pin SDK + toolchain versions as `ARG`s. Pre-bake a placeholder project matching the snippet's file layout so per-validate stays fast. End with the `COPY shared` / `COPY languages/<runtime>/harness` / `ENTRYPOINT` triple.
+3. For native mode, omit `image-prefix`; the harness sources `lib.sh` via `$(cd "$(dirname "$0")/../../../shared" && pwd)/lib.sh` and reads snippet files from `$SNIPPET_DIR`.
+4. Write `harness/run.sh`. Start with `set -eu; . /harness-shared/lib.sh; require_env <LD-key-var> LAUNCHDARKLY_FLAG_KEY SNIPPET_ENTRYPOINT`. Pick the LD key var matching the SDK audience: server → `LAUNCHDARKLY_SDK_KEY`, mobile → `LAUNCHDARKLY_MOBILE_KEY`, browser → `LAUNCHDARKLY_CLIENT_SIDE_ID`.
+5. Stage snippet files from `/snippet/...` into the pre-baked project, run under `timeout` with stdout/stderr to `$LOG`, then `await_success_line "$LOG" "$PID" "$deadline"` (background, regex hit) or grep after exit when the runner echoes the regex itself.
+6. Harness-internal driver code (jest test, Robolectric test, Xcode scaffold) goes under `<runtime>/test/` or `<runtime>/scaffold/` and is `COPY`ed in via the Dockerfile.
+7. Install-style snippets that don't evaluate a flag follow `shell-install`'s shape: sniff the body's leading token, dispatch over package managers, assert install side-effects. Reserve `INSTALL_KIND` for cases (like `ios-install`) where the body can't be sniffed.
+
+## CLI reference
+
+Entry point: `cmd/snippets/main.go`. Subcommands:
+
+```
+snippets render   --target=<adapter> [...]
+snippets verify   --target=<adapter> [...]
+snippets validate --sdk=<id> [...]
+snippets version
+```
+
+No subcommand (or `-h` / `--help` / `help`) prints the usage block; unknown subcommand exits 2.
+
+### `render`
+
+Rewrites consumer files in place.
+
+| Flag | Notes |
+|---|---|
+| `--target` | Required. One of `ld-application`, `ld-docs`, `raw-files`. |
+| `--entrypoint` | Repeatable. Required for `ld-application` and `ld-docs`. Directory inside the consumer checkout to walk for marker files. |
+| `--manifest` | Required for and exclusive to `--target=raw-files`. Path to the YAML manifest of `(snippet-id, output-path)` pairs. |
+| `--consumer` | Consumer-checkout root the manifest's `out:` resolves against. Defaults to the manifest's directory. |
+| `--sdks` | Path to a working `sdks/` tree. Default: the embedded snapshot (see below). |
+
+Adapter behavior:
+
+- `ld-application` (`internal/adapters/ldapplication.Render`) — walks each `--entrypoint`, finds files with `SDK_SNIPPET:RENDER` markers, rewrites JSX children inside marked components. Used by gonfalon.
+- `ld-docs` (`internal/adapters/lddocs.Render`) — same marker flow, rewrites fenced code-block bodies in MDX. Used by ld-docs / ld-docs-private.
+- `raw-files` (`internal/adapters/rawfiles.Render`) — reads the manifest and writes each rendered body to `<consumer>/<manifest.out>/<entry.path>`. Used by gonfalon `packages/sdk-info/` and similar `?raw`-import consumers.
+
+Output: `rewrote <path>` per changed file (marker targets) or `wrote <path>` per emitted file (raw-files); `no changes` / `no files written` when idle.
+
+Realistic invocations:
+
+```
+snippets render --target=ld-application --entrypoint=./packages/sdk-info --sdks=../sdk-meta/sdks
+snippets render --target=ld-docs --entrypoint=./src/content/sdk --entrypoint=./src/content/guides
+snippets render --target=raw-files --manifest=./packages/sdk-info/snippets.yaml
+```
+
+### `verify`
+
+Read-only dry run of `render` for marker-driven targets (`raw-files` is intentionally not supported). Same flags as `render` minus `--manifest` / `--consumer`.
+
+Fails if rendered bytes differ from disk or a marker's hash does not match its region's current contents. Prints `ok` on success, exits 1 on drift. Never writes; never executes snippet code. Used as a CI guard against drift.
+
+### `validate`
+
+Stages snippet bodies, builds the per-language validator (Docker or native), runs each snippet against a real LaunchDarkly environment.
+
+| Flag | Notes |
+|---|---|
+| `--sdk` | Required. Matches `sdks/<sdk>/`. Filters snippets to those whose frontmatter `sdk:` matches. |
+| `--snippet` | Optional. Restricts to a single snippet id. |
+| `--snippet-skip` | Optional. Skips one snippet id. CI uses this to split a slow snippet onto its own matrix row. |
+| `--group` | Optional. Filters on the middle segment of the snippet id (`sdk-info`, `sdk-docs`, ...). |
+| `--sdks` | Path to a working `sdks/` tree. Default: embedded snapshot. |
+| `--validators` | Path to the `validators/` directory. Default: `./validators`. Must be on disk (Docker `COPY` reads from it). |
+
+Behavior:
+
+1. Reads `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, `LAUNCHDARKLY_MOBILE_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID` from env. Snippets with typed inputs / placeholders requiring a key fail fast if it's empty.
+2. Loads all snippets, applies filters, discards scaffolds and snippets without `validation.runtime` or `validation.scaffold`.
+3. Resolves the effective validation snippet (scaffold-bound snippets defer to their scaffold for runtime / entrypoint / companions / requirements).
+4. Stages the rendered body (+ companions, `requirements.txt`, scaffolded `body` slot) into a temp dir, runs the language harness:
+   - `mode: docker` — builds `validators/.../Dockerfile` with build context = entire `validators/` tree, tags with a content hash of `shared/` + the runner dir, then `docker run --rm -v <stage>:/snippet:ro` with `SNIPPET_ENTRYPOINT` and LD env vars forwarded.
+   - `mode: native` — execs `<runner>/harness/run.sh` with `SNIPPET_DIR` and `SNIPPET_ENTRYPOINT` exported.
+5. Errors out with `no validatable snippets found ...` if nothing matched.
+
+Example:
+
+```
+snippets validate --sdk=python-server-sdk --group=sdk-info --sdks=./sdks --validators=./validators
+snippets validate --sdk=flutter-client-sdk --snippet=flutter-client-sdk/sdk-info/install
+```
+
+### Embedded `sdks` FS vs `--sdks`
+
+`resolveSDKsFS` in `main.go`:
+
+```go
+func resolveSDKsFS(sdksFlag string) fs.FS {
+    if sdksFlag == "" {
+        return snippets.SDKsFS()
+    }
+    return os.DirFS(sdksFlag)
+}
+```
+
+- Released binaries ship with an embedded snapshot of `sdks/` (`snippets.SDKsFS()`) so downstream consumers can `go run` / drop in the binary without checking out `sdk-meta`.
+- Local authoring passes `--sdks=./sdks` so edits to the working tree are picked up immediately without rebuilding.
+- `--sdks` is accepted by `render`, `verify`, and `validate`.
+- `validators/` is always read from disk — Docker's build context needs a filesystem path; no embedded equivalent.
+
+## CI: `.github/workflows/snippets-validate.yml`
+
+Triggers on PRs touching `snippets/**` or the workflow itself, plus `workflow_dispatch`. Concurrency group cancels prior runs on the same ref. Permissions: `id-token: write` (OIDC) and `contents: read`.
+
+One job `validate` with `fail-fast: false` and an `include:`-only matrix.
+
+### Matrix row shape
+
+| Field | Required | Notes |
+|---|---|---|
+| `sdk` | yes | Matches `snippets/sdks/<sdk>/`. |
+| `runs-on` | yes | `ubuntu-latest` everywhere except the three `ios-client-sdk` rows (`macos-latest`). |
+| `key-type` | yes | `server` | `client` | `mobile` | `none`. Determines which LD key the verify-hello-app wrapper injects. |
+| `snippet` | – | Restrict to a single bound snippet path. |
+| `snippet_skip` | – | Exclude one bound snippet. Note: matrix key uses underscore; CLI flag uses `--snippet-skip` (dash). |
+| `group` | – | Restrict to one group (`sdk-info`, `sdk-docs`, ...). |
+| `label` | – | Overrides the job name. **Required** when multiple rows share an `sdk` so artifacts don't collide. |
+
+Job name renders as `${{ matrix.label || matrix.sdk }}`. Rows are grouped in the file by purpose: server-key SDKs, JS client, mobile-key dotnet, shell-install-only (dotnet-server-sdk with an unused `key-type: server`), client/mobile init-binding SDKs, the three iOS rows, the android row, and the sdk-docs-syntax-only block at the bottom.
+
+### `verify-hello-app` wrapper
+
+`launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.1` — the same action the `hello-*` example repos use:
+
+1. Assumes the AWS role in `vars.AWS_ROLE_ARN_EXAMPLES` via GitHub OIDC.
+2. Pulls LaunchDarkly Sandbox credentials from AWS Secrets Manager and injects one of `LAUNCHDARKLY_SDK_KEY` / `LAUNCHDARKLY_CLIENT_SIDE_ID` / `LAUNCHDARKLY_MOBILE_KEY` based on the `use_*_key` flag.
+3. Injects `LAUNCHDARKLY_FLAG_KEY` from SSM `/sdk/common/hello-apps/boolean-flag-key`.
+4. Runs `command:` and asserts the output contains the EXAM-HELLO line.
+
+Key-type mapping:
+
+```yaml
+with:
+  use_server_key: ${{ matrix.key-type == 'server' }}
+  use_client_key: ${{ matrix.key-type == 'client' }}
+  use_mobile_key: ${{ matrix.key-type == 'mobile' }}
+  role_arn: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}
+```
+
+Exactly one `use_*_key` is true per row (when `key-type != 'none'`).
+
+### `key-type: none` bypass
+
+Skips `verify-hello-app` entirely and runs a plain shell step `Validate (no key)`. Used for rows whose only bound snippets are install fragments — they exercise package managers (`pod install`, `carthage bootstrap`, `swift package resolve`) in an empty workdir and never produce the EXAM-HELLO marker the action greps for. The two validate steps are mutually exclusive (`if: matrix.key-type != 'none'` vs `if: matrix.key-type == 'none'`); `Record result` treats success on either as ok.
+
+### Optional matrix fields → CLI flags
+
+The optional fields flow through env vars into the `go run ./cmd/snippets validate` invocation in both validate steps:
+
+```yaml
+env:
+  MATRIX_SDK: ${{ matrix.sdk }}
+  MATRIX_SNIPPET: ${{ matrix.snippet }}
+  MATRIX_SNIPPET_SKIP: ${{ matrix.snippet_skip }}
+  MATRIX_GROUP: ${{ matrix.group }}
+```
+
+The shell appends `--snippet=`, `--snippet-skip=`, `--group=` only when the corresponding env var is non-empty. `--sdks=./sdks --validators=./validators` are always passed.
+
+`label` is consumed only by the job name and the artifact-suffix step (`Compute artifact suffix` slugifies `LABEL` via `tr ' ()/' '----' | tr -s '-' | sed 's/-$//'`, falling back to `sdk` when empty). Two rows sharing one `sdk` MUST set distinct `label` values or their artifacts collide.
+
+### Artifact upload + summary
+
+Per-cell `Record result` writes `/tmp/result/status` (`ok` or `fail`) and copies `/tmp/validate.log` to `/tmp/result/log`. `Upload result` uses `actions/upload-artifact@v4` with name `result-<slug>`, `if-no-files-found: ignore`, 14-day retention.
+
+The `summary` job (`needs: validate`, `if: always()`) downloads `result-*` artifacts via `actions/download-artifact@v4` with `pattern: result-*` into `results/`, renders a markdown table in `$GITHUB_STEP_SUMMARY` with columns SDK / Result / Excerpt. Failing cells get the last 3 non-empty log lines (pipes and backticks escaped). A final step re-walks artifacts and `exit 1`s if any status != `ok` — a green summary job means every cell passed.
+
+### CI recipes
+
+- **Add a new SDK row** (server-key, plain): append `- { sdk: <name>, runs-on: ubuntu-latest, key-type: server }` to the appropriate block. The SDK directory must already exist and the CLI must already pick it up.
+- **Add a credentials-less row**: use `key-type: none`; the workflow auto-routes to `Validate (no key)`.
+- **Split one SDK across multiple rows**: repeat `sdk:` with distinct `label:` values, partition with `snippet:` / `snippet_skip:` / `group:`. `label` is required for artifact uniqueness.
+- **Change a row's key-type**: edit just `key-type`. The `use_*_key` booleans recompute automatically; nothing else to touch unless you're crossing the `none` boundary.
+- **Thread a new optional env var**: (1) add `MATRIX_FOO: ${{ matrix.foo }}` to **both** the `Validate` and `Validate (no key)` `env:` blocks; (2) add `[ -n "$MATRIX_FOO" ] && args="$args --foo=$MATRIX_FOO"` to both `command`/`run` shells; (3) set `foo:` on the rows that need it. Keep the two steps in sync — divergence between them is a common bug.
+
+## Local testing
+
+Run all `go` and `snippets` commands from the `snippets/` subdir (this directory). That's where `go.mod`, `cmd/snippets/`, `internal/`, and `validators/` live, and where `--validators=./validators` resolves.
+
+### LD keys for local validate runs
+
+The `/tmp/ld-keys.env` file is the convention; source it before invoking the CLI:
+
+```bash
+set -a; source /tmp/ld-keys.env; set +a
+go run ./cmd/snippets validate --sdk=python-server-sdk --sdks=./sdks
+```
+
+The file must export `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, and (where the SDK requires them) `LAUNCHDARKLY_MOBILE_KEY` / `LAUNCHDARKLY_CLIENT_SIDE_ID`. Missing keys produce a clear `snippet X input Y (type=...) requires LAUNCHDARKLY_... to be set` error before any Docker build kicks off.
+
+### Common operations
+
+```bash
+# Build the binary
+go build -o snippets ./cmd/snippets
+
+# Unit tests (model parser, render DSL, adapters)
+go test ./...
+
+# Validate a single snippet end-to-end
+go run ./cmd/snippets validate \
+  --sdk=python-server-sdk \
+  --snippet=python-server-sdk/sdk-info/init \
+  --sdks=./sdks --validators=./validators
+
+# Validate one SDK's sdk-info group
+go run ./cmd/snippets validate --sdk=node-server-sdk --group=sdk-info \
+  --sdks=./sdks --validators=./validators
+
+# Dry-run check that a consumer checkout is in sync
+go run ./cmd/snippets verify --target=ld-docs --entrypoint=../ld-docs/src/content/sdk
+
+# Re-render a consumer checkout from working-tree snippets
+go run ./cmd/snippets render --target=ld-docs \
+  --entrypoint=../ld-docs/src/content/sdk --sdks=./sdks
+```
+
+`go test ./...` covers the model parser (`internal/model`), the templating DSL (`internal/render`), and adapter render/verify behavior — not the language harnesses (those run only under `snippets validate`).
+
+### Docker prerequisites
+
+`snippets validate` requires Docker available on `PATH` for any non-native runtime. The Go validator builds the image with build context `./validators` and tags it from `image-prefix`, so first-run latency is dominated by the Dockerfile's pre-bake steps. Subsequent runs are fast (image cache + content-hash tag).
+
+## Conventions
+
+### Commit messages
+
+Conventional Commits with `snippets` scope: `feat(snippets): …`, `fix(snippets): …`, `chore(snippets): …`, `docs(snippets): …`. The release-please config drives `snippets/CHANGELOG.md` and the `snippets/vX.Y.Z` release from these.
+
+### Branch + PR layout
+
+Branch: `rlamb/sdk-NNNN/desc` (or `rlamb/<short-desc>` for non-ticketed). Ticket goes in branch + PR body, **not** in the PR title. Sequential PRs preferred over stacked when each is independently mergeable; base a new PR on `main` once its predecessor has merged.
+
+### Port-notes files
+
+When porting snippets from gonfalon, the convention is to drop a `<sdk>/PORT-NOTES.md` (or per-snippet sibling notes) that lists Bucket A (clean ports), Bucket B (small fixes inlined), Bucket C (deferred / parked). The notes live alongside the snippets so the next agent has a paper trail. Don't litter the snippet bodies themselves with porting commentary — describe behavior in code comments, history in the notes file.
+
+### When to inline a fix vs document Bucket C
+
+- **Inline**: the snippet is wrong in a way the new validator catches and the fix is local (typo, missing import, stale package name, wrong placeholder string). Fix it in the same PR that adds the SDK; mention in the PR body.
+- **Bucket C**: the fix requires changing API surface, touches another SDK, or needs product input. Park it in the notes file with a one-line description + link to the broader issue. Don't block the port.
+
+### Code-style guardrails (apply broadly)
+
+- No spec numbers in code (`// spec section 3.2.1`) — paraphrase. Spec numbers go stale.
+- No PR / review / issue refs in code (`// fixes after review #4`) — describe the behavior. The history is in git.
+- No unicode arrows in code or docs — use `-->`.
+- Avoid the word "polling" in LD streaming code — it's a product term for the polling data source. Use "continue" / "keep reading" / "next iteration".
+- Dart code: use case-pattern null narrowing (`if (x case final v?)`) instead of `!`; run `dart format` before committing (CI enforces it separately from analyze/test).
+- Rust code: run `cargo fmt` before committing (CI enforces `rustfmt` separately from build/test).
+
+## Releases (`.github/workflows/release-please.yml`)
+
+The repo runs release-please in monorepo mode with two packages, `api-js` and `snippets`. The `snippets` package is configured `"draft": true`, so the first release-please call creates a draft GitHub release without a git tag. The `release-snippets` job then:
+
+1. Pushes the `snippets/vX.Y.Z` tag manually (drafts don't auto-tag).
+2. Cross-compiles via plain `go build` for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64. (goreleaser was abandoned because its monorepo support is Pro-only.) Each archive is named `snippets_<version-without-v>_<goos>_<goarch>.tar.gz` with `snippets`, `README.md`, `LICENSE` at the archive root (no wrapper dir).
+3. Embeds the bare version via `-X .../internal/version.Version=<version>` ldflags.
+4. Generates `checksums.txt` (sha256sum of all archives).
+5. Attests each archive with `actions/attest-build-provenance@v2` (SLSA, signed via OIDC, stored on GitHub).
+6. Uploads archives + checksums to the draft release with `gh release upload --clobber`.
+7. Flips the release out of draft with `gh release edit --draft=false`. After this step the release is immutable under repo policy, so every asset must be uploaded **first**.
+
+Downstream consumers (e.g. the `sync-snippets` action) resolve the latest release by the `snippets/v*` tag prefix, strip `snippets/v` to get the bare version, fetch `snippets_<version>_<goos>_<goarch>.tar.gz`, and verify with `gh attestation verify <archive> --repo launchdarkly/sdk-meta`. Producer and consumer agree on the bare-version filename — that's why the build strips the leading `v`.
+
+## Source-of-truth quick links
+
+When in doubt, the code is authoritative; this guide paraphrases it. Frequent lookup targets:
+
+- Frontmatter schema, loader, parser: `internal/model/model.go` (`Frontmatter`, `Input`, `Validation`, `ParseFile`, `LoadAll`).
+- Template DSL parser + nodes: `internal/render/template.go` (`Parse`, `Node`, `Literal`, `Var`, `Cond`, `tokenRe`).
+- Render modes (runtime / ld-application / JSX text), filters, foreign-template passthrough: `internal/render/render.go`.
+- Validation runner (filter, stage, harness exec): `internal/validate/validate.go`.
+- CLI entry, usage block, flag wiring: `cmd/snippets/main.go`.
+- Shared harness helpers: `validators/shared/lib.sh`.
+- CI matrix and key-type wiring: `.github/workflows/snippets-validate.yml`.
+- Release tag + artifact contract: `.github/workflows/release-please.yml`.
+- Older but still partially useful authoring doc: `docs/AUTHORING.md` (DSL section accurate; older `kind` values).

--- a/snippets/CLAUDE.md
+++ b/snippets/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Auto-loaded by Claude Code when an agent's cwd is anywhere under `snippets/`. Read this before authoring snippets, scaffolds, validators, or CI rows. This document describes the system **as it is** — not as it might become.
 
+For the "how do I write or change a snippet" reference (frontmatter, `validation.*`, templating DSL, render targets, CLI essentials), see [docs/AUTHORING.md](docs/AUTHORING.md). This file covers everything else: repo map, scaffold internals, validator harnesses, CI matrix, conventions, releases.
+
 ## Don't author snippet content in unrelated repos
 
 This repo (`launchdarkly/sdk-meta`) is the **canonical home** of every snippet body. Consumers (`gonfalon`, `ld-docs-private`, `ld-docs`) only carry **markers** that point back here:
@@ -39,7 +41,7 @@ snippets/
       Dockerfile                      # docker mode only; build context is validators/
       harness/run.sh                  # entrypoint
       scaffold/ or test/              # Optional: pre-built project or driver code
-  docs/AUTHORING.md     # Older authoring doc; partly stale (older kind values), DSL section still accurate
+  docs/AUTHORING.md     # Authoring reference: frontmatter, validation.*, DSL, render targets
 ```
 
 Top-level workflows that touch this tree:
@@ -49,137 +51,7 @@ Top-level workflows that touch this tree:
 
 ## Snippet file format
 
-A snippet lives at `sdks/<sdk>/snippets/<group>/<name>.snippet.md` (or `sdks/_shared/snippets/<group>/<name>.snippet.md` for cross-SDK snippets). The parser expects:
-
-1. YAML frontmatter fenced by `---` lines at the top of the file.
-2. Exactly **one** fenced code block somewhere after the frontmatter; only the FIRST block is captured as the body. Prose between frontmatter and fence is ignored.
-3. `KnownFields(true)` decoding — unknown frontmatter keys are a parse error. Typos (`Description:`, `entrypiont:`) fail loudly.
-4. Globally unique `id` across the whole tree; collisions error at load.
-
-The parsed `Snippet{Path, Frontmatter, CodeLang, CodeBody}` is what every downstream tool consumes.
-
-### Top-level frontmatter fields
-
-Every key the parser models. Adding a new key requires editing `internal/model/model.go`.
-
-| Field | Type | Required | Notes |
-|---|---|---|---|
-| `id` | string | yes | Globally unique. Convention: `<sdk>/<group>/<name>`. `_shared` snippets drop the sdk prefix (e.g. `id: cursor-prompt`). |
-| `sdk` | string | – | Matches a directory under `sdks/`. Omit for `_shared/` snippets. |
-| `kind` | string | yes | Categorical label. Live values: `install`, `init`, `initialize`, `import`, `context`, `implementation`, `flag-eval`, `reference`, `scaffold`. |
-| `lang` | string | yes | Fenced-code language tag. Also the default `validation.runtime` when that field is empty. |
-| `file` | string | – | Relative path consumers see and the validator writes the rendered body to. Omitted on `kind: reference` (the wrapping scaffold owns the path). |
-| `description` | string | recommended | One-liner. Supports YAML `|` block scalars for multi-paragraph rationale (scaffolds). |
-| `inputs` | map | – | Declared templating inputs. Each entry: `type` (e.g. `string`, `flag-key`), `description`, optional `runtime-default`. Use `inputs: {}` for scaffolds that take no parameters. |
-| `validation` | map | – | Absence means "don't run through the validator." See below. |
-
-### `validation.*` fields
-
-| Field | Notes |
-|---|---|
-| `runtime` | Picks a harness under `validators/languages/<runtime>/`. Falls back to `lang:` if empty. Set explicitly when `lang` and runtime differ (e.g. `lang: javascript` + `runtime: node`; `lang: ts` + `runtime: js-client`). |
-| `entrypoint` | File the harness invokes inside the staging dir. Defaults to `file:`. |
-| `requirements` | Runtime-specific dependency descriptor. Python → `requirements.txt` contents (use `|`). Node → top-level dep name. .NET → NuGet package id. Other languages ship deps via a companion manifest scaffold. |
-| `companions` | List of snippet IDs staged alongside; each is rendered with the same inputs and written to its own `file:`. Used for multi-file projects. |
-| `scaffold` | ID of a `kind: scaffold` snippet to wrap this body in. **Mutually exclusive** with `runtime` / `entrypoint` / `requirements` / `companions` — those come from the scaffold. |
-| `scaffold-inputs` | Map of named values passed into the scaffold's template beyond the implicit `body`. Lets one scaffold serve wrappees with slightly different setup. |
-| `env` | Literal `KEY: VALUE` pairs forwarded into the harness process. No substitution. Used as a harness-side discriminator (e.g. `INSTALL_KIND: podfile`, `SNIPPET_MODE: flag-eval`). |
-| `placeholders` | Literal source-text fragments **inside the rendered body** → env-var names. After rendering and scaffold composition, the dispatcher string-replaces each key with the named env var's value. Only the EXAM-HELLO allow-list is honored: `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, `LAUNCHDARKLY_MOBILE_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID`. |
-
-Merge order for the harness env: scaffold's `validation.env` first, then wrappee's `validation.env` overrides. `requireEnvForInputs` walks the entrypoint + companions before any Docker build and fails fast if a placeholder's mapped env var is unset.
-
-### Templating DSL
-
-Defined in `internal/render/template.go` and `render.go`. Intentionally tiny:
-
-- `{{ name }}` — substitute the value of a declared input. Names match `[a-zA-Z][a-zA-Z0-9_]*`. Whitespace inside the braces is flexible; the parser captures the exact source form so foreign-template syntax round-trips byte-identically.
-- `{{ name | filter }}` — substitute with a filter. The only filter today is `camelCase` (react-client-sdk uses it so `useFlags()` destructuring works on a kebab-cased flag key). Any other filter is a parse error.
-- `{{ if name }}…{{ end }}` — emit the inner content only if `name` resolves to non-empty. Conditionals do not nest; the inner content may still contain `{{ name }}` substitutions. The conditional's `name` must be a declared input — undeclared names in a conditional are a render error.
-- **Foreign-template passthrough**: any `{{ name }}` whose name is NOT in the declared inputs map is emitted verbatim, preserving surrounding whitespace. This is what lets Vue's mustache syntax and `_shared/cursor-prompt`'s literal `{{SDK_NAME}}` (no inner whitespace — gonfalon's runtime regex requires exactly that form) survive validation untouched.
-- `{{ body }}` slot in scaffolds is just `{{ name }}` where `name == "body"`. The scaffold declares `inputs: { body: { type: string, description: ... } }` and the validator substitutes the wrappee's rendered body at that point.
-
-The same body renders three ways without authors picking a mode:
-
-- `RenderRuntime` — concrete values for the validator.
-- `RenderForLDApplicationTemplate` — JS template-literal with `${name}` interpolations and `${name ? \`…\` : ''}` ternaries (gonfalon).
-- `RenderForJSXText` — same as ld-application for JSX text contexts.
-
-The `verify` pass renders identically to `ld-application` and compares byte-for-byte against the consumer file.
-
-### Common shapes
-
-**Install (shell-install runtime)**:
-
-```markdown
----
-id: react-client-sdk/sdk-info/install-yarn
-sdk: react-client-sdk
-kind: install
-lang: shell
-file: react-client-sdk/install-yarn.txt
-description: Install command for react-client-sdk (yarn).
-validation:
-  runtime: shell-install
----
-
-```shell
-yarn add @launchdarkly/react-sdk
-```
-```
-
-The `ios-install` variant carries an `env:` discriminator because Podfile / Cartfile / Package.swift fragments aren't shell-sniffable:
-
-```yaml
-validation:
-  runtime: ios-install
-  env:
-    INSTALL_KIND: podfile
-```
-
-**Reference (wrapped by a scaffold)**: no `file:`, no runtime/entrypoint/requirements/companions — the scaffold owns those.
-
-```markdown
----
-id: ios-client-sdk/sdk-docs/evaluate-a-flag-swift
-sdk: ios-client-sdk
-kind: reference
-lang: swift
-description: 'Swift in section "Evaluate a flag"'
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
----
-
-```swift
-let client = LDClient.get()!
-```
-```
-
-**Runnable init (scaffold + placeholders)**: body is unchanged from what consumers see; substitution happens at validate time only.
-
-```markdown
----
-id: ios-client-sdk/sdk-info/init
-sdk: ios-client-sdk
-kind: init
-lang: swift
-file: ios-client-sdk/init.txt
-description: Client initialization snippet for ios-client-sdk.
-validation:
-  scaffold: ios-client-sdk/scaffolds/init-runner
-  placeholders:
-    YOUR_MOBILE_KEY: LAUNCHDARKLY_MOBILE_KEY
----
-
-```swift
-import LaunchDarkly
-
-let config = LDConfig(mobileKey: "YOUR_MOBILE_KEY", autoEnvAttributes: .enabled)
-// ...
-LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in
-    // ...
-}
-```
-```
+Frontmatter schema, `validation.*` fields, the templating DSL, and example shapes for the common kinds live in [docs/AUTHORING.md](docs/AUTHORING.md). Parser invariants worth keeping in mind when extending the system: snippet files are loaded by `internal/model.LoadAll` (see `internal/model/model.go`); decoding uses `KnownFields(true)`, so adding a frontmatter key requires editing the `Frontmatter` struct; `id` is globally unique and collisions error at load; the parsed `Snippet{Path, Frontmatter, CodeLang, CodeBody}` is what every downstream tool consumes.
 
 ## Snippet groups (categories)
 
@@ -248,21 +120,9 @@ Syntax-only scaffolds typically never execute the body — they just want it to 
 
 ### Placeholders contract
 
-gonfalon ships init bodies with literal placeholders like `'YOUR_SDK_KEY'`, `'YOUR_MOBILE_KEY'`, `'YOUR_CLIENT_SIDE_ID'`, `'SDK_KEY'` that the human user is expected to swap. Rewriting the body to use `{{ name }}` markers would corrupt the rendered output the docs consume. Instead the wrappee carries:
+The dispatch order matters for scaffold authors: `validation.placeholders` runs **after** rendering the wrappee and **before** splicing into the scaffold's `{{ body }}` slot. So a placeholder key (e.g. `'YOUR_SDK_KEY'`, `'SDK_KEY'`) only needs to be unique in the wrappee body, not in the composed output — the scaffold's own scaffold-supplied init code can use the same literal text. This is what lets gonfalon keep shipping `'YOUR_SDK_KEY'` placeholders in docs while validation substitutes real keys.
 
-```yaml
-validation:
-  scaffold: react-native-client-sdk/scaffolds/init-runner-observability
-  placeholders:
-    SDK_KEY: LAUNCHDARKLY_MOBILE_KEY
-```
-
-The dispatcher does a literal string replace on the rendered wrappee body **before** splicing into the scaffold. Allow-list is exactly `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, `LAUNCHDARKLY_MOBILE_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID`; any other name is rejected.
-
-`validation.env:` is unrelated — it carries literal KEY=VALUE pairs to the harness process. No env lookup, no template substitution. Used to switch harness behavior per wrappee:
-
-- `ios-install`: each install snippet sets `INSTALL_KIND: swift-package | podfile | cartfile`.
-- `react-client/flag-eval-runner` and `react-native-client/syntax-only`: set `SNIPPET_MODE: flag-eval` or `syntax-only` so the same harness either Babel-parses or runs a full LD-backed render.
+For `env`-keyed harness dispatch (e.g. `INSTALL_KIND` on `ios-install`, `SNIPPET_MODE: flag-eval | syntax-only` on the react harnesses), see [docs/AUTHORING.md#validation-fields](docs/AUTHORING.md#validation-fields) — `validation.env` carries literal KEY=VALUE pairs to the harness with no substitution, and harness scripts switch on the key.
 
 ### init-runner-observability scaffolds
 
@@ -559,34 +419,17 @@ go run ./cmd/snippets validate --sdk=python-server-sdk --sdks=./sdks
 
 The file must export `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, and (where the SDK requires them) `LAUNCHDARKLY_MOBILE_KEY` / `LAUNCHDARKLY_CLIENT_SIDE_ID`. Missing keys produce a clear `snippet X input Y (type=...) requires LAUNCHDARKLY_... to be set` error before any Docker build kicks off.
 
-### Common operations
+### Go-tooling commands
 
 ```bash
 # Build the binary
 go build -o snippets ./cmd/snippets
 
-# Unit tests (model parser, render DSL, adapters)
+# Unit tests (model parser, render DSL, adapters; NOT language harnesses)
 go test ./...
-
-# Validate a single snippet end-to-end
-go run ./cmd/snippets validate \
-  --sdk=python-server-sdk \
-  --snippet=python-server-sdk/sdk-info/init \
-  --sdks=./sdks --validators=./validators
-
-# Validate one SDK's sdk-info group
-go run ./cmd/snippets validate --sdk=node-server-sdk --group=sdk-info \
-  --sdks=./sdks --validators=./validators
-
-# Dry-run check that a consumer checkout is in sync
-go run ./cmd/snippets verify --target=ld-docs --entrypoint=../ld-docs/src/content/sdk
-
-# Re-render a consumer checkout from working-tree snippets
-go run ./cmd/snippets render --target=ld-docs \
-  --entrypoint=../ld-docs/src/content/sdk --sdks=./sdks
 ```
 
-`go test ./...` covers the model parser (`internal/model`), the templating DSL (`internal/render`), and adapter render/verify behavior — not the language harnesses (those run only under `snippets validate`).
+`go test ./...` covers `internal/model` (parser), `internal/render` (DSL), and adapter render/verify behavior. Language harnesses run only under `snippets validate`. For the day-to-day `validate` / `render` / `verify` invocations, see [docs/AUTHORING.md#cli-essentials](docs/AUTHORING.md#cli-essentials).
 
 ### Docker prerequisites
 
@@ -597,10 +440,6 @@ go run ./cmd/snippets render --target=ld-docs \
 ### Commit messages
 
 Conventional Commits with `snippets` scope: `feat(snippets): …`, `fix(snippets): …`, `chore(snippets): …`, `docs(snippets): …`. The release-please config drives `snippets/CHANGELOG.md` and the `snippets/vX.Y.Z` release from these.
-
-### Branch + PR layout
-
-Branch: `rlamb/sdk-NNNN/desc` (or `rlamb/<short-desc>` for non-ticketed). Ticket goes in branch + PR body, **not** in the PR title. Sequential PRs preferred over stacked when each is independently mergeable; base a new PR on `main` once its predecessor has merged.
 
 ### Port-notes files
 
@@ -646,4 +485,4 @@ When in doubt, the code is authoritative; this guide paraphrases it. Frequent lo
 - Shared harness helpers: `validators/shared/lib.sh`.
 - CI matrix and key-type wiring: `.github/workflows/snippets-validate.yml`.
 - Release tag + artifact contract: `.github/workflows/release-please.yml`.
-- Older but still partially useful authoring doc: `docs/AUTHORING.md` (DSL section accurate; older `kind` values).
+- Snippet author reference (frontmatter, `validation.*`, DSL, render targets, CLI essentials): `docs/AUTHORING.md`.

--- a/snippets/docs/AUTHORING.md
+++ b/snippets/docs/AUTHORING.md
@@ -1,102 +1,251 @@
 # Authoring snippets
 
-A snippet is a single Markdown file with YAML frontmatter and one fenced code
-block. See `sdks/python-server-sdk/snippets/getting-started/` for the canonical
-examples.
+How to write or change a `.snippet.md` file. For repo navigation, scaffold internals, validator harness internals, and CI wiring, see [../CLAUDE.md](../CLAUDE.md).
 
-## Frontmatter fields used in the first slice
+A snippet lives at `sdks/<sdk>/snippets/<group>/<name>.snippet.md` (or `sdks/_shared/snippets/<group>/<name>.snippet.md` for cross-SDK snippets). It is a single Markdown file with YAML frontmatter and one fenced code block:
 
-| Field | Required | Notes |
-|---|---|---|
-| `id` | yes | globally unique; convention `<sdk>/<group>/<name>` |
-| `sdk` | yes | matches a directory under `sdks/` |
-| `kind` | yes | one of: `bootstrap` (project-scaffolding command, e.g. `npx create-vue@latest`), `install` (dependency-add command, e.g. `pip install ldclient-py`), `hello-world` (the actual code file the consumer drops in), `run` (the command that runs the result, e.g. `python main.py`). One snippet has exactly one kind; the set is closed for now. New kinds get added here as the snippet system grows. |
-| `lang` | yes | language tag for the fenced code block |
-| `description` | recommended | one-liner shown to the consumer |
-| `inputs` | optional | each input has `type`, `description`, `runtime-default` |
-| `ld-application.slot` | optional | logical slot label for the ld-application adapter |
-| `validation.entrypoint` | optional | filename to run inside the validator (e.g. `main.py`) |
-| `validation.requirements` | optional | line written into `requirements.txt` |
+```markdown
+---
+id: python-server-sdk/sdk-info/init
+sdk: python-server-sdk
+kind: init
+lang: python
+file: python-server-sdk/init.txt
+description: Client initialization snippet for python-server-sdk.
+validation:
+  runtime: python
+  entrypoint: init.py
+  requirements: |
+    launchdarkly-server-sdk
+---
 
-## Templating
+```python
+import ldclient
+# ...
+```
+```
 
-Inside the code block:
+The parser:
 
-- `{{ name }}` — substitutes an input value
-- `{{ if name }}...{{ end }}` — emits the inner content only when `name` has a non-empty value
+1. Reads YAML frontmatter fenced by `---` lines at the top of the file.
+2. Captures the **first** fenced code block; anything between frontmatter and fence is prose and is ignored.
+3. Decodes frontmatter with `KnownFields(true)` — unknown keys are a parse error. Typos (`Description:`, `entrypiont:`) fail loudly.
+4. Enforces globally unique `id` across the whole tree.
 
-Conditionals do not nest. The inner content of a conditional may still contain `{{ name }}`.
+## Snippet groups
 
-## Render modes
+Every snippet sits in one group folder; the group is the middle segment of `id` and is what `--group` filters on. See [../CLAUDE.md#snippet-groups-categories](../CLAUDE.md#snippet-groups-categories) for the full list and what consumes each one.
 
-Same template renders three different ways:
+## Top-level frontmatter fields
 
-| Mode | What it produces |
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Globally unique. Convention: `<sdk>/<group>/<name>`. `_shared` snippets drop the sdk prefix (e.g. `id: cursor-prompt`). |
+| `sdk` | string | – | Matches a directory under `sdks/`. Omit for `_shared/` snippets. |
+| `kind` | string | yes | Categorical label. Live values: `install`, `init`, `initialize`, `import`, `context`, `implementation`, `flag-eval`, `reference`, `scaffold`, `manifest`. |
+| `lang` | string | yes | Fenced-code language tag. Also the default `validation.runtime` when that field is empty. |
+| `file` | string | – | Relative path consumers see and the validator writes the rendered body to. Omitted on `kind: reference` (the wrapping scaffold owns the path). |
+| `description` | string | recommended | One-liner. Supports YAML `|` block scalars for multi-paragraph rationale (scaffolds). |
+| `inputs` | map | – | Declared templating inputs. Each entry: `type` (e.g. `string`, `flag-key`), `description`, optional `runtime-default`. Use `inputs: {}` for scaffolds that take no parameters. |
+| `validation` | map | – | Absence means "don't run through the validator." See below. |
+
+Adding a new top-level key requires editing `internal/model/model.go`.
+
+## `validation.*` fields
+
+| Field | Notes |
 |---|---|
-| `ld-application` | JS template-literal expression with `${name}` interpolations and `${name ? \`...\` : ''}` ternaries inside JSX. |
-| `runtime` (validator) | Plain code with concrete values substituted. |
-| `verify` | Same as `ld-application`, then compared byte-for-byte against the consumer file. |
+| `runtime` | Picks a harness under `validators/languages/<runtime>/` (e.g. `python`, `node`, `shell-install`, `ios-install`, `js-client`, `react-native-client`, `android-client`). Falls back to `lang:` if empty. Set explicitly when `lang` and runtime differ (e.g. `lang: javascript` + `runtime: node`; `lang: ts` + `runtime: js-client`). |
+| `entrypoint` | File the harness invokes inside the staging dir. Defaults to `file:`. |
+| `requirements` | Runtime-specific dependency descriptor. Python → `requirements.txt` contents (use `|`). Node → top-level dep name. .NET → NuGet package id. Other languages ship deps via a companion manifest scaffold. |
+| `companions` | List of snippet IDs staged alongside; each is rendered with the same inputs and written to its own `file:`. Used for multi-file projects. |
+| `scaffold` | ID of a `kind: scaffold` snippet to wrap this body in. **Mutually exclusive** with `runtime` / `entrypoint` / `requirements` / `companions` — those come from the scaffold. |
+| `scaffold-inputs` | Map of named values passed into the scaffold's template beyond the implicit `body`. Lets one scaffold serve wrappees with slightly different setup. |
+| `env` | Literal `KEY: VALUE` pairs forwarded into the harness process. No substitution. Used as a harness-side discriminator (e.g. `INSTALL_KIND: podfile`, `SNIPPET_MODE: flag-eval`). |
+| `placeholders` | Literal source-text fragments **inside the rendered body** → env-var names. After rendering and scaffold composition, the dispatcher string-replaces each key with the named env var's value. Only the allow-list is honored: `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, `LAUNCHDARKLY_MOBILE_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID`. |
 
-## Render markers in consumer files
+Merge order for the harness env: scaffold's `validation.env` first, then wrappee's `validation.env` overrides. Inputs of type `flag-key`/`sdk-key`/`mobile-key`/`client-side-id` are walked before any Docker build and fail fast if the mapped env var is unset — real keys never live in the repo.
 
-The generator never edits files outside a marker comment. Mark each generated
-region with one comment of the host syntax, immediately before the JSX element
-whose body should be replaced:
+### `placeholders` vs `env`
+
+These are easy to confuse:
+
+- `placeholders` rewrites literal text **inside the rendered snippet body** (`'YOUR_SDK_KEY'` → the real key) before validation. Allow-list only. Consumers still see the literal placeholder.
+- `env` sets process env vars on the harness (no body rewrite). Used to switch harness behavior per wrappee (`INSTALL_KIND: podfile`, `SNIPPET_MODE: flag-eval`).
+
+## Templating DSL
+
+Defined in `internal/render/template.go` and `render.go`. Intentionally tiny:
+
+- `{{ name }}` — substitute the value of a declared input. Names match `[a-zA-Z][a-zA-Z0-9_]*`. Whitespace inside the braces is flexible; the parser captures the exact source form so foreign-template syntax round-trips byte-identically.
+- `{{ name | filter }}` — substitute with a filter. The only filter today is `camelCase` (react-client-sdk uses it so `useFlags()` destructuring works on a kebab-cased flag key). Any other filter is a parse error.
+- `{{ if name }}…{{ end }}` — emit the inner content only if `name` resolves to non-empty. Conditionals do not nest; the inner content may still contain `{{ name }}` substitutions. The conditional's `name` must be a declared input — undeclared names in a conditional are a render error.
+- **Foreign-template passthrough**: any `{{ name }}` whose name is NOT in the declared inputs map is emitted verbatim, preserving surrounding whitespace. This is what lets Vue's mustache syntax and `_shared/cursor-prompt`'s literal `{{SDK_NAME}}` (no inner whitespace — gonfalon's runtime regex requires exactly that form) survive validation untouched.
+- `{{ body }}` slot in scaffolds is just `{{ name }}` where `name == "body"`. The scaffold declares `inputs: { body: { type: string, description: ... } }` and the validator substitutes the wrappee's rendered body at that point.
+
+### Render modes
+
+The same body renders three ways without authors picking a mode:
+
+| Mode | Producer | What it produces |
+|---|---|---|
+| `runtime` | `RenderRuntime` | Plain code with concrete input values substituted. The validator runs this. |
+| `ld-application` | `RenderForLDApplicationTemplate` | JS template-literal with `${name}` interpolations and `${name ? \`…\` : ''}` ternaries. Used by gonfalon. |
+| `JSX text` | `RenderForJSXText` | Same shape as `ld-application` but for JSX text contexts. |
+
+`verify` renders identically to `ld-application` and compares byte-for-byte against the consumer file.
+
+## Common shapes
+
+**Install (shell-install runtime):**
+
+```markdown
+---
+id: react-client-sdk/sdk-info/install-yarn
+sdk: react-client-sdk
+kind: install
+lang: shell
+file: react-client-sdk/install-yarn.txt
+description: Install command for react-client-sdk (yarn).
+validation:
+  runtime: shell-install
+---
+
+```shell
+yarn add @launchdarkly/react-sdk
+```
+```
+
+The `ios-install` variant carries an `env:` discriminator because Podfile / Cartfile / Package.swift fragments aren't shell-sniffable:
+
+```yaml
+validation:
+  runtime: ios-install
+  env:
+    INSTALL_KIND: podfile
+```
+
+**Reference (wrapped by a scaffold):** no `file:`, no runtime/entrypoint/requirements/companions — the scaffold owns those.
+
+```markdown
+---
+id: ios-client-sdk/sdk-docs/evaluate-a-flag-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: 'Swift in section "Evaluate a flag"'
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+---
+
+```swift
+let client = LDClient.get()!
+```
+```
+
+**Runnable init (scaffold + placeholders):** body is unchanged from what consumers see; substitution happens at validate time only.
+
+```markdown
+---
+id: ios-client-sdk/sdk-info/init
+sdk: ios-client-sdk
+kind: init
+lang: swift
+file: ios-client-sdk/init.txt
+description: Client initialization snippet for ios-client-sdk.
+validation:
+  scaffold: ios-client-sdk/scaffolds/init-runner
+  placeholders:
+    YOUR_MOBILE_KEY: LAUNCHDARKLY_MOBILE_KEY
+---
+
+```swift
+import LaunchDarkly
+
+let config = LDConfig(mobileKey: "YOUR_MOBILE_KEY", autoEnvAttributes: .enabled)
+// ...
+LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in
+    // ...
+}
+```
+```
+
+## Render targets
+
+A snippet's rendered body reaches consumers via one of three adapters:
+
+| Target | Consumer | How it's wired |
+|---|---|---|
+| `ld-application` | gonfalon (ld-application) | `SDK_SNIPPET:RENDER` markers around JSX components; the adapter rewrites the marked element's children. |
+| `ld-docs` | `ld-docs`, `ld-docs-private` | `<!-- SDK_SNIPPET:RENDER id="..." -->` markers in MDX; the adapter rewrites the fenced code block underneath each marker. |
+| `raw-files` | gonfalon `packages/sdk-info/` (Vite `?raw` imports) | A YAML manifest of `(snippet-id, output-path)` pairs; the adapter emits each rendered body as a standalone file. |
+
+This repo is the canonical home of every snippet body. Consumers carry only markers (or, for `raw-files`, the manifest YAML); never edit snippet content in a consumer repo.
+
+### Marker syntax (ld-application / ld-docs)
+
+The renderer never touches files outside a marker. Mark each generated region with one comment of the host syntax, immediately before the JSX element (or fenced code block, for MDX) whose body should be replaced:
 
 - TS/JS expression context: `// SDK_SNIPPET:RENDER:<id> hash=<h> version=<v>`
 - JSX children context: `{/* SDK_SNIPPET:RENDER:<id> hash=<h> version=<v> */}`
 - Block comment anywhere: `/* SDK_SNIPPET:RENDER:<id> hash=<h> version=<v> */`
+- MDX: `<!-- SDK_SNIPPET:RENDER id="<id>" hash=<h> version=<v> -->`
 
-`hash` and `version` are filled in by `snippets render`. On first wiring, use
-`hash=0` as a placeholder — the next render rewrites it. (Any hex string
-works; `0` just minimizes finger-typing.)
+`hash` and `version` are filled in by `snippets render`. On first wiring, use `hash=0` as a placeholder — the next render rewrites it.
 
-`hash` is load-bearing — it's recomputed from the rendered children on every
-run, and `verify` rejects any drift. `version` is informational: it records
-the version of the `snippets` binary that last produced the children below
-this marker. Re-rendering with a newer binary leaves `version` alone when the
-children would be byte-identical, so a release-without-content-changes
-doesn't churn every marker in the consumer's tree. The version only moves
-forward when the snippet's rendered body actually changes.
+`hash` is load-bearing: it's recomputed from the rendered children on every run, and `verify` rejects any drift. `version` is informational — it records the binary version that last produced the children, and only advances when the rendered body actually changes (so a release without content changes doesn't churn every marker).
 
-The element directly following a marker MUST be a capitalized JSX component
-tag (e.g. `<Snippet>`, `<CodeBlock>`). Lowercase HTML tags (`<pre>`, `<code>`)
-are not recognized; wrap the content in a component first if you need to mark
-it. The marker hash covers only the *children* of the element (between `>`
-and `</`), matching the `scope=content` contract — attributes (`lang`,
-`withCopyButton`, `label`, `className`, …) are the consumer's to choose and
-can be edited without re-running `snippets render`.
+For `ld-application` markers, the element directly following the marker MUST be a capitalized JSX component tag (e.g. `<Snippet>`, `<CodeBlock>`). Lowercase HTML tags (`<pre>`, `<code>`) are not recognized — wrap them in a component first. The marker hash covers only the *children* between `>` and `</`; attributes (`lang`, `withCopyButton`, `label`, `className`, …) are the consumer's to choose and can be edited without re-rendering.
 
-## CLI quick reference
+### Manifest syntax (raw-files)
 
-```sh
-# Validate a snippet end-to-end in Docker, against a real LD environment
-export LAUNCHDARKLY_SDK_KEY=...     # server-side key
-export LAUNCHDARKLY_FLAG_KEY=...    # flag the snippet evaluates
-snippets validate --sdk=python-server-sdk
-
-# Rewrite every marked region under one or more entrypoint dirs in the
-# consumer checkout. --entrypoint is repeatable; the renderer walks each
-# directory recursively, only opens files whose extension it understands
-# (.tsx/.jsx/.ts/.js/.mdx) AND that contain the SDK_SNIPPET:RENDER
-# sentinel, and skips junk dirs (node_modules, .git, dist, build, ...).
-snippets render --target=ld-application \
-  --entrypoint=/path/to/ld-application/static/ld/components/getStarted
-
-# Confirm consumer files match what we'd render (no edits)
-snippets verify --target=ld-application \
-  --entrypoint=/path/to/ld-application/static/ld/components/getStarted
+```yaml
+out: ./generated
+entries:
+  - id: python-server-sdk/sdk-info/install-pip
+    path: python-server-sdk/install-pip.txt
+  - id: python-server-sdk/sdk-info/init
+    path: python-server-sdk/init.txt
 ```
 
-## Validator inputs
+Each `path` is resolved against `<consumer-root>/<out>/`. `--consumer` defaults to the manifest's directory; pass it explicitly when the manifest lives outside the consumer checkout.
 
-Validation runs against a real LaunchDarkly environment. The caller supplies:
+## CLI essentials
 
-| Env var | Mapped to inputs of `type` |
-|---|---|
-| `LAUNCHDARKLY_SDK_KEY` | passed to the snippet via the same env var inside the Docker container; the snippet reads it the same way the `hello-*` sample apps do |
-| `LAUNCHDARKLY_FLAG_KEY` | substituted into any input of `type: flag-key` at render-for-validation time |
+Run all commands from the `snippets/` directory (where `go.mod` lives).
 
-Snippet frontmatter does **not** carry default values for `flag-key` / `sdk-key` /
-`mobile-key` / `client-side-id` types — those always come from the caller's
-environment so real keys never end up committed to this repo.
+```sh
+# Validate one snippet end-to-end against a real LD environment
+set -a; source /tmp/ld-keys.env; set +a
+go run ./cmd/snippets validate \
+  --sdk=python-server-sdk \
+  --snippet=python-server-sdk/sdk-info/init \
+  --sdks=./sdks --validators=./validators
+
+# Validate everything in one SDK
+go run ./cmd/snippets validate --sdk=python-server-sdk --sdks=./sdks
+
+# Filter by group
+go run ./cmd/snippets validate --sdk=node-server-sdk --group=sdk-info \
+  --sdks=./sdks --validators=./validators
+
+# Re-render a consumer checkout from working-tree snippets
+go run ./cmd/snippets render --target=ld-docs \
+  --entrypoint=../ld-docs/src/content/sdk --sdks=./sdks
+
+# Render via manifest (raw-files consumers)
+go run ./cmd/snippets render --target=raw-files \
+  --manifest=../gonfalon/packages/sdk-info/snippets.yaml --sdks=./sdks
+
+# Read-only drift check against a consumer
+go run ./cmd/snippets verify --target=ld-docs \
+  --entrypoint=../ld-docs/src/content/sdk --sdks=./sdks
+```
+
+`/tmp/ld-keys.env` is the convention for local LD keys; it must export `LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_FLAG_KEY`, and (where the SDK requires them) `LAUNCHDARKLY_MOBILE_KEY` / `LAUNCHDARKLY_CLIENT_SIDE_ID`. Missing keys produce a clear `snippet X input Y (type=...) requires LAUNCHDARKLY_... to be set` error before any Docker build kicks off.
+
+`--sdks` defaults to a snapshot embedded in the binary; pass `--sdks=./sdks` while iterating so working-tree edits take effect immediately. Released binaries can be used without checking out `sdk-meta`.
+
+Docker must be on `PATH` for any non-native runtime. First-run latency is dominated by the per-language Dockerfile pre-bake; subsequent runs hit the image cache.
+
+For the full flag matrix on `validate` / `render` / `verify`, plus harness internals, see [../CLAUDE.md#cli-reference](../CLAUDE.md#cli-reference) and [../CLAUDE.md#validator-harnesses](../CLAUDE.md#validator-harnesses).


### PR DESCRIPTION
Documents the snippets system as it stands today for agents picking up future work.

- `snippets/CLAUDE.md` — auto-loaded when cwd is under `snippets/`. Covers the consumer-vs-canonical model, repo layout, snippet format (every frontmatter field, templating DSL, common shapes), scaffold patterns (init-runner pairs, syntax-only, IMPORT_LIFT, placeholders, env, companions, `{{ body }}`), validator harnesses (per-language layout, Docker vs native, EXAM-HELLO contract, shell-install dispatch), full CLI reference (`render` / `verify` / `validate`), CI matrix wiring (key-types, verify-hello-app wrapper, `key-type: none` bypass, optional-field plumbing), local testing (`/tmp/ld-keys.env`, `go test`), commit/branch conventions, and the release flow.
- `AGENTS.md` at the repo root — short pointer to `snippets/CLAUDE.md` plus the top-level repo surfaces (snippets/, api/, api-js/, metadata/, ...).

Both files are written from a survey of the current code (`internal/model`, `internal/render`, `internal/validate`, `cmd/snippets/main.go`, `validators/`, the validate workflow, release-please config) and live snippets, not from any future plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, CI, or snippet behavior impact.
> 
> **Overview**
> Adds **agent-oriented documentation** for the `sdk-meta` monorepo: a new root **`AGENTS.md`** that routes snippets work to `snippets/CLAUDE.md` and lists other top-level trees (`api/`, `metadata/`, release-please packages, etc.), plus a large new **`snippets/CLAUDE.md`** that documents the snippets system end-to-end (canonical vs consumer repos, layout, scaffold composition, validator harnesses, CLI, CI matrix, local testing, releases).
> 
> **`snippets/docs/AUTHORING.md`** is expanded from a short “first slice” into the primary how-to for `.snippet.md` files: full frontmatter and `validation.*` tables, templating DSL and render modes, example shapes (install, reference, init), render targets (`ld-application`, `ld-docs`, `raw-files`) and marker/manifest syntax, and updated CLI examples with cross-links to `CLAUDE.md` for deeper internals.
> 
> No application code, snippets, validators, or workflows change—only markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749e8474ee32fc4fb91dd7b628028ae6cc49de66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->