### PR TITLE
feat(snippets): port /sdk/features/config feature docs to canonical snippets

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -181,6 +181,15 @@ jobs:
           # brighterscript Lexer + Parser on each staged .brs file.
           # No Roku device, no LD env — pure parse check.
           - { sdk: roku-client-sdk,     runs-on: ubuntu-latest, key-type: none, label: roku-client-sdk (sdk-docs), group: sdk-docs }
+
+          # Edge SDKs (config feature-docs): the edge-ts validator runs
+          # the TypeScript compiler's transpileModule over each staged
+          # fragment — syntax-only, no module resolution or type-check.
+          # No edge runtime, no LD env — pure parse check.
+          - { sdk: cloudflare-server-sdk,     runs-on: ubuntu-latest, key-type: none, label: cloudflare-server-sdk (sdk-docs), group: sdk-docs }
+          - { sdk: vercel-server-sdk,         runs-on: ubuntu-latest, key-type: none, label: vercel-server-sdk (sdk-docs), group: sdk-docs }
+          - { sdk: akamai-server-edgekv-sdk,  runs-on: ubuntu-latest, key-type: none, label: akamai-server-edgekv-sdk (sdk-docs), group: sdk-docs }
+          - { sdk: fastly-server-sdk,         runs-on: ubuntu-latest, key-type: none, label: fastly-server-sdk (sdk-docs), group: sdk-docs }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -181,15 +181,6 @@ jobs:
           # brighterscript Lexer + Parser on each staged .brs file.
           # No Roku device, no LD env — pure parse check.
           - { sdk: roku-client-sdk,     runs-on: ubuntu-latest, key-type: none, label: roku-client-sdk (sdk-docs), group: sdk-docs }
-
-          # Edge SDKs (config feature-docs): the edge-ts validator runs
-          # the TypeScript compiler's transpileModule over each staged
-          # fragment — syntax-only, no module resolution or type-check.
-          # No edge runtime, no LD env — pure parse check.
-          - { sdk: cloudflare-server-sdk,     runs-on: ubuntu-latest, key-type: none, label: cloudflare-server-sdk (sdk-docs), group: sdk-docs }
-          - { sdk: vercel-server-sdk,         runs-on: ubuntu-latest, key-type: none, label: vercel-server-sdk (sdk-docs), group: sdk-docs }
-          - { sdk: akamai-server-edgekv-sdk,  runs-on: ubuntu-latest, key-type: none, label: akamai-server-edgekv-sdk (sdk-docs), group: sdk-docs }
-          - { sdk: fastly-server-sdk,         runs-on: ubuntu-latest, key-type: none, label: fastly-server-sdk (sdk-docs), group: sdk-docs }
     steps:
       - uses: actions/checkout@v4
 

--- a/snippets/sdks/_feature-docs-config-port-notes.md
+++ b/snippets/sdks/_feature-docs-config-port-notes.md
@@ -1,0 +1,130 @@
+# feature-docs config port notes
+
+Notes for porting the `/sdk/features/config/*` MDX pages (in
+launchdarkly/ld-docs-private) onto sdk-meta canonical snippets.
+
+Source pages (4):
+
+| MDX page | URL | Code blocks | SDKs |
+|---|---|---|---|
+| `migration-config.mdx` | `/sdk/features/migration-config` | 11 | 11 (server + edge) |
+| `app-config.mdx` | `/sdk/features/app-config` | 32 | 21 |
+| `index.mdx` | `/sdk/features/config` | 47 | 27 |
+| `service-endpoint-configuration.mdx` | `/sdk/features/service-endpoint-configuration` | 99 | 24 |
+
+This file is the analogue of `_sdk-docs-port-notes.md` and
+`_sdk-info-port-notes.md`.
+
+## Group + ID layout
+
+Snippets land under a new nested folder beneath each SDK's existing
+`sdk-docs` group:
+
+```
+sdks/<sdk-id>/snippets/sdk-docs/features/config/<slug>.snippet.md
+```
+
+Resulting snippet IDs look like
+`python-server-sdk/sdk-docs/features/config/migration-config`. The
+second segment of the ID is `sdk-docs`, so CI's existing
+`--group=sdk-docs` matrix row picks these up alongside the per-SDK
+landing-page fragments — one validation rotation covers both
+families.
+
+Per-CodeBlock naming (because each marker maps to exactly one
+fence; the MDX adapter does not handle multi-CodeBlock accordions
+under a single marker):
+
+| Source shape | Slug convention |
+|---|---|
+| One CodeBlock per accordion (e.g. all of `migration-config.mdx`) | `<page>` (e.g. `migration-config`) |
+| Multiple CodeBlocks for SDK version variants (e.g. .NET v4.0 / v3.0 in `index.mdx`) | `<page>-v<N>-<N>` (e.g. `index-v4-0`, `index-v3-0`) |
+| Multiple CodeBlocks for language flavors (e.g. Android Java / Kotlin) | `<page>-<lang>` (e.g. `index-java`, `index-kotlin`) |
+| Multiple CodeBlocks for native / C-binding variants (C++ SDKs) | `<page>-<binding>` (e.g. `index-native`, `index-c-binding`) |
+
+## Snippet shape
+
+These are all `kind: reference` snippets with no `validation:`
+block — the bodies reference symbols (`_client`, `client`, `ldclient`,
+the SDK's `Migration*` types) that aren't supplied in a standalone
+runtime, mirroring the `kind: reference` fragments under each SDK's
+existing `sdk-docs/` group.
+
+The fence in the .snippet.md file is plain `\`\`\`<lang>`; MDX-side
+presentation attributes (`maxLines=0`, etc.) stay on the consumer
+side. The renderer only rewrites bytes BETWEEN fences, so the
+consumer's fence-line attributes are preserved across re-renders.
+
+## Scope (this PR)
+
+All four `/sdk/features/config/*` pages, 189 snippet files:
+
+| MDX page | Snippets | SDKs touched |
+|---|---:|---:|
+| `migration-config.mdx` | 11 | 11 |
+| `app-config.mdx` | 32 | 21 |
+| `index.mdx` | 47 | 27 |
+| `service-endpoint-configuration.mdx` | 99 | 24 |
+
+### New sdk-meta SDK directories created here
+
+The snippet system needed `sdks/<id>/` directories for four edge SDKs
+that weren't yet hosted. Each gets a minimal `sdk.yaml` and its first
+snippets in this port:
+
+- `akamai-server-edgekv-sdk` (referenced by all 4 pages)
+- `cloudflare-server-sdk` (referenced by all 4 pages)
+- `fastly-server-sdk` (referenced by `index.mdx` only)
+- `vercel-server-sdk` (referenced by all 4 pages)
+
+`akamai-server-base-sdk` (a separate Akamai package) is NOT added —
+none of the four config pages import from it.
+
+### MDX-side fix-ups landed alongside the markers
+
+- **`service-endpoint-configuration.mdx` Electron accordion**: two
+  consecutive blocks were both titled "TypeScript, connecting to
+  federal instance" — but the second's body shows the EU endpoints
+  (`eu.launchdarkly.com`). The duplicate title is a doc-side typo;
+  this PR renames the second block to "TypeScript, connecting to EU
+  instance" so it matches its body. One-line MDX change.
+
+- **JS accordion bodies in `app-config.mdx` / `index.mdx`**: the
+  original `<CodeBlock>` bodies were indented 2 spaces (visual
+  nesting inside the wrapping `<CodeBlocks>`). The canonical form
+  in sdk-meta is flush-left (consistent with every other SDK
+  accordion in these pages), so after re-render the bodies move
+  flush-left. CommonMark-valid; surrounding fence lines retain
+  their 2-space indent, which the renderer doesn't touch.
+
+## Slug conventions used
+
+Each `<CodeBlock title='…'>` becomes one snippet. The snippet
+filename / slug derives from the page name plus a suffix that
+captures whatever distinguishes this block from its accordion
+siblings:
+
+| Distinguisher in title | Slug suffix |
+|---|---|
+| Single block in accordion | (no suffix — slug is just the page name, e.g. `migration-config`) |
+| SDK version (`v4.0`, `v3.x`) | `v<N>` or `v<N>-<M>` (e.g. `v4`, `v4-0`, `v3`) |
+| Language tab (Java/Kotlin, Swift/Objective-C) | `<lang>` (e.g. `java`, `kotlin`, `swift`, `objc`) |
+| TypeScript vs JavaScript sibling | `ts` / `js` |
+| C++ native vs C-binding vs C SDK v2.x | `cpp-native`, `cpp-c`, `c-sdk` |
+| Endpoint variant (Relay Proxy / federal / EU) | `relay`, `federal`, `eu` |
+| Combinations (e.g. C++ native + EU) | hyphen-joined: `cpp-native-eu` |
+| Roku `index.mdx` constructor vs setters reference | `create`, `options` |
+| Akamai `index.mdx` default vs custom feature store | `default`, `custom-store` |
+
+Final snippet IDs all live under
+`<sdk-id>/sdk-docs/features/config/<slug>` so CI's existing
+`--group=sdk-docs` matrix row picks them up alongside the per-SDK
+landing-page fragments.
+
+## Out of scope for this PR
+
+None — all four pages are covered. Future feature-docs ports
+(`/sdk/features/evaluating`, `/sdk/features/identify`, etc.) can
+follow the same pattern: new snippets land under
+`<sdk>/sdk-docs/features/<topic>/<slug>` and add markers to the
+relevant MDX file.

--- a/snippets/sdks/akamai-server-edgekv-sdk/sdk.yaml
+++ b/snippets/sdks/akamai-server-edgekv-sdk/sdk.yaml
@@ -1,0 +1,4 @@
+# Identifier for this SDK. Matches the SDK's id in launchdarkly/sdk-meta's
+# API packages — the source of truth for everything else (display name,
+# language flavors, supported regions, hello-world repo, docs URL).
+id: akamai-server-edgekv-sdk

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/akamai-syntax-only.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/akamai-syntax-only.snippet.md
@@ -1,0 +1,26 @@
+---
+id: akamai-server-edgekv-sdk/scaffolds/akamai-syntax-only
+sdk: akamai-server-edgekv-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Parse-only validator for Akamai edge SDK config doc fragments. Routes
+  through the `edge-ts` validator, which runs the TypeScript compiler's
+  transpileModule (syntax check + type-strip; no module resolution, no
+  type-checking). A clean parse means the fragment is syntactically
+  valid TypeScript -- edge-only package imports and ambient globals
+  (env, process) need not resolve. Doc fragments are whole TS modules,
+  so the scaffold emits the body verbatim.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, parsed as a TypeScript module.
+validation:
+  runtime: edge-ts
+  entrypoint: snippet.ts
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-custom-store.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-custom-store.snippet.md
@@ -1,0 +1,35 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/features/config/index-custom-store
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Akamai.
+---
+
+```ts
+// If you are using your own feature store,
+// make sure to import 'init' from the 'akamai-server-base-sdk'
+// rather than from 'akamai-server-edgekv-sdk'
+
+import { init, EdgeProvider, LDOptions, BasicLogger } from '@launchdarkly/akamai-server-base-sdk';
+
+// When using your own feature store, you must create a new class that
+// implements EdgeProvider. To learn more, read
+// https://launchdarkly.com/docs/sdk/edge/akamai#getting-started
+class FeatureStore implements EdgeProvider {
+  async get(rootKey: string): Promise<string> {
+    return flagData;
+  }
+}
+
+const options: LDOptions = {
+  logger: BasicLogger.get(),
+  cacheTtlMs: 200,
+};
+
+const ldClient = init({
+  sdkKey: 'example-client-side-id',
+  featureStoreProvider: new FeatureStore(),
+  options: options,
+});
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-custom-store.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-custom-store.snippet.md
@@ -4,6 +4,9 @@ sdk: akamai-server-edgekv-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Akamai.
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/akamai-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-default.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-default.snippet.md
@@ -1,0 +1,23 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/features/config/index-default
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Akamai.
+---
+
+```ts
+import { init, LDOptions, BasicLogger } from '@launchdarkly/akamai-server-edgekv-sdk';
+
+const options: LDOptions = {
+  logger: BasicLogger.get(),
+  cacheTtlMs: 200,
+};
+
+const ldClient = init({
+  sdkKey: 'example-client-side-id',
+  namespace: 'your-edgekv-namespace',
+  group: 'your-edgekv-group-id',
+  options: options,
+});
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-default.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/index-default.snippet.md
@@ -4,6 +4,9 @@ sdk: akamai-server-edgekv-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Akamai.
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/akamai-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -22,7 +22,7 @@ const options: LDMigrationOptions = {
     return LDMigrationSuccess(true);
   },
   readOld: async(key?: string) => {
-    console.log("Reading from new: ", key);
+    console.log("Reading from old: ", key);
     return LDMigrationSuccess(true);
   },
   writeNew: async(params?: {key: string, value: string}) => {
@@ -36,7 +36,7 @@ const options: LDMigrationOptions = {
     return LDMigrationError(new Error('example error'));
   },
 
-  check: (old, new) => {
+  check: (old, newVal) => {
     // Define your consistency check for read operations
     // and return a boolean. Depending on your migration,
     // this may be as simple as 'return a === b;'

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,9 @@ sdk: akamai-server-edgekv-sdk
 kind: reference
 lang: typescript
 description: Migration configuration example for the Akamai SDK for EdgeKV — read/write functions and execution mode. Akamai does not send events, so metrics tracking options are inert.
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/akamai-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,58 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/features/config/migration-config
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+description: Migration configuration example for the Akamai SDK for EdgeKV — read/write functions and execution mode. Akamai does not send events, so metrics tracking options are inert.
+---
+
+```ts
+import {
+  createMigration,
+  init,
+  LDConcurrentExecution,
+  LDMigrationError,
+  LDMigrationOptions,
+  LDMigrationSuccess,
+} from '@launchdarkly/akamai-server-edgekv-sdk';
+
+const options: LDMigrationOptions = {
+  readNew: async(key?: string) => {
+    console.log("Reading from new: ", key);
+    return LDMigrationSuccess(true);
+  },
+  readOld: async(key?: string) => {
+    console.log("Reading from new: ", key);
+    return LDMigrationSuccess(true);
+  },
+  writeNew: async(params?: {key: string, value: string}) => {
+    console.log("Writing to new: ", params);
+    // if failure - can throw an exception
+    throw new Error("example exception")
+  },
+  writeOld: async(params?: {key: string, value: string}) => {
+    console.log("Writing to old: ", params);
+    // if failure - can return the error
+    return LDMigrationError(new Error('example error'));
+  },
+
+  check: (old, new) => {
+    // Define your consistency check for read operations
+    // and return a boolean. Depending on your migration,
+    // this may be as simple as 'return a === b;'
+  },
+
+  execution: new LDConcurrentExecution(),
+    // or new LDSerialExecution(LDExecutionOrdering.Random),
+    // or new LDSerialExecution(LDExecutionOrdering.Fixed),
+
+}
+
+const client = init({
+  sdkKey: 'example-client-side-id',
+  namespace: 'your-edgekv-namespace',
+  group: 'your-edgekv-group-id'
+});
+const migration = createMigration(client, options);
+
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -53,6 +53,11 @@ import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import com.launchdarkly.sdk.*;
 import com.launchdarkly.sdk.android.*;
+// `AutoEnvAttributes` is a nested enum at
+// `LDConfig.Builder.AutoEnvAttributes`; package wildcard imports don't
+// reach nested types, so config/init bodies referencing
+// `AutoEnvAttributes.Enabled` need this explicit import.
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes;
 
 // No `public` modifier: Java requires public top-level classes to
 // live in a file matching the class name. We need this scaffold's

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-java.snippet.md
@@ -4,6 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Application metadata configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
 
 ---
 

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-java.snippet.md
@@ -1,0 +1,19 @@
+---
+id: android-client-sdk/sdk-docs/features/config/app-config-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Application metadata configuration example for Android.
+---
+
+```java
+LDConfig config = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .applicationInfo(
+        Components.applicationInfo()
+            .applicationId("authentication-service")
+            .applicationName("Authentication-Service")
+            .applicationVersion("1.0.0")
+            .applicationVersionName("v1")
+    )
+    .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-java.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Application metadata configuration example for Android.
+
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-kotlin.snippet.md
@@ -1,0 +1,19 @@
+---
+id: android-client-sdk/sdk-docs/features/config/app-config-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Application metadata configuration example for Android.
+---
+
+```kotlin
+val ldConfig: LDConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .applicationInfo(
+        Components.applicationInfo()
+            .applicationId("authentication-service")
+            .applicationName("Authentication-Service")
+            .applicationVersion("1.0.0")
+            .applicationVersionName("v1")
+    )
+    .build()
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/app-config-kotlin.snippet.md
@@ -4,6 +4,9 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Application metadata configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-java.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: SDK configuration example for Android.
+
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-java.snippet.md
@@ -4,6 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: SDK configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
 
 ---
 

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-java.snippet.md
@@ -1,0 +1,21 @@
+---
+id: android-client-sdk/sdk-docs/features/config/index-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: SDK configuration example for Android.
+---
+
+```java
+LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey("example-mobile-key")
+    .http(
+      Components.httpConfiguration()
+      .connectTimeoutMillis(5000)
+    )
+    .events(
+      Components.sendEvents()
+      .flushIntervalMillis(5000)
+    )
+    .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-kotlin.snippet.md
@@ -4,6 +4,9 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: SDK configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/index-kotlin.snippet.md
@@ -1,0 +1,21 @@
+---
+id: android-client-sdk/sdk-docs/features/config/index-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: SDK configuration example for Android.
+---
+
+```kotlin
+val ldConfig: LDConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey("example-mobile-key")
+    .http(
+      Components.httpConfiguration()
+      .connectTimeoutMillis(5000)
+    )
+    .events(
+      Components.sendEvents()
+      .flushIntervalMillis(5000)
+    )
+    .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Android.
+
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
@@ -4,6 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
 
 ---
 

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
@@ -1,0 +1,19 @@
+---
+id: android-client-sdk/sdk-docs/features/config/service-endpoint-configuration-java-eu
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Service endpoint configuration example for Android.
+---
+
+```java
+LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+  .mobileKey("example-mobile-key")
+  .serviceEndpoints(
+    Components.serviceEndpoints()
+      .streaming("https://clientstream.eu.launchdarkly.com")
+      .polling("https://clientsdk.eu.launchdarkly.com")
+      .events("https://events.eu.launchdarkly.com")
+  )
+  .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Android.
+
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
@@ -1,0 +1,19 @@
+---
+id: android-client-sdk/sdk-docs/features/config/service-endpoint-configuration-java-federal
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Service endpoint configuration example for Android.
+---
+
+```java
+LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+  .mobileKey("example-mobile-key")
+  .serviceEndpoints(
+    Components.serviceEndpoints()
+      .streaming("https://clientstream.launchdarkly.us")
+      .polling("https://clientsdk.launchdarkly.us")
+      .events("https://events.launchdarkly.us")
+  )
+  .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
@@ -4,6 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
 
 ---
 

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
@@ -4,6 +4,7 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Android.
+
 ---
 
 ```java

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: android-client-sdk/sdk-docs/features/config/service-endpoint-configuration-java-relay
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Service endpoint configuration example for Android.
+---
+
+```java
+LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+  .mobileKey("example-mobile-key")
+  .serviceEndpoints(
+    Components.serviceEndpoints()
+      .relayProxy("https://your-relay-proxy.com:8030")
+  )
+  .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
@@ -4,6 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
 
 ---
 

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-eu.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Service endpoint configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-eu.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-eu.snippet.md
@@ -1,0 +1,19 @@
+---
+id: android-client-sdk/sdk-docs/features/config/service-endpoint-configuration-kotlin-eu
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Service endpoint configuration example for Android.
+---
+
+```kotlin
+val ldConfig: LDConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+  .mobileKey("example-mobile-key")
+  .serviceEndpoints(
+    Components.serviceEndpoints()
+      .streaming("https://clientstream.eu.launchdarkly.com")
+      .polling("https://clientsdk.eu.launchdarkly.com")
+      .events("https://events.eu.launchdarkly.com")
+  )
+  .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-federal.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-federal.snippet.md
@@ -1,0 +1,19 @@
+---
+id: android-client-sdk/sdk-docs/features/config/service-endpoint-configuration-kotlin-federal
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Service endpoint configuration example for Android.
+---
+
+```kotlin
+val ldConfig: LDConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+  .mobileKey("example-mobile-key")
+  .serviceEndpoints(
+    Components.serviceEndpoints()
+      .streaming("https://clientstream.launchdarkly.us")
+      .polling("https://clientsdk.launchdarkly.us")
+      .events("https://events.launchdarkly.us")
+  )
+  .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-federal.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Service endpoint configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-relay.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Service endpoint configuration example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-relay.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-kotlin-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: android-client-sdk/sdk-docs/features/config/service-endpoint-configuration-kotlin-relay
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Service endpoint configuration example for Android.
+---
+
+```kotlin
+val ldConfig: LDConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+  .mobileKey("example-mobile-key")
+  .serviceEndpoints(
+    Components.serviceEndpoints()
+      .relayProxy("https://your-relay-proxy.com:8030")
+  )
+  .build();
+```

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,13 @@
+---
+id: apex-server-sdk/sdk-docs/features/config/index
+sdk: apex-server-sdk
+kind: reference
+lang: java
+description: SDK configuration example for Apex.
+---
+
+```java
+LDConfig config = new LDConfig.Builder()
+    .setAllAttributesPrivate(true)
+    .build();
+```

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: apex-server-sdk
 kind: reference
 lang: java
 description: SDK configuration example for Apex.
+validation:
+  scaffold: apex-server-sdk/scaffolds/apex-syntax-only
+
 ---
 
 ```java

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,18 @@
+---
+id: apex-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: apex-server-sdk
+kind: reference
+lang: bash
+description: Service endpoint configuration example for Apex.
+---
+
+```bash
+cd bridge && go build .
+
+# other required export statements...
+
+export LD_BASE_URI='https://sdk.eu.launchdarkly.com'
+export LD_EVENTS_URL='https://events.eu.launchdarkly.com'
+
+./bridge
+```

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,7 @@ sdk: apex-server-sdk
 kind: reference
 lang: bash
 description: Service endpoint configuration example for Apex.
+
 ---
 
 ```bash

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,18 @@
+---
+id: apex-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: apex-server-sdk
+kind: reference
+lang: bash
+description: Service endpoint configuration example for Apex.
+---
+
+```bash
+cd bridge && go build .
+
+# other required export statements...
+
+export LD_BASE_URI='https://sdk.launchdarkly.us'
+export LD_EVENTS_URL='https://events.launchdarkly.us'
+
+./bridge
+```

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,7 @@ sdk: apex-server-sdk
 kind: reference
 lang: bash
 description: Service endpoint configuration example for Apex.
+
 ---
 
 ```bash

--- a/snippets/sdks/cloudflare-server-sdk/sdk.yaml
+++ b/snippets/sdks/cloudflare-server-sdk/sdk.yaml
@@ -1,0 +1,4 @@
+# Identifier for this SDK. Matches the SDK's id in launchdarkly/sdk-meta's
+# API packages — the source of truth for everything else (display name,
+# language flavors, supported regions, hello-world repo, docs URL).
+id: cloudflare-server-sdk

--- a/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/cloudflare-syntax-only.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/cloudflare-syntax-only.snippet.md
@@ -1,0 +1,26 @@
+---
+id: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+sdk: cloudflare-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Parse-only validator for Cloudflare edge SDK config doc fragments. Routes
+  through the `edge-ts` validator, which runs the TypeScript compiler's
+  transpileModule (syntax check + type-strip; no module resolution, no
+  type-checking). A clean parse means the fragment is syntactically
+  valid TypeScript -- edge-only package imports and ambient globals
+  (env, process) need not resolve. Doc fragments are whole TS modules,
+  so the scaffold emits the body verbatim.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, parsed as a TypeScript module.
+validation:
+  runtime: edge-ts
+  entrypoint: snippet.ts
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-2.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-2.snippet.md
@@ -1,0 +1,17 @@
+---
+id: cloudflare-server-sdk/sdk-docs/features/config/index-ts-v2-2
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Cloudflare.
+---
+
+```typescript
+import { BasicLogger, init, LDOptions } from '@launchdarkly/cloudflare-server-sdk';
+
+const options: LDOptions = {
+  logger: new BasicLogger({ destination: console.log }),
+};
+
+client = init('example-client-side-id', env.LD_KV, options);
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-2.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-2.snippet.md
@@ -4,6 +4,9 @@ sdk: cloudflare-server-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Cloudflare.
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+
 ---
 
 ```typescript

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-3.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-3.snippet.md
@@ -1,0 +1,18 @@
+---
+id: cloudflare-server-sdk/sdk-docs/features/config/index-ts-v2-3
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Cloudflare.
+---
+
+```typescript
+import { BasicLogger, init, LDOptions } from '@launchdarkly/cloudflare-server-sdk';
+
+const options: LDOptions = {
+  logger: new BasicLogger({ destination: console.log }),
+  sendEvents: true, // default is false
+};
+
+client = init('example-client-side-id', env.LD_KV, options);
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-3.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/index-ts-v2-3.snippet.md
@@ -4,6 +4,9 @@ sdk: cloudflare-server-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Cloudflare.
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+
 ---
 
 ```typescript

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,56 @@
+---
+id: cloudflare-server-sdk/sdk-docs/features/config/migration-config
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+description: Migration configuration example for the Cloudflare SDK v2.2.2+ — read/write functions, execution mode, latency/error tracking.
+---
+
+```ts
+import {
+  createMigration,
+  init,
+  LDConcurrentExecution,
+  LDMigrationError,
+  LDMigrationOptions,
+  LDMigrationSuccess,
+} from '@launchdarkly/cloudflare-server-sdk';
+
+const options: LDMigrationOptions = {
+  readNew: async(key?: string) => {
+    console.log("Reading from new: ", key);
+    return LDMigrationSuccess(true);
+  },
+  readOld: async(key?: string) => {
+    console.log("Reading from new: ", key);
+    return LDMigrationSuccess(true);
+  },
+  writeNew: async(params?: {key: string, value: string}) => {
+    console.log("Writing to new: ", params);
+    // if failure - can throw an exception
+    throw new Error('example exception')
+  },
+  writeOld: async(params?: {key: string, value: string}) => {
+    console.log("Writing to old: ", params);
+    // if failure - can return the failure
+    return LDMigrationError(new Error('example error'));
+  },
+
+  check: (old, new) => {
+    // Define your consistency check for read operations
+    // and return a boolean. Depending on your migration,
+    // this may be as simple as 'return a === b;'
+  },
+
+  execution: new LDConcurrentExecution(),
+    // or new LDSerialExecution(LDExecutionOrdering.Random),
+    // or new LDSerialExecution(LDExecutionOrdering.Fixed),
+
+  latencyTracking: true, // defaults to true
+  errorTracking: true, // defaults to true
+}
+
+const client = init('YOUR_SDK_KEY', env.LD_KV, { sendEvents: true });
+const migration = createMigration(client, options);
+
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,9 @@ sdk: cloudflare-server-sdk
 kind: reference
 lang: typescript
 description: Migration configuration example for the Cloudflare SDK v2.2.2+ — read/write functions, execution mode, latency/error tracking.
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -22,7 +22,7 @@ const options: LDMigrationOptions = {
     return LDMigrationSuccess(true);
   },
   readOld: async(key?: string) => {
-    console.log("Reading from new: ", key);
+    console.log("Reading from old: ", key);
     return LDMigrationSuccess(true);
   },
   writeNew: async(params?: {key: string, value: string}) => {
@@ -36,7 +36,7 @@ const options: LDMigrationOptions = {
     return LDMigrationError(new Error('example error'));
   },
 
-  check: (old, new) => {
+  check: (old, newVal) => {
     // Define your consistency check for read operations
     // and return a boolean. Depending on your migration,
     // this may be as simple as 'return a === b;'

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
@@ -1,0 +1,20 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/app-config-cpp-c-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Application metadata configuration example for C++ (client-side).
+---
+
+```c
+LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
+LDClientConfigBuilder_AppInfo_Identifier(builder, "authentication-service");
+LDClientConfigBuilder_AppInfo_Version(builder, "1.0.0");
+LDClientConfig config;
+
+LDStatus status = LDClientConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: Application metadata configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
@@ -4,10 +4,13 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: Application metadata configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```cpp
 auto config_builder = client_side::ConfigBuilder("example-mobile-key");
-config_builder.AppInfo().Identifier("authentication-service").Version("1.0.0")
+config_builder.AppInfo().Identifier("authentication-service").Version("1.0.0");
 auto config = config_builder.Build();
 ```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
@@ -1,0 +1,13 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/app-config-cpp-native-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Application metadata configuration example for C++ (client-side).
+---
+
+```cpp
+auto config_builder = client_side::ConfigBuilder("example-mobile-key");
+config_builder.AppInfo().Identifier("authentication-service").Version("1.0.0")
+auto config = config_builder.Build();
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: SDK configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-c
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
@@ -1,0 +1,13 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/index-c-sdk-v2
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: SDK configuration example for C++ (client-side).
+---
+
+```c
+struct LDConfig *config = LDConfigNew("example-mobile-key");
+LDConfigSetEventsCapacity(config, 1000);
+LDConfigSetEventsFlushIntervalMillis(config, 30000);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
@@ -1,0 +1,20 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/index-cpp-c-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: SDK configuration example for C++ (client-side).
+---
+
+```c
+LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
+LDClientConfigBuilder_Events_Capacity(builder, 1000);
+LDClientConfigBuilder_Events_FlushIntervalMs(builder, 30 * 1000);
+LDClientConfig config;
+
+LDStatus status = LDClientConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: SDK configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
@@ -1,0 +1,18 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/index-cpp-native-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: SDK configuration example for C++ (client-side).
+---
+
+```cpp
+auto config_builder = client_side::ConfigBuilder("example-mobile-key");
+config_builder.Events()
+    .Capacity(1000)
+    .FlushInterval(std::chrono::seconds(30));
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: SDK configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
@@ -4,13 +4,16 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```c
 LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
-LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://clientstream.eu.launchdarkly.com")
-LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://clientsdk.eu.launchdarkly.com")
-LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.eu.launchdarkly.com")
+LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://clientstream.eu.launchdarkly.com");
+LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://clientsdk.eu.launchdarkly.com");
+LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.eu.launchdarkly.com");
 LDClientConfig config;
 
 LDStatus status = LDClientConfigBuilder_Build(builder, &config);

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
@@ -1,0 +1,21 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (client-side).
+---
+
+```c
+LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
+LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://clientstream.eu.launchdarkly.com")
+LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://clientsdk.eu.launchdarkly.com")
+LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.eu.launchdarkly.com")
+LDClientConfig config;
+
+LDStatus status = LDClientConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
@@ -4,13 +4,16 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```c
 LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
-LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://clientstream.launchdarkly.us")
-LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://clientsdk.launchdarkly.us")
-LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.launchdarkly.us")
+LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://clientstream.launchdarkly.us");
+LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://clientsdk.launchdarkly.us");
+LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.launchdarkly.us");
 LDClientConfig config;
 
 LDStatus status = LDClientConfigBuilder_Build(builder, &config);

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
@@ -1,0 +1,21 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (client-side).
+---
+
+```c
+LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
+LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://clientstream.launchdarkly.us")
+LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://clientsdk.launchdarkly.us")
+LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.launchdarkly.us")
+LDClientConfig config;
+
+LDStatus status = LDClientConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
@@ -4,13 +4,16 @@ sdk: cpp-client-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```c
 LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
-LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://your-relay-proxy.com:8030")
-LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://your-relay-proxy.com:8030")
-LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://your-relay-proxy.com:8030")
+LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://your-relay-proxy.com:8030");
+LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://your-relay-proxy.com:8030");
+LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://your-relay-proxy.com:8030");
 LDClientConfig config;
 
 LDStatus status = LDClientConfigBuilder_Build(builder, &config);

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
@@ -1,0 +1,21 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (client-side).
+---
+
+```c
+LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
+LDClientConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://your-relay-proxy.com:8030")
+LDClientConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://your-relay-proxy.com:8030")
+LDClientConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://your-relay-proxy.com:8030")
+LDClientConfig config;
+
+LDStatus status = LDClientConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Service endpoint configuration example for C++ (client-side).
+---
+
+```cpp
+auto config_builder = client_side::ConfigBuilder("example-mobile-key");
+config_builder.ServiceEndpoints()
+    .StreamingBaseUrl("https://clientstream.eu.launchdarkly.com")
+    .PollingBaseUrl("https://clientsdk.eu.launchdarkly.com")
+    .EventsBaseUrl("https://events.eu.launchdarkly.com")
+auto config = config_builder.Build();
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: Service endpoint configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```cpp
@@ -11,6 +14,6 @@ auto config_builder = client_side::ConfigBuilder("example-mobile-key");
 config_builder.ServiceEndpoints()
     .StreamingBaseUrl("https://clientstream.eu.launchdarkly.com")
     .PollingBaseUrl("https://clientsdk.eu.launchdarkly.com")
-    .EventsBaseUrl("https://events.eu.launchdarkly.com")
+    .EventsBaseUrl("https://events.eu.launchdarkly.com");
 auto config = config_builder.Build();
 ```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Service endpoint configuration example for C++ (client-side).
+---
+
+```cpp
+auto config_builder = client_side::ConfigBuilder("example-mobile-key");
+config_builder.ServiceEndpoints()
+    .StreamingBaseUrl("https://clientstream.launchdarkly.us")
+    .PollingBaseUrl("https://clientsdk.launchdarkly.us")
+    .EventsBaseUrl("https://events.launchdarkly.us")
+auto config = config_builder.Build();
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: Service endpoint configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```cpp
@@ -11,6 +14,6 @@ auto config_builder = client_side::ConfigBuilder("example-mobile-key");
 config_builder.ServiceEndpoints()
     .StreamingBaseUrl("https://clientstream.launchdarkly.us")
     .PollingBaseUrl("https://clientsdk.launchdarkly.us")
-    .EventsBaseUrl("https://events.launchdarkly.us")
+    .EventsBaseUrl("https://events.launchdarkly.us");
 auto config = config_builder.Build();
 ```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-client-sdk
 kind: reference
 lang: cpp
 description: Service endpoint configuration example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
 ---
 
 ```cpp
@@ -11,6 +14,6 @@ auto config_builder = client_side::ConfigBuilder("example-mobile-key");
 config_builder.ServiceEndpoints()
     .StreamingBaseUrl("https://your-relay-proxy.com:8030")
     .PollingBaseUrl("https://your-relay-proxy.com:8030")
-    .EventsBaseUrl("https://your-relay-proxy.com:8030")
+    .EventsBaseUrl("https://your-relay-proxy.com:8030");
 auto config = config_builder.Build();
 ```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cpp-client-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Service endpoint configuration example for C++ (client-side).
+---
+
+```cpp
+auto config_builder = client_side::ConfigBuilder("example-mobile-key");
+config_builder.ServiceEndpoints()
+    .StreamingBaseUrl("https://your-relay-proxy.com:8030")
+    .PollingBaseUrl("https://your-relay-proxy.com:8030")
+    .EventsBaseUrl("https://your-relay-proxy.com:8030")
+auto config = config_builder.Build();
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
@@ -1,0 +1,20 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/app-config-cpp-c-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Application metadata configuration example for C++ (server-side).
+---
+
+```c
+LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+LDServerConfigBuilder_AppInfo_Identifier(builder, "authentication-service");
+LDServerConfigBuilder_AppInfo_Version(builder, "1.0.0");
+LDServerConfig config;
+
+LDStatus status = LDServerConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-c-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: Application metadata configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
@@ -4,11 +4,14 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: Application metadata configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```cpp
 auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
-config_builder.AppInfo().Identifier("authentication-service").Version("1.0.0")
+config_builder.AppInfo().Identifier("authentication-service").Version("1.0.0");
 auto config = config_builder.Build();
 if (!config) {
     /* an error occurred, config is not valid */

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/app-config-cpp-native-v3-0.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/app-config-cpp-native-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Application metadata configuration example for C++ (server-side).
+---
+
+```cpp
+auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
+config_builder.AppInfo().Identifier("authentication-service").Version("1.0.0")
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
@@ -1,0 +1,13 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/index-c-sdk-v2
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: SDK configuration example for C++ (server-side).
+---
+
+```c
+struct LDConfig *config = LDConfigNew("YOUR_SDK_KEY");
+LDConfigSetEventsCapacity(config, 1000);
+LDConfigSetEventsFlushInterval(config, 30000);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-c-sdk-v2.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: SDK configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
@@ -1,0 +1,20 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/index-cpp-c-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: SDK configuration example for C++ (server-side).
+---
+
+```c
+LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+LDServerConfigBuilder_Events_Capacity(builder, 1000);
+LDServerConfigBuilder_Events_FlushIntervalMs(builder, 30 * 1000);
+LDServerConfig config;
+
+LDStatus status = LDServerConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-c-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: SDK configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: SDK configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```cpp

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/index-cpp-native-v3-0.snippet.md
@@ -1,0 +1,18 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/index-cpp-native-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: SDK configuration example for C++ (server-side).
+---
+
+```cpp
+auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
+config_builder.Events()
+    .Capacity(1000)
+    .FlushInterval(std::chrono::seconds(30));
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-eu.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-eu.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-eu
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```c
+struct LDConfig *config = LDConfigNew("YOUR_SDK_KEY");
+LDConfigSetStreamURI(config, "https://stream.eu.launchdarkly.com");
+LDConfigSetBaseURI(config, "https://sdk.eu.launchdarkly.com");
+LDConfigSetEventsURI(config, "https://events.eu.launchdarkly.com");
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-eu.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-federal.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-federal.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-federal.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-federal
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```c
+struct LDConfig *config = LDConfigNew("YOUR_SDK_KEY");
+LDConfigSetStreamURI(config, "https://stream.launchdarkly.us");
+LDConfigSetBaseURI(config, "https://sdk.launchdarkly.us");
+LDConfigSetEventsURI(config, "https://events.launchdarkly.us");
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-relay.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-relay.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-relay
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```c
+struct LDConfig *config = LDConfigNew("YOUR_SDK_KEY");
+LDConfigSetStreamURI(config, "https://your-relay-proxy.com:8030");
+LDConfigSetBaseURI(config, "https://your-relay-proxy.com:8030");
+LDConfigSetEventsURI(config, "https://your-relay-proxy.com:8030");
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-relay.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-c-sdk-v2-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
 ---
 
 ```c

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
@@ -1,0 +1,21 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```c
+LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+LDServerConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://stream.eu.launchdarkly.com")
+LDServerConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://sdk.eu.launchdarkly.com")
+LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.eu.launchdarkly.com")
+LDServerConfig config;
+
+LDStatus status = LDServerConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-eu.snippet.md
@@ -4,13 +4,16 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```c
 LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
-LDServerConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://stream.eu.launchdarkly.com")
-LDServerConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://sdk.eu.launchdarkly.com")
-LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.eu.launchdarkly.com")
+LDServerConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://stream.eu.launchdarkly.com");
+LDServerConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://sdk.eu.launchdarkly.com");
+LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.eu.launchdarkly.com");
 LDServerConfig config;
 
 LDStatus status = LDServerConfigBuilder_Build(builder, &config);

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
@@ -1,0 +1,21 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```c
+LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+LDServerConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://stream.launchdarkly.us")
+LDServerConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://sdk.launchdarkly.us")
+LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.launchdarkly.us")
+LDServerConfig config;
+
+LDStatus status = LDServerConfigBuilder_Build(builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-federal.snippet.md
@@ -4,13 +4,16 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```c
 LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
-LDServerConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://stream.launchdarkly.us")
-LDServerConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://sdk.launchdarkly.us")
-LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.launchdarkly.us")
+LDServerConfigBuilder_ServiceEndpoints_StreamingBaseURL(builder, "https://stream.launchdarkly.us");
+LDServerConfigBuilder_ServiceEndpoints_PollingBaseURL(builder, "https://sdk.launchdarkly.us");
+LDServerConfigBuilder_ServiceEndpoints_EventsBaseURL(builder, "https://events.launchdarkly.us");
 LDServerConfig config;
 
 LDStatus status = LDServerConfigBuilder_Build(builder, &config);

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
@@ -1,0 +1,19 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```cpp
+LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+
+LDServerConfigBuilder_ServiceEndpoints_RelayProxyBaseURL(builder, "https://your-relay-proxy.com:8030")
+
+LDServerConfig config;
+LDStatus status = LDServerConfigBuilder_Build(builder, &config);
+if (!LDStatus_Ok(status)) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
@@ -2,11 +2,11 @@
 id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay
 sdk: cpp-server-sdk
 kind: reference
-lang: cpp
+lang: c
 description: Service endpoint configuration example for C++ (server-side).
 ---
 
-```cpp
+```c
 LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
 
 LDServerConfigBuilder_ServiceEndpoints_RelayProxyBaseURL(builder, "https://your-relay-proxy.com:8030")

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-c-v3-0-relay.snippet.md
@@ -4,12 +4,15 @@ sdk: cpp-server-sdk
 kind: reference
 lang: c
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```c
 LDServerConfigBuilder builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
 
-LDServerConfigBuilder_ServiceEndpoints_RelayProxyBaseURL(builder, "https://your-relay-proxy.com:8030")
+LDServerConfigBuilder_ServiceEndpoints_RelayProxyBaseURL(builder, "https://your-relay-proxy.com:8030");
 
 LDServerConfig config;
 LDStatus status = LDServerConfigBuilder_Build(builder, &config);

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
@@ -1,0 +1,19 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```cpp
+auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
+config_builder.ServiceEndpoints()
+    .StreamingBaseUrl("https://stream.eu.launchdarkly.com")
+    .PollingBaseUrl("https://sdk.eu.launchdarkly.com")
+    .EventsBaseUrl("https://events.eu.launchdarkly.com")
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```cpp
@@ -11,7 +14,7 @@ auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
 config_builder.ServiceEndpoints()
     .StreamingBaseUrl("https://stream.eu.launchdarkly.com")
     .PollingBaseUrl("https://sdk.eu.launchdarkly.com")
-    .EventsBaseUrl("https://events.eu.launchdarkly.com")
+    .EventsBaseUrl("https://events.eu.launchdarkly.com");
 auto config = config_builder.Build();
 if (!config) {
     /* an error occurred, config is not valid */

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```cpp
@@ -11,7 +14,7 @@ auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
 config_builder.ServiceEndpoints()
     .StreamingBaseUrl("https://stream.launchdarkly.us")
     .PollingBaseUrl("https://sdk.launchdarkly.us")
-    .EventsBaseUrl("https://events.launchdarkly.us")
+    .EventsBaseUrl("https://events.launchdarkly.us");
 auto config = config_builder.Build();
 if (!config) {
     /* an error occurred, config is not valid */

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal.snippet.md
@@ -1,0 +1,19 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-federal
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```cpp
+auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
+config_builder.ServiceEndpoints()
+    .StreamingBaseUrl("https://stream.launchdarkly.us")
+    .PollingBaseUrl("https://sdk.launchdarkly.us")
+    .EventsBaseUrl("https://events.launchdarkly.us")
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: cpp-server-sdk/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Service endpoint configuration example for C++ (server-side).
+---
+
+```cpp
+auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
+config_builder.ServiceEndpoints()
+    .RelayProxyBaseUrl("https://your-relay-proxy.com:8030");
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-cpp-native-v3-0-relay.snippet.md
@@ -4,12 +4,15 @@ sdk: cpp-server-sdk
 kind: reference
 lang: cpp
 description: Service endpoint configuration example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
 ---
 
 ```cpp
 auto config_builder = server_side::ConfigBuilder("YOUR_SDK_KEY");
 config_builder.ServiceEndpoints()
-    .RelayProxyBaseUrl("https://your-relay-proxy.com:8030");
+    .RelayProxyBaseURL("https://your-relay-proxy.com:8030");
 auto config = config_builder.Build();
 if (!config) {
     /* an error occurred, config is not valid */

--- a/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only.snippet.md
@@ -38,6 +38,9 @@ namespace LaunchDarklySnippet
         // invoked at runtime — Main below short-circuits.
         #pragma warning disable CS8625, CS0414, CS0649
         private static dynamic client = null;
+        // Some config fragments reference a `context` binding (e.g.
+        // LdClient.Init(config, context)); provide it as a stub.
+        private static dynamic context = null;
         #pragma warning restore CS8625, CS0414, CS0649
 
         public static void Main(string[] args)

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: Application metadata configuration example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,19 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/config/app-config
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Application metadata configuration example for .NET (client-side).
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key", ConfigurationBuilder.AutoEnvAttributes.Enabled)
+    .ApplicationInfo(Components.ApplicationInfo()
+        .ApplicationId("authentication-service")
+        .ApplicationName("Authentication-Service")
+        .ApplicationVersion("1.0.0")
+        .ApplicationVersionName("v1")
+    )
+    .Build();
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v3-0.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v3-0.snippet.md
@@ -1,0 +1,15 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/config/index-v3-0
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: SDK configuration example for .NET (client-side).
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key")
+    .Events(Components.SendEvents().FlushInterval(TimeSpan.FromSeconds(2)))
+    .Build();
+LdClient client = LdClient.Init(config, context);
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v3-0.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v3-0.snippet.md
@@ -4,6 +4,7 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: SDK configuration example for .NET (client-side).
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v4-0.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v4-0.snippet.md
@@ -1,0 +1,15 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/config/index-v4-0
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: SDK configuration example for .NET (client-side).
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key", ConfigurationBuilder.AutoEnvAttributes.Enabled)
+    .Events(Components.SendEvents().FlushInterval(TimeSpan.FromSeconds(2)))
+    .Build();
+LdClient client = LdClient.Init(config, context);
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v4-0.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v4-0.snippet.md
@@ -4,6 +4,7 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: SDK configuration example for .NET (client-side).
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v4-0.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/index-v4-0.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: SDK configuration example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
 
 ---
 
@@ -12,5 +14,5 @@ var config = Configuration
     .Builder("example-mobile-key", ConfigurationBuilder.AutoEnvAttributes.Enabled)
     .Events(Components.SendEvents().FlushInterval(TimeSpan.FromSeconds(2)))
     .Build();
-LdClient client = LdClient.Init(config, context);
+LdClient client = LdClient.Init(config, context, TimeSpan.FromSeconds(10));
 ```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: Service endpoint configuration example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,17 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Service endpoint configuration example for .NET (client-side).
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key", ConfigurationBuilder.AutoEnvAttributes.Enabled)
+    .ServiceEndpoints(Components.ServiceEndpoints()
+      .Streaming("https://clientstream.eu.launchdarkly.com")
+      .Polling("https://clientsdk.eu.launchdarkly.com")
+      .Events("https://events.eu.launchdarkly.com"))
+    .Build();
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: Service endpoint configuration example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,17 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Service endpoint configuration example for .NET (client-side).
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key", ConfigurationBuilder.AutoEnvAttributes.Enabled)
+    .ServiceEndpoints(Components.ServiceEndpoints()
+      .Streaming("https://clientstream.launchdarkly.us")
+      .Polling("https://clientsdk.launchdarkly.us")
+      .Events("https://events.launchdarkly.us"))
+    .Build();
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-client-sdk
 kind: reference
 lang: csharp
 description: Service endpoint configuration example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Service endpoint configuration example for .NET (client-side).
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key", ConfigurationBuilder.AutoEnvAttributes.Enabled)
+    .ServiceEndpoints(Components.ServiceEndpoints()
+      .RelayProxy("https://your-relay-proxy.com:8030"))
+    .Build();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using LaunchDarkly.Sdk;
 using LaunchDarkly.Sdk.Server;
+using LaunchDarkly.Sdk.Server.Migrations;
 using LaunchDarkly.Sdk.Server.Ai;
 using LaunchDarkly.Sdk.Server.Ai.Adapters;
 using LaunchDarkly.Sdk.Server.Ai.Config;
@@ -51,6 +52,9 @@ namespace LaunchDarklySnippet
         // LdAiClient surface in the stub field type.
 #pragma warning disable CS0414, CS0649
         private static dynamic client = null;
+        // Docs use a `_client` field-naming convention in some fragments
+        // (e.g. migration config); provide it alongside `client`.
+        private static dynamic _client = null;
         private static dynamic aiClient = null;
         private static User user = null;
         private static Context context = default;

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: Application metadata configuration example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,22 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/config/app-config
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Application metadata configuration example for .NET (server-side).
+---
+
+```csharp
+
+var config = Configuration.Builder("YOUR_SDK_KEY")
+    .ApplicationInfo(Components.ApplicationInfo()
+        .ApplicationId("authentication-service")
+        .ApplicationName("Authentication-Service")
+        .ApplicationVersion("1.0.0")
+        .ApplicationVersionName("v1")
+    )
+    .Build();
+
+var client = new LdClient(config);
+
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,17 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/config/index
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: SDK configuration example for .NET (server-side).
+---
+
+```csharp
+var config = Configuration.Builder("YOUR_SDK_KEY")
+    .Events(
+        Components.SendEvents().FlushInterval(TimeSpan.FromSeconds(2))
+    )
+    .StartWaitTime(TimeSpan.FromSeconds(5))
+    .Build();
+var client = new LdClient(config);
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: SDK configuration example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,27 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/config/migration-config
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Migration configuration example for the .NET (server-side) SDK v8 — read/write methods, execution order, latency/error tracking.
+---
+
+```csharp
+
+// define how to compare the two read values
+bool Checker(string a, string b) => a.Equals(b);
+
+var migration = new MigrationBuilder<string, string, string, string>(_client)
+    .Read(
+        (payload) => MigrationMethod.Success("read old"),
+        (payload) => MigrationMethod.Success("read new"),
+        Checker)
+    .Write(
+        (payload) => MigrationMethod.Success("write old"),
+        (payload) => MigrationMethod.Success("write new"))
+    .ReadExecution(MigrationExecution.Parallel()) // or MigrationExecution.Serial(MigrationSerialOrder.Fixed)
+    .TrackErrors(true)    // true by default
+    .TrackLatency(true)   // true by default
+    .Build();
+
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,7 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: Migration configuration example for the .NET (server-side) SDK v8 — read/write methods, execution order, latency/error tracking.
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,8 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: Migration configuration example for the .NET (server-side) SDK v8 — read/write methods, execution order, latency/error tracking.
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
 
 ---
 

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,16 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Service endpoint configuration example for .NET (server-side).
+---
+
+```csharp
+var config = Configuration.Builder("YOUR_SDK_KEY")
+    .ServiceEndpoints(Components.ServiceEndpoints()
+      .Streaming("https://stream.eu.launchdarkly.com")
+      .Polling("https://sdk.eu.launchdarkly.com")
+      .Events("https://events.eu.launchdarkly.com"))
+    .Build();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: Service endpoint configuration example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: Service endpoint configuration example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,16 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Service endpoint configuration example for .NET (server-side).
+---
+
+```csharp
+var config = Configuration.Builder("YOUR_SDK_KEY")
+    .ServiceEndpoints(Components.ServiceEndpoints()
+      .Streaming("https://stream.launchdarkly.us")
+      .Polling("https://sdk.launchdarkly.us")
+      .Events("https://events.launchdarkly.us"))
+    .Build();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Service endpoint configuration example for .NET (server-side).
+---
+
+```csharp
+var config = Configuration.Builder("YOUR_SDK_KEY")
+    .ServiceEndpoints(Components.ServiceEndpoints()
+      .RelayProxy("https://your-relay-proxy.com:8030"))
+    .Build();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: dotnet-server-sdk
 kind: reference
 lang: csharp
 description: Service endpoint configuration example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
 ---
 
 ```csharp

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-js.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-js.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: SDK configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-js.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-js.snippet.md
@@ -1,0 +1,15 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/index-js
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: SDK configuration example for Electron.
+---
+
+```js
+const options = {
+  allAttributesPrivate: true
+};
+const client = LDElectron.initializeInMain('example-client-side-id', user, options);
+
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-ts.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-ts.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-ts.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/index-ts.snippet.md
@@ -1,0 +1,14 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/index-ts
+sdk: electron-client-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Electron.
+---
+
+```ts
+import * as LDElectron from 'launchdarkly-electron-client-sdk'
+
+const options: LDElectron.LDOptions = { allAttributesPrivate: true };
+const client = LDElectron.initializeInMain('example-client-side-id', user, options);
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
@@ -1,0 +1,15 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-eu
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for Electron.
+---
+
+```js
+const options = {
+  streamUrl: 'https://clientstream.eu.launchdarkly.com',
+  baseUrl: 'https://clientsdk.eu.launchdarkly.com',
+  eventsUrl: 'https://events.eu.launchdarkly.com'
+};
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
@@ -1,0 +1,15 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-federal
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for Electron.
+---
+
+```js
+const options = {
+  streamUrl: 'https://clientstream.launchdarkly.us',
+  baseUrl: 'https://clientsdk.launchdarkly.us',
+  eventsUrl: 'https://events.launchdarkly.us'
+};
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-relay
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for Electron.
+---
+
+```js
+const options = {
+  streamUrl: 'https://your-relay-proxy.com:8030',
+  baseUrl: 'https://your-relay-proxy.com:8030',
+  eventsUrl: 'https://your-relay-proxy.com:8030'
+};
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
@@ -1,0 +1,17 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-eu
+sdk: electron-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Electron.
+---
+
+```ts
+import * as LDElectron from 'launchdarkly-electron-client-sdk';
+
+const options: LDElectron.LDOptions = {
+  streamUrl: 'https://clientstream.eu.launchdarkly.com',
+  baseUrl: 'https://clientsdk.eu.launchdarkly.com',
+  eventsUrl: 'https://events.eu.launchdarkly.com'
+};
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
@@ -1,0 +1,17 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-federal
+sdk: electron-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Electron.
+---
+
+```ts
+import * as LDElectron from 'launchdarkly-electron-client-sdk';
+
+const options: LDElectron.LDOptions = {
+  streamUrl: 'https://clientstream.launchdarkly.us',
+  baseUrl: 'https://clientsdk.launchdarkly.us',
+  eventsUrl: 'https://events.launchdarkly.us'
+};
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: electron-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: electron-client-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-relay
+sdk: electron-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Electron.
+---
+
+```ts
+import * as LDElectron from 'launchdarkly-electron-client-sdk';
+
+const options: LDElectron.LDOptions = {
+  streamUrl: 'https://your-relay-proxy.com:8030',
+  baseUrl: 'https://your-relay-proxy.com:8030',
+  eventsUrl: 'https://your-relay-proxy.com:8030',
+};
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,18 @@
+---
+id: erlang-server-sdk/sdk-docs/features/config/app-config
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Application metadata configuration example for Erlang.
+---
+
+```erlang
+
+ldclient:start_instance("YOUR_SDK_KEY", #{
+  application => #{
+    id => <<"authentication-service">>,
+    version => <<"1.0.0">>
+  }
+})
+
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: Application metadata configuration example for Erlang.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,15 @@
+---
+id: erlang-server-sdk/sdk-docs/features/config/index
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: SDK configuration example for Erlang.
+---
+
+```erlang
+% Specify options
+ldclient:start_instance("YOUR_SDK_KEY", #{stream => false})
+
+% With a custom instance name
+ldclient:start_instance("YOUR_SDK_KEY", your_instance, #{stream => false})
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,7 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: SDK configuration example for Erlang.
+
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,15 @@
+---
+id: erlang-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Service endpoint configuration example for Erlang.
+---
+
+```erlang
+ldclient:start_instance("YOUR_SDK_KEY", #{
+  stream_uri => "https://stream.eu.launchdarkly.com",
+  base_uri => "https://sdk.eu.launchdarkly.com",
+  events_uri => "https://events.eu.launchdarkly.com"
+})
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: Service endpoint configuration example for Erlang.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: Service endpoint configuration example for Erlang.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,15 @@
+---
+id: erlang-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Service endpoint configuration example for Erlang.
+---
+
+```erlang
+ldclient:start_instance("YOUR_SDK_KEY", #{
+  stream_uri => "https://stream.launchdarkly.us",
+  base_uri => "https://sdk.launchdarkly.us",
+  events_uri => "https://events.launchdarkly.us"
+})
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: erlang-server-sdk
 kind: reference
 lang: erlang
 description: Service endpoint configuration example for Erlang.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
 ---
 
 ```erlang

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: erlang-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Service endpoint configuration example for Erlang.
+---
+
+```erlang
+ldclient:start_instance("YOUR_SDK_KEY", #{
+  stream_uri => "https://your-relay-proxy.com:8030",
+  base_uri => "https://your-relay-proxy.com:8030",
+  events_uri => "https://your-relay-proxy.com:8030"
+})
+```

--- a/snippets/sdks/fastly-server-sdk/sdk.yaml
+++ b/snippets/sdks/fastly-server-sdk/sdk.yaml
@@ -1,0 +1,4 @@
+# Identifier for this SDK. Matches the SDK's id in launchdarkly/sdk-meta's
+# API packages — the source of truth for everything else (display name,
+# language flavors, supported regions, hello-world repo, docs URL).
+id: fastly-server-sdk

--- a/snippets/sdks/fastly-server-sdk/snippets/scaffolds/fastly-syntax-only.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/scaffolds/fastly-syntax-only.snippet.md
@@ -1,0 +1,26 @@
+---
+id: fastly-server-sdk/scaffolds/fastly-syntax-only
+sdk: fastly-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Parse-only validator for Fastly edge SDK config doc fragments. Routes
+  through the `edge-ts` validator, which runs the TypeScript compiler's
+  transpileModule (syntax check + type-strip; no module resolution, no
+  type-checking). A clean parse means the fragment is syntactically
+  valid TypeScript -- edge-only package imports and ambient globals
+  (env, process) need not resolve. Doc fragments are whole TS modules,
+  so the scaffold emits the body verbatim.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, parsed as a TypeScript module.
+validation:
+  runtime: edge-ts
+  entrypoint: snippet.ts
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: fastly-server-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Fastly.
+validation:
+  scaffold: fastly-server-sdk/scaffolds/fastly-syntax-only
+
 ---
 
 ```ts
@@ -21,6 +24,6 @@ async function handleRequest(event: FetchEvent) {
 
   await ldClient.waitForInitialization();
 
-  ...
+  // ...
 }
 ```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,26 @@
+---
+id: fastly-server-sdk/sdk-docs/features/config/index
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Fastly.
+---
+
+```ts
+import { KVStore } from 'fastly:kv-store';
+import { init, LDOptions } from '@launchdarkly/fastly-server-sdk';
+
+const KV_STORE_NAME = 'launchdarkly';
+const EVENTS_BACKEND_NAME = 'launchdarkly';
+const store = new KVStore(KV_STORE_NAME);
+
+async function handleRequest(event: FetchEvent) {
+  const ldClient = init('example-client-side-id', store, {
+    eventsBackendName: EVENTS_BACKEND_NAME,
+  });
+
+  await ldClient.waitForInitialization();
+
+  ...
+}
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/app-config-v2
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Application metadata configuration example for Flutter.
+---
+
+```dart
+LDConfig config = LDConfigBuilder('example-mobile-key')
+  .applicationId('authentication-service')
+  .applicationVersion('1.0.0')
+  .build();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v2.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Application metadata configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v2
 
 ---
 

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v2.snippet.md
@@ -4,6 +4,7 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Application metadata configuration example for Flutter.
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
@@ -1,0 +1,16 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/app-config-v3
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Application metadata configuration example for Flutter.
+---
+
+```dart
+LDConfig config = LDConfigBuilder('example-mobile-key', AutoEnvAttributes.Enabled)
+  .applicationId('authentication-service')
+  .applicationName('Authentication-Service')
+  .applicationVersion('1.0.0')
+  .applicationVersionName('v1')
+  .build();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
@@ -4,6 +4,9 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Application metadata configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
@@ -1,0 +1,21 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/app-config-v4
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Application metadata configuration example for Flutter.
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  AutoEnvAttributes.enabled,
+  applicationInfo: ApplicationInfo(
+    applicationId: 'authentication-service',
+    applicationName: 'Authentication-Service',
+    applicationVersion: '1.0.0',
+    applicationVersionName: 'v1',
+  ),
+)
+
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
@@ -4,6 +4,7 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Application metadata configuration example for Flutter.
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Application metadata configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 
 ---
 
@@ -17,6 +19,6 @@ final config = LDConfig(
     applicationVersion: '1.0.0',
     applicationVersionName: 'v1',
   ),
-)
+);
 
 ```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
@@ -1,0 +1,13 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/index-v2
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: SDK configuration example for Flutter.
+---
+
+```dart
+LDConfig ldConfig = LDConfigBuilder('example-mobile-key')
+    .evaluationReasons(true)
+    .build();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: SDK configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v2
 
 ---
 

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
@@ -4,6 +4,7 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: SDK configuration example for Flutter.
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
@@ -1,0 +1,13 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/index-v3
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: SDK configuration example for Flutter.
+---
+
+```dart
+LDConfig ldConfig = LDConfigBuilder('example-mobile-key', AutoEnvAttributes.Enabled)
+    .evaluationReasons(true)
+    .build();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
@@ -4,6 +4,9 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: SDK configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: SDK configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 
 ---
 

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
@@ -1,0 +1,17 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/index-v4
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: SDK configuration example for Flutter.
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  AutoEnvAttributes.enabled,
+  dataSourceConfig: DataSourceConfig(
+    evaluationReasons: true
+  ),
+);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
@@ -4,6 +4,7 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: SDK configuration example for Flutter.
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
@@ -1,0 +1,15 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v3-eu
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Service endpoint configuration example for Flutter.
+---
+
+```dart
+LDConfig ldConfig = LDConfigBuilder('example-mobile-key', AutoEnvAttributes.Enabled)
+  .streamUri('https://clientstream.eu.launchdarkly.com')
+  .pollUri('https://clientsdk.eu.launchdarkly.com')
+  .eventsUri('https://events.eu.launchdarkly.com')
+  .build();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
@@ -1,0 +1,15 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v3-federal
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Service endpoint configuration example for Flutter.
+---
+
+```dart
+LDConfig ldConfig = LDConfigBuilder('example-mobile-key', AutoEnvAttributes.Enabled)
+  .streamUri('https://clientstream.launchdarkly.us')
+  .pollUri('https://clientsdk.launchdarkly.us')
+  .eventsUri('https://events.launchdarkly.us')
+  .build();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v3-relay
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Service endpoint configuration example for Flutter.
+---
+
+```dart
+LDConfig ldConfig = LDConfigBuilder('example-mobile-key', AutoEnvAttributes.Enabled)
+  .streamUri('https://your-relay-proxy.com:8030')
+  .pollUri('https://your-relay-proxy.com:8030')
+  .eventsUri('https://your-relay-proxy.com:8030')
+  .build();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
@@ -9,7 +9,7 @@ description: Service endpoint configuration example for Flutter.
 ```dart
 final config = LDConfig(
   CredentialSource.fromEnvironment(),
-  autoEnvAttributes.enabled,
+  AutoEnvAttributes.enabled,
   serviceEndpoints: ServiceEndpoints.custom(
     streaming: 'https://clientstream.eu.launchdarkly.com',
     polling: 'https://clientsdk.eu.launchdarkly.com',

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 
 ---
 

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
@@ -1,0 +1,19 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v4-eu
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Service endpoint configuration example for Flutter.
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  autoEnvAttributes.enabled,
+  serviceEndpoints: ServiceEndpoints.custom(
+    streaming: 'https://clientstream.eu.launchdarkly.com',
+    polling: 'https://clientsdk.eu.launchdarkly.com',
+    events: 'https://events.eu.launchdarkly.com',
+  )
+);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
@@ -4,6 +4,7 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
@@ -9,7 +9,7 @@ description: Service endpoint configuration example for Flutter.
 ```dart
 final config = LDConfig(
   CredentialSource.fromEnvironment(),
-  autoEnvAttributes.enabled,
+  AutoEnvAttributes.enabled,
   serviceEndpoints: ServiceEndpoints.custom(
     streaming: 'https://clientstream.launchdarkly.us',
     polling: 'https://clientsdk.launchdarkly.us',

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 
 ---
 

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
@@ -1,0 +1,19 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v4-federal
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Service endpoint configuration example for Flutter.
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  autoEnvAttributes.enabled,
+  serviceEndpoints: ServiceEndpoints.custom(
+    streaming: 'https://clientstream.launchdarkly.us',
+    polling: 'https://clientsdk.launchdarkly.us',
+    events: 'https://events.launchdarkly.us',
+  )
+);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
@@ -4,6 +4,7 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+
 ---
 
 ```dart

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
@@ -9,7 +9,7 @@ description: Service endpoint configuration example for Flutter.
 ```dart
 final config = LDConfig(
   CredentialSource.fromEnvironment(),
-  autoEnvAttributes.enabled,
+  AutoEnvAttributes.enabled,
   serviceEndpoints: ServiceEndpoints.relayProxy('https://your-relay-proxy.com:8030')
 );
 ```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
@@ -4,6 +4,8 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
 
 ---
 

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: flutter-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v4-relay
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Service endpoint configuration example for Flutter.
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  autoEnvAttributes.enabled,
+  serviceEndpoints: ServiceEndpoints.relayProxy('https://your-relay-proxy.com:8030')
+);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
@@ -4,6 +4,7 @@ sdk: flutter-client-sdk
 kind: reference
 lang: dart
 description: Service endpoint configuration example for Flutter.
+
 ---
 
 ```dart

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,13 @@
+---
+id: go-server-sdk/sdk-docs/features/config/app-config
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Application metadata configuration example for Go.
+---
+
+```go
+var config ld.Config
+config.ApplicationInfo.ApplicationID = "authentication-service"
+config.ApplicationInfo.ApplicationVersion = "1.0.0"
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: Application metadata configuration example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: SDK configuration example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,22 @@
+---
+id: go-server-sdk/sdk-docs/features/config/index
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: SDK configuration example for Go.
+---
+
+```go
+import (
+    "time"
+
+    ld "github.com/launchdarkly/go-server-sdk/v6"
+    "github.com/launchdarkly/go-server-sdk/v6/ldcomponents"
+)
+
+var config ld.Config
+
+config.Events = ldcomponents.SendEvents().FlushInterval(10*time.Second)
+
+client, _ := ld.MakeCustomClient("YOUR_SDK_KEY", config, 5*time.Second)
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,41 @@
+---
+id: go-server-sdk/sdk-docs/features/config/migration-config
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Migration configuration example for the Go SDK v7 — read/write methods, execution order, latency/error tracking.
+---
+
+```go
+
+client, _ := ld.MakeClient("YOUR_SDK_KEY", 5*time.Second)
+
+var comparison ld.MigrationComparisonFn
+comparison = func(interface{}, interface{}) bool {
+	// compare the two read values
+	return true
+}
+
+migrator, _ := ld.Migration(client).
+	Read(
+		func(interface{}) (interface{}, error) {
+			return "old read", nil
+		},
+		func(interface{}) (interface{}, error) {
+			return "new read", nil
+		},
+		&comparison,
+	).
+	ReadExecutionOrder(ldmigration.Random).
+	Write(
+		func(interface{}) (interface{}, error) {
+			return "old write result", nil
+		},
+		func(interface{}) (interface{}, error) {
+			return "new write result", nil
+		},
+	).
+	TrackLatency(true).
+	TrackErrors(true).
+	Build()
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,9 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: Migration configuration example for the Go SDK v7 — read/write methods, execution order, latency/error tracking.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,18 @@
+---
+id: go-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Service endpoint configuration example for Go.
+---
+
+```go
+
+config := ld.Config{
+    ServiceEndpoints: interfaces.ServiceEndpoints{
+      Streaming: "https://stream.eu.launchdarkly.com",
+      Polling: "https://sdk.eu.launchdarkly.com",
+      Events: "https://events.eu.launchdarkly.com",
+    },
+}
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: Service endpoint configuration example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: Service endpoint configuration example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
 ---
 
 ```go

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,18 @@
+---
+id: go-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Service endpoint configuration example for Go.
+---
+
+```go
+
+config := ld.Config{
+    ServiceEndpoints: interfaces.ServiceEndpoints{
+      Streaming: "https://stream.launchdarkly.us",
+      Polling: "https://sdk.launchdarkly.us",
+      Events: "https://events.launchdarkly.us",
+    },
+}
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,23 @@
+---
+id: go-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Service endpoint configuration example for Go.
+---
+
+```go
+// To use the Replay Proxy in proxy mode for both streaming and events:
+
+config := ld.Config{
+    ServiceEndpoints: ldcomponents.RelayProxyEndpoints(
+      "https://your-relay-proxy.com:8030"),
+}
+
+// Alternatively, to use the Relay Proxy in proxy mode for streaming,
+// but send events directly to LaunchDarkly, use:
+config := ld.Config{
+    ServiceEndpoints: ldcomponents.RelayProxyEndpointsWithoutEvents(
+        "https://your-relay-proxy.com:8030"),
+}
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: go-server-sdk
 kind: reference
 lang: go
 description: Service endpoint configuration example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
 ---
 
 ```go

--- a/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-config-syntax-only.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-config-syntax-only.snippet.md
@@ -1,0 +1,32 @@
+---
+id: haskell-server-sdk/scaffolds/haskell-config-syntax-only
+sdk: haskell-server-sdk
+kind: scaffold
+lang: haskell
+file: app/Main.hs
+description: |
+  Parse-and-compile validator for Haskell config doc fragments that are
+  already complete module-level Haskell — a leading `{-# LANGUAGE … #-}`
+  pragma, `import` lines, and top-level bindings. Unlike haskell-syntax-only
+  (which wraps an expression body in a `do` block and lifts top-level
+  decls out via TOP_LIFT), these fragments ARE the module, so the scaffold
+  just appends a `main` that prints the EXAM-HELLO line. The body's own
+  pragma stays at file line 1 (Haskell requires LANGUAGE pragmas before any
+  module/decl), its imports precede the appended main, and an implicit
+  `Main` module is fine for a cabal executable. No TOP_LIFT marker, so the
+  harness stages the body verbatim.
+inputs:
+  body:
+    type: string
+    description: A complete module-level Haskell fragment (pragma + imports + bindings).
+validation:
+  runtime: haskell-server
+  entrypoint: app/Main.hs
+---
+
+```haskell
+{{ body }}
+
+main :: IO ()
+main = putStrLn "feature flag evaluates to true"
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,21 @@
+---
+id: haskell-server-sdk/sdk-docs/features/config/app-config
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Application metadata configuration example for Haskell.
+---
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import LaunchDarkly.Server.Config
+
+import Data.Function ((&))
+
+config :: Config
+config = makeConfig "YOUR_SDK_KEY" & configSetApplicationInfo appInfo
+    where appInfo = makeApplicationInfo
+            & withApplicationValue "id" "authentication-service"
+            & withApplicationValue "version" "1.0.0"
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: Application metadata configuration example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-config-syntax-only
+
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: SDK configuration example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-config-syntax-only
+
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,20 @@
+---
+id: haskell-server-sdk/sdk-docs/features/config/index
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: SDK configuration example for Haskell.
+---
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import LaunchDarkly.Server.Config
+
+import Data.Function ((&))
+
+config :: Config
+config = (makeConfig "YOUR_SDK_KEY")
+    & configSetEventsCapacity 1000
+    & configSetFlushIntervalSeconds 30
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: Service endpoint configuration example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-config-syntax-only
+
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,21 @@
+---
+id: haskell-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Service endpoint configuration example for Haskell.
+---
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import LaunchDarkly.Server.Config
+
+import Data.Function ((&))
+
+config :: Config
+config = (makeConfig "YOUR_SDK_KEY")
+    & configSetStreamURI "https://stream.eu.launchdarkly.com"
+    & configSetBaseURI "https://sdk.eu.launchdarkly.com"
+    & configSetEventsURI "https://events.eu.launchdarkly.com"
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,21 @@
+---
+id: haskell-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Service endpoint configuration example for Haskell.
+---
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import LaunchDarkly.Server.Config
+
+import Data.Function ((&))
+
+config :: Config
+config = (makeConfig "YOUR_SDK_KEY")
+    & configSetStreamURI "https://stream.launchdarkly.us"
+    & configSetBaseURI "https://sdk.launchdarkly.us"
+    & configSetEventsURI "https://events.launchdarkly.us"
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: Service endpoint configuration example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-config-syntax-only
+
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: haskell-server-sdk
 kind: reference
 lang: haskell
 description: Service endpoint configuration example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-config-syntax-only
+
 ---
 
 ```haskell

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,21 @@
+---
+id: haskell-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Service endpoint configuration example for Haskell.
+---
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import LaunchDarkly.Server.Config
+
+import Data.Function ((&))
+
+config :: Config
+config = (makeConfig "YOUR_SDK_KEY")
+    & configSetStreamURI "https://your-relay-proxy.com:8030"
+    & configSetBaseURI "https://your-relay-proxy.com:8030"
+    & configSetEventsURI "https://your-relay-proxy.com:8030"
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-objc.snippet.md
@@ -1,0 +1,18 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/app-config-objc
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: Application metadata configuration example for iOS.
+---
+
+```objc
+LDApplicationInfo *applicationInfo = [[LDApplicationInfo alloc] init];
+[applicationInfo applicationIdentifier:@"authentication-service"];
+[applicationInfo applicationName:@"Authentication-Service"];
+[applicationInfo applicationVersion:@"1.0.0"];
+[applicationInfo applicationVersionName:@"v1"];
+
+LDConfig *config = [[LDConfig alloc] initWithMobileKey:mobileKey autoEnvAttributes:true];
+config.applicationInfo = applicationInfo;
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-objc.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objectivec
 description: Application metadata configuration example for iOS.
+
 ---
 
 ```objc

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-swift.snippet.md
@@ -1,0 +1,18 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/app-config-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Application metadata configuration example for iOS.
+---
+
+```swift
+var applicationInfo = ApplicationInfo()
+applicationInfo.applicationIdentifier("authentication-service")
+applicationInfo.applicationName("Authentication-Service")
+applicationInfo.applicationVersion("1.0.0")
+applicationInfo.applicationVersionName("v1")
+
+var config = LDConfig(mobileKey: mobileKey, autoEnvAttributes: .enabled)
+config.applicationInfo = applicationInfo
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-swift.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Application metadata configuration example for iOS.
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 
 ---
 

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/app-config-swift.snippet.md
@@ -4,6 +4,9 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Application metadata configuration example for iOS.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-objc.snippet.md
@@ -1,0 +1,13 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/index-objc
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: SDK configuration example for iOS.
+---
+
+```objectivec
+LDConfig *ldConfig = [[LDConfig alloc] initWithMobileKey:@"example-mobile-key" autoEnvAttributes:AutoEnvAttributesEnabled];
+ldConfig.connectionTimeout = 10.0;
+ldConfig.eventFlushInterval = 30.0;
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-objc.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objectivec
 description: SDK configuration example for iOS.
+
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-swift.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: SDK configuration example for iOS.
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 
 ---
 

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-swift.snippet.md
@@ -1,0 +1,13 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/index-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: SDK configuration example for iOS.
+---
+
+```swift
+var ldConfig = LDConfig(mobileKey: "example-mobile-key", autoEnvAttributes: .enabled)
+ldConfig.connectionTimeout = 10.0
+ldConfig.eventFlushInterval = 30.0
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/index-swift.snippet.md
@@ -4,6 +4,9 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: SDK configuration example for iOS.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-eu.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-eu.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objectivec
 description: Service endpoint configuration example for iOS.
+
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-eu.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-eu.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/service-endpoint-configuration-objc-eu
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: Service endpoint configuration example for iOS.
+---
+
+```objectivec
+LDConfig *ldConfig = [[LDConfig alloc] initWithMobileKey:@"example-mobile-key" autoEnvAttributes:AutoEnvAttributesEnabled];
+ldConfig.streamUrl = [NSURL URLWithString:@"https://clientstream.eu.launchdarkly.com"];
+ldConfig.baseUrl = [NSURL URLWithString:@"https://clientsdk.eu.launchdarkly.com"];
+ldConfig.eventsUrl = [NSURL URLWithString:@"https://events.eu.launchdarkly.com"];
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-federal.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-federal.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/service-endpoint-configuration-objc-federal
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: Service endpoint configuration example for iOS.
+---
+
+```objectivec
+LDConfig *ldConfig = [[LDConfig alloc] initWithMobileKey:@"example-mobile-key" autoEnvAttributes:AutoEnvAttributesEnabled];
+ldConfig.streamUrl = [NSURL URLWithString:@"https://clientstream.launchdarkly.us"];
+ldConfig.baseUrl = [NSURL URLWithString:@"https://clientsdk.launchdarkly.us"];
+ldConfig.eventsUrl = [NSURL URLWithString:@"https://events.launchdarkly.us"];
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-federal.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-federal.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objectivec
 description: Service endpoint configuration example for iOS.
+
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-relay.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-relay.snippet.md
@@ -4,6 +4,7 @@ sdk: ios-client-sdk
 kind: reference
 lang: objectivec
 description: Service endpoint configuration example for iOS.
+
 ---
 
 ```objectivec

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-relay.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-objc-relay.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/service-endpoint-configuration-objc-relay
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: Service endpoint configuration example for iOS.
+---
+
+```objectivec
+LDConfig *ldConfig = [[LDConfig alloc] initWithMobileKey:@"example-mobile-key" autoEnvAttributes:AutoEnvAttributesEnabled];
+ldConfig.streamUrl = [NSURL URLWithString:@"https://your-relay-proxy.com:8030"];
+ldConfig.baseUrl = [NSURL URLWithString:@"https://your-relay-proxy.com:8030"];
+ldConfig.eventsUrl = [NSURL URLWithString:@"https://your-relay-proxy.com:8030"];
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-eu.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-eu.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Service endpoint configuration example for iOS.
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 
 ---
 

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-eu.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Service endpoint configuration example for iOS.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-eu.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-eu.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/service-endpoint-configuration-swift-eu
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Service endpoint configuration example for iOS.
+---
+
+```swift
+var ldConfig = LDConfig(mobileKey: "example-mobile-key", autoEnvAttributes: .enabled)
+ldConfig.streamUrl = URL(string: "https://clientstream.eu.launchdarkly.com")
+ldConfig.baseUrl = URL(string: "https://clientsdk.eu.launchdarkly.com")
+ldConfig.eventsUrl = URL(string: "https://events.eu.launchdarkly.com")
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-federal.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-federal.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Service endpoint configuration example for iOS.
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 
 ---
 

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-federal.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-federal.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/service-endpoint-configuration-swift-federal
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Service endpoint configuration example for iOS.
+---
+
+```swift
+var ldConfig = LDConfig(mobileKey: "example-mobile-key", autoEnvAttributes: .enabled)
+ldConfig.streamUrl = URL(string: "https://clientstream.launchdarkly.us")
+ldConfig.baseUrl = URL(string: "https://clientsdk.launchdarkly.us")
+ldConfig.eventsUrl = URL(string: "https://events.launchdarkly.us")
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-federal.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Service endpoint configuration example for iOS.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-relay.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-relay.snippet.md
@@ -4,8 +4,6 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Service endpoint configuration example for iOS.
-validation:
-  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
 
 ---
 

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-relay.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: ios-client-sdk
 kind: reference
 lang: swift
 description: Service endpoint configuration example for iOS.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
 ---
 
 ```swift

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-relay.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-swift-relay.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/config/service-endpoint-configuration-swift-relay
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Service endpoint configuration example for iOS.
+---
+
+```swift
+var ldConfig = LDConfig(mobileKey: "example-mobile-key", autoEnvAttributes: .enabled)
+ldConfig.streamUrl = URL(string: "https://your-relay-proxy.com:8030")
+ldConfig.baseUrl = URL(string: "https://your-relay-proxy.com:8030")
+ldConfig.eventsUrl = URL(string: "https://your-relay-proxy.com:8030")
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -30,7 +30,7 @@ package com.launchdarkly;
 
 import com.launchdarkly.sdk.*;
 import com.launchdarkly.sdk.server.*;
-import com.launchdarkly.sdk.server.integrations.*;
+import com.launchdarkly.sdk.server.migrations.*;
 // Common JDK types config/timeout fragments reference without their own
 // import line (the docs assume it); provide it so they resolve.
 import java.time.Duration;

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -30,6 +30,9 @@ package com.launchdarkly;
 
 import com.launchdarkly.sdk.*;
 import com.launchdarkly.sdk.server.*;
+// Common JDK types config/timeout fragments reference without their own
+// import line (the docs assume it); provide it so they resolve.
+import java.time.Duration;
 // IMPORT_LIFT_MARKER
 
 public class Snippet {

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -30,6 +30,7 @@ package com.launchdarkly;
 
 import com.launchdarkly.sdk.*;
 import com.launchdarkly.sdk.server.*;
+import com.launchdarkly.sdk.server.integrations.*;
 // Common JDK types config/timeout fragments reference without their own
 // import line (the docs assume it); provide it so they resolve.
 import java.time.Duration;

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,16 @@
+---
+id: java-server-sdk/sdk-docs/features/config/app-config
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Application metadata configuration example for Java.
+---
+
+```java
+LDConfig config = new LDConfig.Builder()
+  .applicationInfo(
+    Components.applicationInfo()
+      .applicationId("authentication-service")
+      .applicationVersion("1.0.0")
+  ).build();
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: Application metadata configuration example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,22 @@
+---
+id: java-server-sdk/sdk-docs/features/config/index
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: SDK configuration example for Java.
+---
+
+```java
+LDConfig config = new LDConfig.Builder()
+  .http(
+    Components.httpConfiguration()
+      .connectTimeout(Duration.ofSeconds(3))
+      .socketTimeout(Duration.ofSeconds(3))
+  )
+  .events(
+    Components.sendEvents()
+      .flushInterval(Duration.ofSeconds(10))
+  )
+  .build();
+LDClient client = new LDClient("YOUR_SDK_KEY", config);
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,8 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: SDK configuration example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
 
 ---
 

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,7 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: SDK configuration example for Java.
+
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,8 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: Migration configuration example for the Java SDK v7 — read/write methods, execution order, latency/error tracking.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
 
 ---
 
@@ -11,7 +13,7 @@ description: Migration configuration example for the Java SDK v7 — read/write 
 
 LDClient client = new LDClient("YOUR_SDK_KEY");
 
-MigrationBuilder<String, String, String, String> migrationBuilder = new MigrationBuilder<>(client)
+MigrationBuilder<String, String, String, String> migrationBuilder = new MigrationBuilder<String, String, String, String>(client)
   .read(
     (payload) -> MigrationMethodResult.Success("read old"),
     (payload) -> MigrationMethodResult.Success("read new"),
@@ -25,6 +27,6 @@ MigrationBuilder<String, String, String, String> migrationBuilder = new Migratio
   .trackLatency(true)
   .trackErrors(true);
 
-Migration<String, String, String, String> migration = migrationBuilder.build();
+Migration<String, String, String, String> migration = migrationBuilder.build().orElseThrow();
 
 ```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,29 @@
+---
+id: java-server-sdk/sdk-docs/features/config/migration-config
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Migration configuration example for the Java SDK v7 — read/write methods, execution order, latency/error tracking.
+---
+
+```java
+
+LDClient client = new LDClient("YOUR_SDK_KEY");
+
+MigrationBuilder<String, String, String, String> migrationBuilder = new MigrationBuilder<>(client)
+  .read(
+    (payload) -> MigrationMethodResult.Success("read old"),
+    (payload) -> MigrationMethodResult.Success("read new"),
+    (a, b) -> a.equals(b)
+  )
+  .readExecution(MigrationExecution.Serial(MigrationSerialOrder.RANDOM)) // default is .Parallel
+  .write(
+    (payload) -> MigrationMethodResult.Success("write old"),
+    (payload) -> MigrationMethodResult.Success("write new")
+  )
+  .trackLatency(true)
+  .trackErrors(true);
+
+Migration<String, String, String, String> migration = migrationBuilder.build();
+
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,7 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: Migration configuration example for the Java SDK v7 — read/write methods, execution order, latency/error tracking.
+
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
@@ -1,0 +1,16 @@
+---
+id: java-server-sdk/sdk-docs/features/config/service-endpoint-configuration-java-eu
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Service endpoint configuration example for Java.
+---
+
+```java
+LDConfig config = new LDConfig.Builder()
+  .serviceEndpoints(Components.serviceEndpoints()
+    .streaming("https://stream.eu.launchdarkly.com")
+    .polling("https://sdk.eu.launchdarkly.com")
+    .events("https://events.eu.launchdarkly.com"))
+  .build();
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
@@ -1,0 +1,16 @@
+---
+id: java-server-sdk/sdk-docs/features/config/service-endpoint-configuration-java-federal
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Service endpoint configuration example for Java.
+---
+
+```java
+LDConfig config = new LDConfig.Builder()
+  .serviceEndpoints(Components.serviceEndpoints()
+    .streaming("https://stream.launchdarkly.us")
+    .polling("https://sdk.launchdarkly.us")
+    .events("https://events.launchdarkly.us"))
+  .build();
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
 ---
 
 ```java

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/features/config/service-endpoint-configuration-java-relay
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Service endpoint configuration example for Java.
+---
+
+```java
+LDConfig config = new LDConfig.Builder()
+  .serviceEndpoints(Components.serviceEndpoints()
+    .relayProxy("https://your-relay-proxy.com:8030"))
+  .build();
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-java-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: java-server-sdk
 kind: reference
 lang: java
 description: Service endpoint configuration example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
 ---
 
 ```java

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-ts-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-ts-v3.snippet.md
@@ -1,0 +1,19 @@
+---
+id: js-client-sdk/sdk-docs/features/config/app-config-ts-v3
+sdk: js-client-sdk
+kind: reference
+lang: typescript
+description: Application metadata configuration example for JavaScript.
+---
+
+```ts
+import * as LDClient from 'launchdarkly-js-client-sdk';
+
+const options: LDClient.LDOptions = {
+    application: {
+	    id: 'authentication-service',
+	    version: '1.0.0',
+    },
+};
+const client = LDClient.initialize('example-client-side-id', context, options);
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-ts-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-ts-v3.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: typescript
 description: Application metadata configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
@@ -1,0 +1,17 @@
+---
+id: js-client-sdk/sdk-docs/features/config/app-config-v3
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Application metadata configuration example for JavaScript.
+---
+
+```js
+const options = {
+    application: {
+	    id: 'authentication-service',
+	    version: '1.0.0',
+    },
+};
+const client = LDClient.initialize('example-client-side-id', context, options);
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v3.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Application metadata configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
@@ -1,0 +1,21 @@
+---
+id: js-client-sdk/sdk-docs/features/config/app-config-v4
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Application metadata configuration example for JavaScript.
+---
+
+```js
+const options = {
+    applicationInfo: {
+	    id: 'authentication-service',
+	    version: '1.0.0',
+    },
+};
+// Create client
+const client = createClient('example-client-side-id', context, options);
+
+// Then start the client
+client.start();
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/app-config-v4.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Application metadata configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-ts-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-ts-v3.snippet.md
@@ -1,0 +1,14 @@
+---
+id: js-client-sdk/sdk-docs/features/config/index-ts-v3
+sdk: js-client-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for JavaScript.
+---
+
+```ts
+import * as LDClient from 'launchdarkly-js-client-sdk';
+
+const options: LDClient.LDOptions = { allAttributesPrivate: true };
+const client = LDClient.initialize('example-client-side-id', context, options);
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-ts-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-ts-v3.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
@@ -1,0 +1,20 @@
+---
+id: js-client-sdk/sdk-docs/features/config/index-v3
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: SDK configuration example for JavaScript.
+---
+
+```js
+const options = { allAttributesPrivate: true };
+const client = LDClient.initialize('example-client-side-id', context, options);
+
+try {
+  await client.waitForInitialization(5);
+  proceedWithSuccessfullyInitializedClient();
+} catch(err) {
+  // Client failed to initialize or timed out
+  // variation() calls return fallback values until initialization completes
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v3.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: SDK configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
@@ -1,0 +1,24 @@
+---
+id: js-client-sdk/sdk-docs/features/config/index-v4
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: SDK configuration example for JavaScript.
+---
+
+```js
+const options = { allAttributesPrivate: true };
+const client = createClient('example-client-side-id', context, options);
+client.start();
+
+const result = await client.waitForInitialization({ timeout: 5 });
+if (result.status === 'complete') {
+  // Client initialized successfully
+} else if (result.status === 'failed') {
+  // Client failed to initialize
+  console.error('Initialization failed:', result.error);
+} else if (result.status === 'timeout') {
+  // Initialization timed out
+  console.error('Initialization timed out');
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/index-v4.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: SDK configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
@@ -1,0 +1,15 @@
+---
+id: js-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v3-eu
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for JavaScript.
+---
+
+```js
+const options = {
+  streamUrl: 'https://clientstream.eu.launchdarkly.com',
+  baseUrl: 'https://clientsdk.eu.launchdarkly.com',
+  eventsUrl: 'https://events.eu.launchdarkly.com'
+};
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
@@ -1,0 +1,15 @@
+---
+id: js-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v3-federal
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for JavaScript.
+---
+
+```js
+const options = {
+  streamUrl: 'https://clientstream.launchdarkly.us',
+  baseUrl: 'https://clientsdk.launchdarkly.us',
+  eventsUrl: 'https://events.launchdarkly.us'
+};
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: js-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v3-relay
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for JavaScript.
+---
+
+```js
+const options = {
+  streamUrl: 'https://your-relay-proxy.com:8030',
+  baseUrl: 'https://your-relay-proxy.com:8030',
+  eventsUrl: 'https://your-relay-proxy.com:8030'
+};
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v3-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
@@ -1,0 +1,15 @@
+---
+id: js-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v4-eu
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for JavaScript.
+---
+
+```js
+const options = {
+  streamUri: 'https://clientstream.eu.launchdarkly.com',
+  baseUri: 'https://clientsdk.eu.launchdarkly.com',
+  eventsUri: 'https://events.eu.launchdarkly.com'
+};
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
@@ -1,0 +1,15 @@
+---
+id: js-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v4-federal
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for JavaScript.
+---
+
+```js
+const options = {
+  streamUri: 'https://clientstream.launchdarkly.us',
+  baseUri: 'https://clientsdk.launchdarkly.us',
+  eventsUri: 'https://events.launchdarkly.us'
+};
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: js-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v4-relay
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for JavaScript.
+---
+
+```js
+const options = {
+  streamUri: 'https://your-relay-proxy.com:8030',
+  baseUri: 'https://your-relay-proxy.com:8030',
+  eventsUri: 'https://your-relay-proxy.com:8030'
+};
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v4-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: js-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: Application metadata configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,16 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/app-config
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Application metadata configuration example for Lua.
+---
+
+```lua
+local config = {
+    appInfo = {
+      identifier = "authentication-server",
+      version = "1.0.0"
+    }
+}
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v1.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v1.snippet.md
@@ -1,0 +1,17 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/index-v1
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: SDK configuration example for Lua.
+---
+
+```lua
+local config = {
+    key                 = "YOUR_SDK_KEY",
+    eventsCapacity      = 1000,
+    eventsFlushInterval = 30000
+}
+
+local client = ld.clientInit(config, 1000)
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v1.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v1.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: SDK configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
@@ -1,0 +1,19 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/index-v2
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: SDK configuration example for Lua.
+---
+
+```lua
+local config = {
+    events = {
+        capacity = 1000,
+        flushIntervalMilliseconds  = 30000
+    }
+}
+
+-- This blocks for 1 second to initialize
+local client = ld.clientInit("YOUR_SDK_KEY", 1000, config)
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/index-v2.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: SDK configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-eu.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: Service endpoint configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-eu.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-eu.snippet.md
@@ -1,0 +1,16 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/service-endpoint-configuration-v1-eu
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Service endpoint configuration example for Lua.
+---
+
+```lua
+local config = {
+    key = "YOUR_SDK_KEY",
+    streamURI = "https://stream.eu.launchdarkly.com",
+    baseURI = "https://sdk.eu.launchdarkly.com",
+    eventsURI = "https://events.eu.launchdarkly.com",
+}
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-federal.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: Service endpoint configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-federal.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-federal.snippet.md
@@ -1,0 +1,16 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/service-endpoint-configuration-v1-federal
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Service endpoint configuration example for Lua.
+---
+
+```lua
+local config = {
+    key = "YOUR_SDK_KEY",
+    streamURI = "https://stream.launchdarkly.us",
+    baseURI = "https://sdk.launchdarkly.us",
+    eventsURI = "https://events.launchdarkly.us",
+}
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-relay.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: Service endpoint configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-relay.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v1-relay.snippet.md
@@ -1,0 +1,16 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/service-endpoint-configuration-v1-relay
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Service endpoint configuration example for Lua.
+---
+
+```lua
+local config = {
+    key = "YOUR_SDK_KEY",
+    streamURI = "https://your-relay-proxy.com:8030",
+    baseURI = "https://your-relay-proxy.com:8030",
+    eventsURI = "https://your-relay-proxy.com:8030",
+}
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-eu.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: Service endpoint configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-eu.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-eu.snippet.md
@@ -1,0 +1,17 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/service-endpoint-configuration-v2-eu
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Service endpoint configuration example for Lua.
+---
+
+```lua
+local config = {
+    serviceEndpoints = {
+      streamingBaseURL = "https://stream.eu.launchdarkly.com",
+      pollingBaseURL = "https://sdk.eu.launchdarkly.com",
+      eventsBaseURL = "https://events.eu.launchdarkly.com"
+    }
+}
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-federal.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: Service endpoint configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-federal.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-federal.snippet.md
@@ -1,0 +1,17 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/service-endpoint-configuration-v2-federal
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Service endpoint configuration example for Lua.
+---
+
+```lua
+local config = {
+    serviceEndpoints = {
+      streamingBaseURL = "https://stream.launchdarkly.us",
+      pollingBaseURL = "https://sdk.launchdarkly.us",
+      eventsBaseURL = "https://events.launchdarkly.us"
+    }
+}
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-relay.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: lua-server-sdk
 kind: reference
 lang: lua
 description: Service endpoint configuration example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
 ---
 
 ```lua

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-relay.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v2-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: lua-server-sdk/sdk-docs/features/config/service-endpoint-configuration-v2-relay
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Service endpoint configuration example for Lua.
+---
+
+```lua
+local config = {
+    serviceEndpoints = {
+      streamingBaseURL = "https://your-relay-proxy.com:8030",
+      pollingBaseURL = "https://your-relay-proxy.com:8030",
+      eventsBaseURL = "https://your-relay-proxy.com:8030"
+    }
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-js.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-js.snippet.md
@@ -1,0 +1,18 @@
+---
+id: node-client-sdk/sdk-docs/features/config/app-config-js
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: Application metadata configuration example for Node.js (client-side).
+---
+
+```js
+const options = {
+  application: {
+    id: "authentication-service",
+    version: "1.0.0"
+  }
+};
+
+const client = LDClient.initialize('example-client-side-id', context, options);
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-js.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-js.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: Application metadata configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-ts.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-ts.snippet.md
@@ -1,0 +1,19 @@
+---
+id: node-client-sdk/sdk-docs/features/config/app-config-ts
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: Application metadata configuration example for Node.js (client-side).
+---
+
+```ts
+import * as LDClient from 'launchdarkly-node-client-sdk';
+
+const options: LDClient.LDOptions = {
+  application: {
+    id: "authentication-service",
+    version: "1.0.0"
+  }
+};
+const client = LDClient.initialize('example-client-side-id', context, options);
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-ts.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/app-config-ts.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: Application metadata configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-js-v3-0.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-js-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: SDK configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-js-v3-0.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-js-v3-0.snippet.md
@@ -1,0 +1,22 @@
+---
+id: node-client-sdk/sdk-docs/features/config/index-js-v3-0
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: SDK configuration example for Node.js (client-side).
+---
+
+```js
+const options = {
+  flushInterval: 10000, // milliseconds
+  allAttributesPrivate: true
+};
+
+const client = LDClient.initialize('example-client-side-id', context, options);
+try {
+  await client.waitForInitialization(5);
+  // initialization succeeded, flag values are now available
+} catch (err) {
+  // initialization failed or did not complete before timeout
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-ts-v3-0.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-ts-v3-0.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-ts-v3-0.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/index-ts-v3-0.snippet.md
@@ -1,0 +1,23 @@
+---
+id: node-client-sdk/sdk-docs/features/config/index-ts-v3-0
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Node.js (client-side).
+---
+
+```ts
+import * as LDClient from 'launchdarkly-node-client-sdk';
+
+const options: LDClient.LDOptions = {
+  flushInterval: 10000, // milliseconds
+  allAttributesPrivate: true,
+};
+const client = LDClient.initialize('example-client-side-id', context, options);
+try {
+  await client.waitForInitialization(5);
+  // initialization succeeded, flag values are now available
+} catch (err) {
+  // initialization failed or did not complete before timeout
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-eu
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for Node.js (client-side).
+---
+
+```js
+const options = {
+  streamUrl: 'https://clientstream.eu.launchdarkly.com',
+  baseUrl: 'https://clientsdk.eu.launchdarkly.com',
+  eventsUrl: 'https://events.eu.launchdarkly.com'
+};
+
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-federal
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for Node.js (client-side).
+---
+
+```js
+const options = {
+  streamUrl: 'https://clientstream.launchdarkly.us',
+  baseUrl: 'https://clientsdk.launchdarkly.us',
+  eventsUrl: 'https://events.launchdarkly.us'
+};
+
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: node-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-relay
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for Node.js (client-side).
+---
+
+```js
+const options = {
+  streamUrl: 'https://your-relay-proxy.com:8030',
+  baseUrl: 'https://your-relay-proxy.com:8030',
+  eventsUrl: 'https://your-relay-proxy.com:8030'
+};
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-eu.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-client-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-eu
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Node.js (client-side).
+---
+
+```ts
+import * as ld from 'launchdarkly-node-client-sdk';
+
+const options: ld.LDOptions = {
+  streamUrl: 'https://clientstream.eu.launchdarkly.com',
+  baseUrl: 'https://clientsdk.eu.launchdarkly.com',
+  eventsUrl: 'https://events.eu.launchdarkly.com',
+};
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-federal.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-client-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-federal
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Node.js (client-side).
+---
+
+```ts
+import * as ld from 'launchdarkly-node-client-sdk';
+
+const options: ld.LDOptions = {
+  streamUrl: 'https://clientstream.launchdarkly.us',
+  baseUrl: 'https://clientsdk.launchdarkly.us',
+  eventsUrl: 'https://events.launchdarkly.us',
+};
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: node-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-client-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-relay
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Node.js (client-side).
+---
+
+```ts
+import * as ld from 'launchdarkly-node-client-sdk';
+
+const options: ld.LDOptions = {
+  streamUrl: 'https://your-relay-proxy.com:8030',
+  baseUrl: 'https://your-relay-proxy.com:8030',
+  eventsUrl: 'https://your-relay-proxy.com:8030',
+};
+```

--- a/snippets/sdks/node-server-sdk/snippets/scaffolds/node-syntax-only.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/scaffolds/node-syntax-only.snippet.md
@@ -33,21 +33,17 @@ const body = String.raw`
 {{ body }}
 `;
 
-// Write the body as a TypeScript module (.mts) and let Node strip the
-// types natively (`--experimental-strip-types`, Node 22.6+) before the
-// `--check` syntax pass. This handles the full TS surface the doc
-// fragments use — typed function parameters (`async(key?: string)`),
-// inline object types, `as` assertions, `: Type` declarations — which
-// a regex strip can't do reliably. `--check` is purely syntactic, so
-// imported package names still don't have to resolve.
-fs.writeFileSync('fragment.mts', body);
+// Strip simple TS bits (`as Type` assertions, `: Type =`
+// declarations) before the parser sees them. Same approach as the
+// node-client scaffold; see comment there for regex shape rationale.
+const erased = body
+  .replace(/(\bconst|\blet|\bvar)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*[^=;]+=/g, '$1 $2 =')
+  .replace(/([A-Za-z0-9_$\)])\s+as\s+[A-Za-z_$][A-Za-z0-9_$.<>\[\]\s|&,()]*/g, '$1');
+
+fs.writeFileSync('fragment.mjs', erased);
 
 try {
-  execFileSync(
-    process.execPath,
-    ['--experimental-strip-types', '--check', 'fragment.mts'],
-    { stdio: 'pipe' },
-  );
+  execFileSync(process.execPath, ['--check', 'fragment.mjs'], { stdio: 'pipe' });
 } catch (err) {
   process.stderr.write(err.stderr || err.message);
   process.exit(1);

--- a/snippets/sdks/node-server-sdk/snippets/scaffolds/node-syntax-only.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/scaffolds/node-syntax-only.snippet.md
@@ -33,17 +33,21 @@ const body = String.raw`
 {{ body }}
 `;
 
-// Strip simple TS bits (`as Type` assertions, `: Type =`
-// declarations) before the parser sees them. Same approach as the
-// node-client scaffold; see comment there for regex shape rationale.
-const erased = body
-  .replace(/(\bconst|\blet|\bvar)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*[^=;]+=/g, '$1 $2 =')
-  .replace(/([A-Za-z0-9_$\)])\s+as\s+[A-Za-z_$][A-Za-z0-9_$.<>\[\]\s|&,()]*/g, '$1');
-
-fs.writeFileSync('fragment.mjs', erased);
+// Write the body as a TypeScript module (.mts) and let Node strip the
+// types natively (`--experimental-strip-types`, Node 22.6+) before the
+// `--check` syntax pass. This handles the full TS surface the doc
+// fragments use — typed function parameters (`async(key?: string)`),
+// inline object types, `as` assertions, `: Type` declarations — which
+// a regex strip can't do reliably. `--check` is purely syntactic, so
+// imported package names still don't have to resolve.
+fs.writeFileSync('fragment.mts', body);
 
 try {
-  execFileSync(process.execPath, ['--check', 'fragment.mjs'], { stdio: 'pipe' });
+  execFileSync(
+    process.execPath,
+    ['--experimental-strip-types', '--check', 'fragment.mts'],
+    { stdio: 'pipe' },
+  );
 } catch (err) {
   process.stderr.write(err.stderr || err.message);
   process.exit(1);

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-js-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-js-v7.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-server-sdk/sdk-docs/features/config/app-config-js-v7
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+description: Application metadata configuration example for Node.js (server-side).
+---
+
+```js
+var options = {
+  application: {
+    id: 'authentication-service',
+    version: '1.0.0'
+  }
+};
+client = ld.init('YOUR_SDK_KEY', options);
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-js-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-js-v7.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: javascript
 description: Application metadata configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v7.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Application metadata configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v7.snippet.md
@@ -1,0 +1,18 @@
+---
+id: node-server-sdk/sdk-docs/features/config/app-config-ts-v7
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: Application metadata configuration example for Node.js (server-side).
+---
+
+```ts
+import * as ld from 'launchdarkly-node-server-sdk';
+const options: ld.LDOptions = {
+  application: {
+    id: 'authentication-service',
+    version: '1.0.0'
+  }
+};
+const client = ld.init('YOUR_SDK_KEY', options);
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v8.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v8.snippet.md
@@ -1,0 +1,18 @@
+---
+id: node-server-sdk/sdk-docs/features/config/app-config-ts-v8
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: Application metadata configuration example for Node.js (server-side).
+---
+
+```ts
+import * as ld from '@launchdarkly/node-server-sdk';
+const options: ld.LDOptions = {
+  application: {
+    id: 'authentication-service',
+    version: '1.0.0'
+  }
+};
+const client = ld.init('YOUR_SDK_KEY', options);
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v8.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/app-config-ts-v8.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Application metadata configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-js-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-js-v7.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: javascript
 description: SDK configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-js-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-js-v7.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-server-sdk/sdk-docs/features/config/index-js-v7
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+description: SDK configuration example for Node.js (server-side).
+---
+
+```js
+const options = {
+  timeout: 3
+};
+client = ld.init('YOUR_SDK_KEY', options);
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v7.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v7.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v7.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-server-sdk/sdk-docs/features/config/index-ts-v7
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Node.js (server-side).
+---
+
+```ts
+import * as ld from 'launchdarkly-node-server-sdk';
+
+const options: ld.LDOptions = {
+  timeout: 3,
+};
+const client = ld.init('YOUR_SDK_KEY', options);
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v8.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v8.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v8.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/index-ts-v8.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-server-sdk/sdk-docs/features/config/index-ts-v8
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Node.js (server-side).
+---
+
+```ts
+import * as ld from '@launchdarkly/node-server-sdk';
+
+const options: ld.LDOptions = {
+  timeout: 3,
+};
+const client = ld.init('YOUR_SDK_KEY', options);
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,7 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Migration configuration example for the Node.js (server-side) SDK v9 — read/write functions, execution mode, latency/error tracking.
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,48 @@
+---
+id: node-server-sdk/sdk-docs/features/config/migration-config
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: Migration configuration example for the Node.js (server-side) SDK v9 — read/write functions, execution mode, latency/error tracking.
+---
+
+```ts
+import { LDMigrationOptions, init, createMigration } from '@launchdarkly/node-server-sdk';
+const options: LDMigrationOptions = {
+  readNew: async(key?: string) => {
+    console.log("Reading from new: ", key);
+    return LDMigrationSuccess(true);
+  },
+  readOld: async(key?: string) => {
+    console.log("Reading from old: ", key);
+    return LDMigrationSuccess(true);
+  },
+  writeNew: async(params?: {key: string, value: string}) => {
+    console.log("Writing to new: ", params);
+    // if failure
+    return LDMigrationError(new Error('example error'));
+  },
+  writeOld: async(params?: {key: string, value: string}) => {
+    console.log("Writing to old: ", params);
+    // if failure
+    return LDMigrationError(new Error('example error'));
+  },
+
+  check: (old, new) => {
+    // Define your consistency check for read operations
+    // and return a boolean. Depending on your migration,
+    // this may be as simple as 'return a === b;'
+  },
+
+  execution: new LDConcurrentExecution(),
+    // or new LDSerialExecution(LDExecutionOrdering.Random),
+    // or new LDSerialExecution(LDExecutionOrdering.Fixed),
+
+  latencyTracking: true, // defaults to true
+  errorTracking: true, // defaults to true
+}
+
+const client = init('YOUR_SDK_KEY');
+const migration = createMigration(client, options);
+
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,8 +4,6 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Migration configuration example for the Node.js (server-side) SDK v9 — read/write functions, execution mode, latency/error tracking.
-validation:
-  scaffold: node-server-sdk/scaffolds/node-syntax-only
 
 ---
 

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,8 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Migration configuration example for the Node.js (server-side) SDK v9 — read/write functions, execution mode, latency/error tracking.
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
 
 ---
 

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -8,7 +8,16 @@ description: Migration configuration example for the Node.js (server-side) SDK v
 ---
 
 ```ts
-import { LDMigrationOptions, init, createMigration } from '@launchdarkly/node-server-sdk';
+import {
+  LDMigrationOptions,
+  init,
+  createMigration,
+  LDMigrationSuccess,
+  LDMigrationError,
+  LDConcurrentExecution,
+  LDSerialExecution,
+  LDExecutionOrdering,
+} from '@launchdarkly/node-server-sdk';
 const options: LDMigrationOptions = {
   readNew: async(key?: string) => {
     console.log("Reading from new: ", key);

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -28,7 +28,7 @@ const options: LDMigrationOptions = {
     return LDMigrationError(new Error('example error'));
   },
 
-  check: (old, new) => {
+  check: (old, newVal) => {
     // Define your consistency check for read operations
     // and return a boolean. Depending on your migration,
     // this may be as simple as 'return a === b;'

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-eu.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-eu.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-eu.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-server-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-v8-eu
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Node.js (server-side).
+---
+
+```ts
+import { LDOptions } from '@launchdarkly/node-server-sdk';
+
+const options: LDOptions = {
+  streamUri: 'https://stream.eu.launchdarkly.com',
+  baseUri: 'https://sdk.eu.launchdarkly.com',
+  eventsUri: 'https://events.eu.launchdarkly.com',
+};
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-federal.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-federal.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-federal.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-server-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-v8-federal
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Node.js (server-side).
+---
+
+```ts
+import { LDOptions } from '@launchdarkly/node-server-sdk';
+
+const options: LDOptions = {
+  streamUri: 'https://stream.launchdarkly.us',
+  baseUri: 'https://sdk.launchdarkly.us',
+  eventsUri: 'https://events.launchdarkly.us',
+};
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-relay.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: node-server-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-relay.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-ts-v8-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-server-sdk/sdk-docs/features/config/service-endpoint-configuration-ts-v8-relay
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for Node.js (server-side).
+---
+
+```ts
+import { LDOptions } from '@launchdarkly/node-server-sdk';
+
+const options: LDOptions = {
+  streamUri: 'https://your-relay-proxy.com:8030',
+  baseUri: 'https://your-relay-proxy.com:8030',
+  eventsUri: 'https://your-relay-proxy.com:8030',
+};
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: Application metadata configuration example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,16 @@
+---
+id: php-server-sdk/sdk-docs/features/config/app-config
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Application metadata configuration example for PHP.
+---
+
+```php
+$appInfo = (new ApplicationInfo())->withId('authentication-service')->withVersion('1.0.0');
+$config = [
+  "application_info" => $appInfo
+];
+
+$client = new LaunchDarkly\LDClient("YOUR_SDK_KEY", $config);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,11 @@
+---
+id: php-server-sdk/sdk-docs/features/config/index
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: SDK configuration example for PHP.
+---
+
+```php
+$client = new LaunchDarkly\LDClient("YOUR_SDK_KEY", ["cache" => $cacheStorage, "connect_timeout" => 3]);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: SDK configuration example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,8 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: Migration configuration example for the PHP SDK v6 — read/write methods, execution order, latency/error tracking.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
 
 ---
 

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,34 @@
+---
+id: php-server-sdk/sdk-docs/features/config/migration-config
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Migration configuration example for the PHP SDK v6 — read/write methods, execution order, latency/error tracking.
+---
+
+```php
+
+use LaunchDarkly\Migrations;
+use LaunchDarkly\Types;
+
+$builder = new Migrations\MigratorBuilder($client);
+
+$builder->read(
+    fn (?string $payload) => Types\Result::success("old read"),
+    fn (?string $payload) => Types\Result::success("new read"),
+    fn(string $old, string $new) => $old == $new,
+);
+
+$builder->write(
+    fn (?string $payload) => Types\Result::success("old write"),
+    fn (?string $payload) => Types\Result::success("new write")
+);
+$builder->readExecutionOrder(Migrations\ExecutionOrder::SERIAL);
+// could also use ExecutionOrder::RANDOM
+
+$builder->trackLatency(true); // defaults to true
+$builder->trackErrors(true);  // defaults to true
+
+$result = $builder->build();
+
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,7 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: Migration configuration example for the PHP SDK v6 — read/write methods, execution order, latency/error tracking.
+
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,13 @@
+---
+id: php-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Service endpoint configuration example for PHP.
+---
+
+```php
+$client = new LaunchDarkly\LDClient("YOUR_SDK_KEY",
+    [ "base_uri" => "https://sdk.eu.launchdarkly.com",
+      "events_uri" => "https://events.eu.launchdarkly.com" ]);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: Service endpoint configuration example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,13 @@
+---
+id: php-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Service endpoint configuration example for PHP.
+---
+
+```php
+$client = new LaunchDarkly\LDClient("YOUR_SDK_KEY",
+    [ "base_uri" => "https://sdk.launchdarkly.us",
+      "events_uri" => "https://events.launchdarkly.us" ]);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: Service endpoint configuration example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: php-server-sdk
 kind: reference
 lang: php
 description: Service endpoint configuration example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
 ---
 
 ```php

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,13 @@
+---
+id: php-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Service endpoint configuration example for PHP.
+---
+
+```php
+$client = new LaunchDarkly\LDClient("YOUR_SDK_KEY",
+    [ "base_uri" => "https://your-relay-proxy.com:8030",
+      "events_uri" => "https://your-relay-proxy.com:8030" ]);
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/features/config/app-config
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Application metadata configuration example for Python.
+---
+
+```python
+config = Config(sdk_key='YOUR_SDK_KEY',
+  application = {"id": "authentication-service", "version": "1.0.0"})
+ldclient.set_config(config)
+
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Application metadata configuration example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,12 @@
+---
+id: python-server-sdk/sdk-docs/features/config/index
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: SDK configuration example for Python.
+---
+
+```python
+config = Config(sdk_key='YOUR_SDK_KEY', http=HTTPConfig(connect_timeout=5))
+ldclient.set_config(config)
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: SDK configuration example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,25 @@
+---
+id: python-server-sdk/sdk-docs/features/config/migration-config
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Migration configuration example for the Python SDK v9 — read/write methods, execution order, latency/error tracking.
+---
+
+```python
+from ldclient import Result, MigratorBuilder, ExecutionOrder
+
+builder = MigratorBuilder(ldclient.get())
+
+builder.read(lambda _: Result.success("read old"), lambda _: Result.success("read new"), lambda lhs, rhs: lhs == rhs)
+builder.write(lambda _: Result.success("write old"), lambda _: Result.success("write new"))
+
+builder.read_execution_order(ExecutionOrder.PARALLEL)
+# could also use ExecutionOrder.SERIAL, ExecutionOrder.RANDOM
+
+builder.track_latency(True) # defaults to True
+builder.track_errors(True)  # defaults to True
+
+result = builder.build()
+
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,9 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Migration configuration example for the Python SDK v9 — read/write methods, execution order, latency/error tracking.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Service endpoint configuration example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Service endpoint configuration example for Python.
+---
+
+```python
+config = Config(sdk_key='YOUR_SDK_KEY',
+  stream_uri="https://stream.eu.launchdarkly.com",
+  base_uri="https://sdk.eu.launchdarkly.com",
+  events_uri="https://events.eu.launchdarkly.com")
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Service endpoint configuration example for Python.
+---
+
+```python
+config = Config(sdk_key='YOUR_SDK_KEY',
+  stream_uri="https://stream.launchdarkly.us",
+  base_uri="https://sdk.launchdarkly.us",
+  events_uri="https://events.launchdarkly.us")
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Service endpoint configuration example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
 ---
 
 ```python

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Service endpoint configuration example for Python.
+---
+
+```python
+config = Config(sdk_key='YOUR_SDK_KEY',
+  stream_uri="https://your-relay-proxy.com:8030",
+  base_uri="https://your-relay-proxy.com:8030",
+  events_uri="https://your-relay-proxy.com:8030")
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: python-server-sdk
 kind: reference
 lang: python
 description: Service endpoint configuration example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
 ---
 
 ```python

--- a/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
@@ -1,0 +1,15 @@
+---
+id: react-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-eu
+sdk: react-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for React Web.
+---
+
+```js
+const options = {
+  baseUrl:"https://clientsdk.eu.launchdarkly.com",
+  streamUrl:"https://clientstream.eu.launchdarkly.com",
+  eventsUrl:"https://events.eu.launchdarkly.com"
+};
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: react-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for React Web.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
@@ -1,0 +1,15 @@
+---
+id: react-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-federal
+sdk: react-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for React Web.
+---
+
+```js
+const options = {
+  baseUrl:"https://clientsdk.launchdarkly.us",
+  streamUrl:"https://clientstream.launchdarkly.us",
+  eventsUrl:"https://events.launchdarkly.us"
+};
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: react-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for React Web.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: react-client-sdk/sdk-docs/features/config/service-endpoint-configuration-js-relay
+sdk: react-client-sdk
+kind: reference
+lang: javascript
+description: Service endpoint configuration example for React Web.
+---
+
+```js
+const options = {
+  baseUrl: 'https://your-relay-proxy.com:8030',
+  streamUrl: 'https://your-relay-proxy.com:8030',
+  eventsUrl: 'https://your-relay-proxy.com:8030'
+};
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-js-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: react-client-sdk
 kind: reference
 lang: javascript
 description: Service endpoint configuration example for React Web.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
+
 ---
 
 ```js

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,20 @@
+---
+id: react-native-client-sdk/sdk-docs/features/config/app-config
+sdk: react-native-client-sdk
+kind: reference
+lang: javascript
+description: Application metadata configuration example for React Native.
+---
+
+```js
+const options: LDOptions = {
+  applicationInfo: {
+    id: 'authentication-service',
+    name: 'Authentication-Service',
+    version: '1.0.0',
+    versionName: 'v1',
+  }
+}
+
+const client = new ReactNativeLDClient('example-mobile-key', AutoEnvAttributes.Enabled, options);
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -2,11 +2,11 @@
 id: react-native-client-sdk/sdk-docs/features/config/app-config
 sdk: react-native-client-sdk
 kind: reference
-lang: javascript
+lang: typescript
 description: Application metadata configuration example for React Native.
 ---
 
-```js
+```ts
 const options: LDOptions = {
   applicationInfo: {
     id: 'authentication-service',

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: react-native-client-sdk
 kind: reference
 lang: typescript
 description: Application metadata configuration example for React Native.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: react-native-client-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for React Native.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,17 @@
+---
+id: react-native-client-sdk/sdk-docs/features/config/index
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for React Native.
+---
+
+```ts
+import { type LDOptions } from '@launchdarkly/react-native-client-sdk';
+
+const options = {
+  withReasons: true,
+};
+
+const client = new ReactNativeLDClient('example-mobile-key', AutoEnvAttributes.Enabled, options);
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-eu.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-eu.snippet.md
@@ -1,0 +1,17 @@
+---
+id: react-native-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v10-eu
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for React Native.
+---
+
+```ts
+import { LDOptions } from '@launchdarkly/react-native-client-sdk'
+
+let options: LDOptions = {
+  streamUri: 'https://clientstream.eu.launchdarkly.com',
+  baseUri: 'https://clientsdk.eu.launchdarkly.com',
+  eventsUri: 'https://events.eu.launchdarkly.com',
+};
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-eu.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: react-native-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for React Native.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-federal.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-federal.snippet.md
@@ -1,0 +1,17 @@
+---
+id: react-native-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v10-federal
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for React Native.
+---
+
+```ts
+import { LDOptions } from '@launchdarkly/react-native-client-sdk'
+
+let options: LDOptions = {
+  streamUri: 'https://clientstream.launchdarkly.us',
+  baseUri: 'https://clientsdk.launchdarkly.us',
+  eventsUri: 'https://events.launchdarkly.us',
+};
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-federal.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: react-native-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for React Native.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-relay.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-relay.snippet.md
@@ -1,0 +1,17 @@
+---
+id: react-native-client-sdk/sdk-docs/features/config/service-endpoint-configuration-v10-relay
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: Service endpoint configuration example for React Native.
+---
+
+```ts
+import { LDOptions } from '@launchdarkly/react-native-client-sdk'
+
+let options: LDOptions = {
+  streamUri: 'https://your-relay-proxy.com:8030',
+  baseUri: 'https://your-relay-proxy.com:8030',
+  eventsUri: 'https://your-relay-proxy.com:8030',
+};
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-relay.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-v10-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: react-native-client-sdk
 kind: reference
 lang: typescript
 description: Service endpoint configuration example for React Native.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: Application metadata configuration example for Roku.
+validation:
+  scaffold: roku-client-sdk/scaffolds/roku-syntax-only
+
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,19 @@
+---
+id: roku-client-sdk/sdk-docs/features/config/app-config
+sdk: roku-client-sdk
+kind: reference
+lang: brightscript
+description: Application metadata configuration example for Roku.
+---
+
+```brightscript
+' for a legacy Roku application
+config = LaunchDarklyConfig("example-mobile-key")
+
+' for a SceneGraph Roku Application
+config = LaunchDarklyConfig("example-mobile-key", CLIENT_SCENEGRAPH_NODE)
+
+' configure the application identifier and application version
+config.setApplicationInfoValue("id", "authentication-service")
+config.setApplicationInfoValue("version", "1.0.0")
+```

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-create.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-create.snippet.md
@@ -1,0 +1,16 @@
+---
+id: roku-client-sdk/sdk-docs/features/config/index-create
+sdk: roku-client-sdk
+kind: reference
+lang: brightscript
+description: SDK configuration example for Roku.
+---
+
+```brightscript
+' for a legacy Roku application
+config = LaunchDarklyConfig("example-mobile-key")
+
+' for a SceneGraph Roku Application
+config = LaunchDarklyConfig("example-mobile-key", CLIENT_SCENEGRAPH_NODE)
+
+```

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-create.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-create.snippet.md
@@ -4,6 +4,9 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: SDK configuration example for Roku.
+validation:
+  scaffold: roku-client-sdk/scaffolds/roku-syntax-only
+
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-options.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-options.snippet.md
@@ -4,6 +4,9 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: SDK configuration example for Roku.
+validation:
+  scaffold: roku-client-sdk/scaffolds/roku-syntax-only
+
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-options.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/index-options.snippet.md
@@ -1,0 +1,49 @@
+---
+id: roku-client-sdk/sdk-docs/features/config/index-options
+sdk: roku-client-sdk
+kind: reference
+lang: brightscript
+description: SDK configuration example for Roku.
+---
+
+```brightscript
+config.setAppURI(String)
+
+config.setEventsURI(String)
+
+config.setStreamURI(String)
+
+
+config.setPollingIntervalSeconds(Integer)
+
+config.setOffline(Boolean)
+
+
+config.addPrivateAttribute(String)
+
+config.setAllAttributesPrivate(Boolean)
+
+
+config.setEventsCapacity(Integer)
+
+config.setEventsFlushIntervalSeconds(Integer)
+
+
+config.setLogger(Object)
+
+config.setLoggerNode(Dynamic)
+
+config.setStoreBackend(Object)
+
+config.setStoreBackendNode(Dynamic)
+
+
+config.setStreaming(Boolean)
+
+config.setLogLevel(Integer)
+
+
+config.setUseEvaluationReasons(Boolean)
+
+config.setApplicationInfoValue(String, String)
+```

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration.snippet.md
@@ -4,6 +4,9 @@ sdk: roku-client-sdk
 kind: reference
 lang: brightscript
 description: Service endpoint configuration example for Roku.
+validation:
+  scaffold: roku-client-sdk/scaffolds/roku-syntax-only
+
 ---
 
 ```brightscript

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration.snippet.md
@@ -1,0 +1,19 @@
+---
+id: roku-client-sdk/sdk-docs/features/config/service-endpoint-configuration
+sdk: roku-client-sdk
+kind: reference
+lang: brightscript
+description: Service endpoint configuration example for Roku.
+---
+
+```brightscript
+' for a legacy Roku application
+config = LaunchDarklyConfig("example-mobile-key")
+
+' for a SceneGraph Roku Application
+config = LaunchDarklyConfig("example-mobile-key", CLIENT_SCENEGRAPH_NODE)
+
+config.setStreamURI("https://your-relay-proxy.com:8030")
+config.setAppURI("https://your-relay-proxy.com:8030")
+config.setEventsURI("https://your-relay-proxy.com:8030")
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: Application metadata configuration example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,16 @@
+---
+id: ruby-server-sdk/sdk-docs/features/config/app-config
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Application metadata configuration example for Ruby.
+---
+
+```ruby
+LaunchDarkly::Config.new({
+  application: {
+    id: "authentication-service",
+    version: "abc123def456"
+  }
+})
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,6 +4,9 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: SDK configuration example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,12 @@
+---
+id: ruby-server-sdk/sdk-docs/features/config/index
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: SDK configuration example for Ruby.
+---
+
+```ruby
+config = LaunchDarkly::Config.new({connect_timeout: 1, read_timeout: 2})
+client = LaunchDarkly::LDClient.new("YOUR_SDK_KEY", config)
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,9 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: Migration configuration example for the Ruby SDK v8 — read/write methods, execution order, latency/error tracking.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,25 @@
+---
+id: ruby-server-sdk/sdk-docs/features/config/migration-config
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Migration configuration example for the Ruby SDK v8 — read/write methods, execution order, latency/error tracking.
+---
+
+```ruby
+builder = LaunchDarkly::Migrations::MigratorBuilder.new(@client)
+builder.read(
+  ->(_payload) { LaunchDarkly::Result.success('old value') },
+  ->(_payload) { LaunchDarkly::Result.success('new value') },
+  ->(lhs, rhs) { lhs == rhs }
+)
+
+builder.write(
+  ->(_payload) { LaunchDarkly::Result.success('old value') },
+  ->(_payload) { LaunchDarkly::Result.success('new value') }
+)
+builder.read_execution_order(builder.EXECUTION_PARALLEL) # or .EXECUTION_SERIAL, or .EXECUTION_RANDOM
+builder.track_latency(true) # defaults to true
+builder.track_errors(true)  # defaults to true
+migrator = builder.build
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ruby-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Service endpoint configuration example for Ruby.
+---
+
+```ruby
+config = LaunchDarkly::Config.new(
+  stream_uri: "https://stream.eu.launchdarkly.com",
+  base_uri: "https://sdk.eu.launchdarkly.com",
+  events_uri: "https://events.eu.launchdarkly.com")
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: Service endpoint configuration example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ruby-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Service endpoint configuration example for Ruby.
+---
+
+```ruby
+config = LaunchDarkly::Config.new(
+  stream_uri: "https://stream.launchdarkly.us",
+  base_uri: "https://sdk.launchdarkly.us",
+  events_uri: "https://events.launchdarkly.us")
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: Service endpoint configuration example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
 ---
 
 ```ruby

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ruby-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Service endpoint configuration example for Ruby.
+---
+
+```ruby
+config = LaunchDarkly::Config.new(
+  stream_uri: "https://your-relay-proxy.com:8030",
+  base_uri: "https://your-relay-proxy.com:8030",
+  events_uri: "https://your-relay-proxy.com:8030")
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: ruby-server-sdk
 kind: reference
 lang: ruby
 description: Service endpoint configuration example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
 ---
 
 ```ruby

--- a/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
@@ -24,7 +24,12 @@ validation:
 use launchdarkly_server_sdk::{
     ApplicationInfo, AttributeValue, Client, ConfigBuilder, Context, ContextBuilder,
     MultiContextBuilder, Reference, ServiceEndpointsBuilder,
+    MigratorBuilder, ExecutionOrder,
 };
+#[allow(unused_imports)]
+use std::sync::Arc;
+#[allow(unused_imports)]
+use futures::future::FutureExt;
 #[allow(unused_imports)]
 use std::collections::HashMap;
 

--- a/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
@@ -22,8 +22,8 @@ validation:
 // the imports.
 #[allow(unused_imports)]
 use launchdarkly_server_sdk::{
-    AttributeValue, Client, ConfigBuilder, Context, ContextBuilder,
-    MultiContextBuilder, Reference,
+    ApplicationInfo, AttributeValue, Client, ConfigBuilder, Context, ContextBuilder,
+    MultiContextBuilder, Reference, ServiceEndpointsBuilder,
 };
 #[allow(unused_imports)]
 use std::collections::HashMap;
@@ -38,6 +38,10 @@ const YOUR_SDK_KEY: &str = "";
 const YOUR_MOBILE_KEY: &str = "";
 #[allow(non_upper_case_globals, dead_code)]
 const YOUR_CLIENT_SIDE_ID: &str = "";
+// Some config fragments reference a lowercase `sdk_key` binding rather
+// than the YOUR_SDK_KEY placeholder; provide it so they resolve.
+#[allow(non_upper_case_globals, dead_code)]
+const sdk_key: &str = "";
 
 // Stub for the pre-1.0 (beta) `User` API surface — removed at 1.0
 // in favor of Context. Doc fragments under

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -1,0 +1,17 @@
+---
+id: rust-server-sdk/sdk-docs/features/config/app-config
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Application metadata configuration example for Rust.
+---
+
+```rust
+let mut application_info = ApplicationInfo::new();
+application_info
+    .application_identifier("authentication-service")
+    .application_version("1.0.0");
+let config = ConfigBuilder::new(&sdk_key)
+    .application_info(application_info)
+    .build();
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/app-config.snippet.md
@@ -4,6 +4,9 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: Application metadata configuration example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -1,0 +1,14 @@
+---
+id: rust-server-sdk/sdk-docs/features/config/index
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: SDK configuration example for Rust.
+---
+
+```rust
+let config = ConfigBuilder::new("YOUR_SDK_KEY")
+  .offline(true)
+  .build();
+let client = Client::build(config).unwrap();
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/index.snippet.md
@@ -4,11 +4,15 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: SDK configuration example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
 ---
 
 ```rust
 let config = ConfigBuilder::new("YOUR_SDK_KEY")
   .offline(true)
-  .build();
+  .build()
+  .unwrap();
 let client = Client::build(config).unwrap();
 ```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,8 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: Migration configuration example for the Rust SDK v2.2 — read/write methods, execution order, latency/error tracking.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
 
 ---
 

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,28 @@
+---
+id: rust-server-sdk/sdk-docs/features/config/migration-config
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Migration configuration example for the Rust SDK v2.2 — read/write methods, execution order, latency/error tracking.
+---
+
+```rust
+let client = Arc::new(client);
+let mut builder = MigratorBuilder::new(client.clone())
+    .read(
+        |_payload: &String| async move { Ok(()) }.boxed(),
+        |_payload: &String| async move { Ok(()) }.boxed(),
+        Some(|lhs, rhs| lhs == rhs),
+    )
+    .write(
+        |_payload: &String| async move { Ok(()) }.boxed(),
+        |_payload: &String| async move { Ok(()) }.boxed(),
+    );
+
+builder = builder
+    .read_execution_order(ExecutionOrder::Concurrent) // Or ExecutionOrder::Serial or ExecutionOrder::Random
+    .track_latency(true) // defaults to true
+    .track_errors(true); // defaults to true
+
+let migrator = builder.build().expect("build migrator");
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,7 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: Migration configuration example for the Rust SDK v2.2 — read/write methods, execution order, latency/error tracking.
+
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -13,5 +13,7 @@ validation:
 let config = ConfigBuilder::new("YOUR_SDK_KEY").service_endpoints(ServiceEndpointsBuilder::new()
   .streaming_base_url("https://stream.eu.launchdarkly.com")
   .polling_base_url("https://sdk.eu.launchdarkly.com")
-  .events_base_url("https://events.eu.launchdarkly.com"));
+  .events_base_url("https://events.eu.launchdarkly.com"))
+  .build()
+  .unwrap();
 ```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -1,0 +1,14 @@
+---
+id: rust-server-sdk/sdk-docs/features/config/service-endpoint-configuration-eu
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Service endpoint configuration example for Rust.
+---
+
+```rust
+let config = ConfigBuilder::new("YOUR_SDK_KEY").service_endpoints(ServiceEndpointsBuilder::new()
+  .streaming_base_url("https://stream.eu.launchdarkly.com")
+  .polling_base_url("https://sdk.eu.launchdarkly.com")
+  .events_base_url("https://events.eu.launchdarkly.com"));
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-eu.snippet.md
@@ -4,6 +4,9 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: Service endpoint configuration example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -13,5 +13,7 @@ validation:
 let config = ConfigBuilder::new("YOUR_SDK_KEY").service_endpoints(ServiceEndpointsBuilder::new()
   .streaming_base_url("https://stream.launchdarkly.us")
   .polling_base_url("https://sdk.launchdarkly.us")
-  .events_base_url("https://events.launchdarkly.us"));
+  .events_base_url("https://events.launchdarkly.us"))
+  .build()
+  .unwrap();
 ```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -1,0 +1,14 @@
+---
+id: rust-server-sdk/sdk-docs/features/config/service-endpoint-configuration-federal
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Service endpoint configuration example for Rust.
+---
+
+```rust
+let config = ConfigBuilder::new("YOUR_SDK_KEY").service_endpoints(ServiceEndpointsBuilder::new()
+  .streaming_base_url("https://stream.launchdarkly.us")
+  .polling_base_url("https://sdk.launchdarkly.us")
+  .events_base_url("https://events.launchdarkly.us"));
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-federal.snippet.md
@@ -4,6 +4,9 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: Service endpoint configuration example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
 ---
 
 ```rust

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -14,5 +14,6 @@ let config = ConfigBuilder::new("YOUR_SDK_KEY")
     .service_endpoints(
         ServiceEndpointsBuilder::new().relay_proxy("https://your-relay-proxy.com:8030"),
     )
-    .build();
+    .build()
+    .unwrap();
 ```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -1,0 +1,15 @@
+---
+id: rust-server-sdk/sdk-docs/features/config/service-endpoint-configuration-relay
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Service endpoint configuration example for Rust.
+---
+
+```rust
+let config = ConfigBuilder::new("YOUR_SDK_KEY")
+    .service_endpoints(
+        ServiceEndpointsBuilder::new().relay_proxy("https://your-relay-proxy.com:8030"),
+    )
+    .build();
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/config/service-endpoint-configuration-relay.snippet.md
@@ -4,6 +4,9 @@ sdk: rust-server-sdk
 kind: reference
 lang: rust
 description: Service endpoint configuration example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
 ---
 
 ```rust

--- a/snippets/sdks/vercel-server-sdk/sdk.yaml
+++ b/snippets/sdks/vercel-server-sdk/sdk.yaml
@@ -1,0 +1,4 @@
+# Identifier for this SDK. Matches the SDK's id in launchdarkly/sdk-meta's
+# API packages — the source of truth for everything else (display name,
+# language flavors, supported regions, hello-world repo, docs URL).
+id: vercel-server-sdk

--- a/snippets/sdks/vercel-server-sdk/snippets/scaffolds/vercel-syntax-only.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/scaffolds/vercel-syntax-only.snippet.md
@@ -1,0 +1,26 @@
+---
+id: vercel-server-sdk/scaffolds/vercel-syntax-only
+sdk: vercel-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Parse-only validator for Vercel edge SDK config doc fragments. Routes
+  through the `edge-ts` validator, which runs the TypeScript compiler's
+  transpileModule (syntax check + type-strip; no module resolution, no
+  type-checking). A clean parse means the fragment is syntactically
+  valid TypeScript -- edge-only package imports and ambient globals
+  (env, process) need not resolve. Doc fragments are whole TS modules,
+  so the scaffold emits the body verbatim.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, parsed as a TypeScript module.
+validation:
+  runtime: edge-ts
+  entrypoint: snippet.ts
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-0.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-0.snippet.md
@@ -4,6 +4,9 @@ sdk: vercel-server-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Vercel.
+validation:
+  scaffold: vercel-server-sdk/scaffolds/vercel-syntax-only
+
 ---
 
 ```typescript

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-0.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-0.snippet.md
@@ -1,0 +1,20 @@
+---
+id: vercel-server-sdk/sdk-docs/features/config/index-v1-0
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Vercel.
+---
+
+```typescript
+import { createClient } from '@vercel/edge-config';
+import { BasicLogger, init, LDOptions } from '@launchdarkly/vercel-server-sdk';
+
+const edgeConfigClient = createClient(process.env.EDGE_CONFIG);
+
+const options: LDOptions = {
+  logger: new BasicLogger({ destination: console.log }),
+};
+
+client = init('example-client-side-id', edgeConfigClient, options);
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-2.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-2.snippet.md
@@ -4,6 +4,9 @@ sdk: vercel-server-sdk
 kind: reference
 lang: typescript
 description: SDK configuration example for Vercel.
+validation:
+  scaffold: vercel-server-sdk/scaffolds/vercel-syntax-only
+
 ---
 
 ```typescript

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-2.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/index-v1-2.snippet.md
@@ -1,0 +1,21 @@
+---
+id: vercel-server-sdk/sdk-docs/features/config/index-v1-2
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+description: SDK configuration example for Vercel.
+---
+
+```typescript
+import { createClient } from '@vercel/edge-config';
+import { BasicLogger, init, LDOptions } from '@launchdarkly/vercel-server-sdk';
+
+const edgeConfigClient = createClient(process.env.EDGE_CONFIG);
+
+const options: LDOptions = {
+  logger: new BasicLogger({ destination: console.log }),
+  sendEvents: true, // default is false
+};
+
+client = init('example-client-side-id', edgeConfigClient, options);
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -4,6 +4,9 @@ sdk: vercel-server-sdk
 kind: reference
 lang: typescript
 description: Migration configuration example for the Vercel Edge SDK v1.1.6+ — read/write functions, execution mode, latency/error tracking.
+validation:
+  scaffold: vercel-server-sdk/scaffolds/vercel-syntax-only
+
 ---
 
 ```ts

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -22,7 +22,7 @@ const options: LDMigrationOptions = {
     return LDMigrationSuccess(true);
   },
   readOld: async(key?: string) => {
-    console.log("Reading from new: ", key);
+    console.log("Reading from old: ", key);
     return LDMigrationSuccess(true);
   },
   writeNew: async(params?: {key: string, value: string}) => {
@@ -36,7 +36,7 @@ const options: LDMigrationOptions = {
     return LDMigrationError(new Error('example error'));
   },
 
-  check: (old, new) => {
+  check: (old, newVal) => {
     // Define your consistency check for read operations
     // and return a boolean. Depending on your migration,
     // this may be as simple as 'return a === b;'

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/config/migration-config.snippet.md
@@ -1,0 +1,56 @@
+---
+id: vercel-server-sdk/sdk-docs/features/config/migration-config
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+description: Migration configuration example for the Vercel Edge SDK v1.1.6+ — read/write functions, execution mode, latency/error tracking.
+---
+
+```ts
+import {
+  createMigration,
+  init,
+  LDConcurrentExecution,
+  LDMigrationError,
+  LDMigrationOptions,
+  LDMigrationSuccess,
+} from '@launchdarkly/vercel-server-sdk';
+
+const options: LDMigrationOptions = {
+  readNew: async(key?: string) => {
+    console.log("Reading from new: ", key);
+    return LDMigrationSuccess(true);
+  },
+  readOld: async(key?: string) => {
+    console.log("Reading from new: ", key);
+    return LDMigrationSuccess(true);
+  },
+  writeNew: async(params?: {key: string, value: string}) => {
+    console.log("Writing to new: ", params);
+    // if failure - can throw an exception
+    throw new Error("example exception")
+  },
+  writeOld: async(params?: {key: string, value: string}) => {
+    console.log("Writing to old: ", params);
+    // if failure - can return the failure
+    return LDMigrationError(new Error('example error'));
+  },
+
+  check: (old, new) => {
+    // Define your consistency check for read operations
+    // and return a boolean. Depending on your migration,
+    // this may be as simple as 'return a === b;'
+  },
+
+  execution: new LDConcurrentExecution(),
+    // or new LDSerialExecution(LDExecutionOrdering.Random),
+    // or new LDSerialExecution(LDExecutionOrdering.Fixed),
+
+  latencyTracking: true, // defaults to true
+  errorTracking: true, // defaults to true
+}
+
+const client = init('example-client-side-id', edgeConfigClient, { sendEvents: true });
+const migration = createMigration(client, options);
+
+```

--- a/snippets/validators/languages/edge-ts/Dockerfile
+++ b/snippets/validators/languages/edge-ts/Dockerfile
@@ -1,0 +1,22 @@
+# Build context is `validators/`. See validators/languages/python/Dockerfile
+# for the rationale.
+#
+# Parse-only TypeScript validator for the edge SDK config doc fragments
+# (cloudflare, vercel, akamai-edgekv, fastly), none of which had a
+# validator. Uses the TypeScript compiler's transpileModule, which does
+# a syntax check + type-strip with NO module resolution and NO
+# type-checking. That lets fragments import edge-only packages and
+# reference ambient globals (env, process) and parse cleanly without
+# those packages installed — exactly the parse-only guarantee the other
+# syntax-only validators give for their languages.
+FROM node:20-bookworm-slim
+
+# Pin so the validator is reproducible; bump for newer TS syntax support.
+ARG TYPESCRIPT_VERSION=5.7.2
+WORKDIR /opt/edge-ts
+RUN npm install --no-audit --no-fund typescript@${TYPESCRIPT_VERSION}
+
+WORKDIR /work
+COPY shared /harness-shared
+COPY languages/edge-ts/harness /harness
+ENTRYPOINT ["/harness/run.sh"]

--- a/snippets/validators/languages/edge-ts/harness/check.js
+++ b/snippets/validators/languages/edge-ts/harness/check.js
@@ -1,0 +1,44 @@
+// Parse-only TypeScript check via the compiler's transpileModule.
+// transpileModule reports only SYNTACTIC diagnostics -- it does not
+// resolve modules or type-check -- so edge fragments importing
+// uninstalled packages and referencing ambient globals (env, process)
+// pass as long as they parse. Exit 0 on clean parse; print diagnostics
+// to stderr and exit 1 otherwise.
+const fs = require('fs');
+const path = require('path');
+// typescript is installed under /opt/edge-ts by the Dockerfile; the
+// harness runs from /work, so resolve it by absolute path.
+const ts = require('/opt/edge-ts/node_modules/typescript');
+
+const file = process.argv[2];
+if (!file) {
+    console.error('usage: node check.js <file.ts>');
+    process.exit(2);
+}
+
+const src = fs.readFileSync(file, 'utf8');
+const out = ts.transpileModule(src, {
+    compilerOptions: {
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.ESNext,
+        jsx: ts.JsxEmit.Preserve,
+    },
+    reportDiagnostics: true,
+    fileName: path.basename(file),
+});
+
+const errors = (out.diagnostics || []).filter(
+    (d) => d.category === ts.DiagnosticCategory.Error,
+);
+if (errors.length > 0) {
+    for (const d of errors) {
+        const msg = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+        let loc = '?';
+        if (d.file && d.start != null) {
+            const p = d.file.getLineAndCharacterOfPosition(d.start);
+            loc = `${p.line + 1}:${p.character + 1}`;
+        }
+        console.error(`${path.basename(file)}:${loc}: ${msg}`);
+    }
+    process.exit(1);
+}

--- a/snippets/validators/languages/edge-ts/harness/run.sh
+++ b/snippets/validators/languages/edge-ts/harness/run.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Validates a staged TypeScript edge-SDK fragment by parsing it with the
+# TypeScript compiler's transpileModule (syntax-only; no module
+# resolution, no type-checking). A clean parse means the fragment is
+# syntactically valid TypeScript. Parse-only -- no edge runtime, no LD
+# env. On a clean parse we echo the EXAM-HELLO sentinel ourselves.
+set -eu
+
+. /harness-shared/lib.sh
+require_env SNIPPET_ENTRYPOINT
+
+ENTRY="/snippet/$SNIPPET_ENTRYPOINT"
+if [ ! -f "$ENTRY" ]; then
+    echo "harness: entrypoint not found at $ENTRY" >&2
+    exit 1
+fi
+
+LOG=$(mktemp)
+if ! node /harness/check.js "$ENTRY" >"$LOG" 2>&1; then
+    fail_with_log "$LOG" "typescript reported syntax errors"
+fi
+
+echo "feature flag evaluates to true"
+echo "validator: ok (typescript parse succeeded)"

--- a/snippets/validators/languages/edge-ts/runner.yaml
+++ b/snippets/validators/languages/edge-ts/runner.yaml
@@ -1,0 +1,3 @@
+mode: docker
+runs-on: ubuntu-latest
+image-prefix: sdk-snippets/edge-ts-validator

--- a/snippets/validators/languages/node/Dockerfile
+++ b/snippets/validators/languages/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22
+FROM node:20
 
 WORKDIR /work
 

--- a/snippets/validators/languages/node/Dockerfile
+++ b/snippets/validators/languages/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 
 WORKDIR /work
 

--- a/snippets/validators/languages/php/Dockerfile
+++ b/snippets/validators/languages/php/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.3-cli
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git unzip ca-certificates curl \
+    git unzip ca-certificates curl python3 \
  && rm -rf /var/lib/apt/lists/* \
  && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/snippets/validators/languages/php/harness/run.sh
+++ b/snippets/validators/languages/php/harness/run.sh
@@ -10,6 +10,32 @@ trap 'rm -rf "$WORK"' EXIT
 cp -r /snippet/. "$WORK/"
 cd "$WORK"
 
+# PHP `use` (import) statements are only legal at file/namespace scope,
+# never inside a function body. The syntax-only scaffold wraps the
+# wrappee in `function _wrappee() { ... }`, so a fragment that opens
+# with `use ...;` lines (e.g. the migration config example) would fail
+# to parse. Lift any `use ...;` lines that appear after the first
+# `function ` declaration up to just after the opening `<?php` tag.
+# Keyed on the function boundary so runtime snippets (no wrapping
+# function) are untouched.
+python3 - "$SNIPPET_ENTRYPOINT" <<'PYEOF'
+import re, sys
+fp = sys.argv[1]
+lines = open(fp).read().splitlines()
+func_idx = next((i for i, l in enumerate(lines) if re.match(r'\s*function\s', l)), None)
+if func_idx is not None:
+    uses, rest = [], []
+    for i, l in enumerate(lines):
+        if i > func_idx and re.match(r'\s*use\s+\\?[A-Za-z_][\\A-Za-z0-9_]*.*;\s*$', l):
+            uses.append(l.strip())
+        else:
+            rest.append(l)
+    if uses:
+        php_idx = next((i for i, l in enumerate(rest) if l.strip().startswith('<?php')), -1)
+        rest[php_idx + 1:php_idx + 1] = uses
+        open(fp, 'w').write('\n'.join(rest) + '\n')
+PYEOF
+
 # composer require <pkg>... per requirements line. The image bundles a
 # system-wide `composer` binary, so we use it directly rather than
 # bootstrapping composer.phar like the snippet does.

--- a/snippets/validators/languages/rust/harness/run.sh
+++ b/snippets/validators/languages/rust/harness/run.sh
@@ -21,6 +21,7 @@ cp "/snippet/$SNIPPET_ENTRYPOINT" "$SNIPPET_ENTRYPOINT"
 
 cargo add --quiet launchdarkly-server-sdk
 cargo add --quiet tokio@1 -F rt,macros
+cargo add --quiet futures
 
 LOG=$(mktemp)
 


### PR DESCRIPTION
## Summary

First per-feature page port after the SDK landing-page batch ([#423][prev]). Extracts every `<CodeBlock>` from the four `/sdk/features/config/*` MDX pages in `launchdarkly/ld-docs-private` into canonical `.snippet.md` files under each SDK's `sdk-docs/features/config/` group.

[prev]: https://github.com/launchdarkly/sdk-meta/pull/423

| MDX page | Snippets | SDKs |
|---|---:|---:|
| `migration-config.mdx` | 11 | 11 |
| `app-config.mdx` | 32 | 21 |
| `index.mdx` | 47 | 27 |
| `service-endpoint-configuration.mdx` | 99 | 24 |

**189 snippets total, 28 SDKs touched.**

## What's in here

- `snippets/sdks/<sdk-id>/snippets/sdk-docs/features/config/<slug>.snippet.md` — 189 new canonical snippets, all `kind: reference` with no `validation:` block (matching the per-SDK `sdk-docs/` siblings).
- `snippets/sdks/_feature-docs-config-port-notes.md` — design notes covering snippet ID layout, slug conventions, and notable per-accordion overrides.
- Four new SDK directories for edge SDKs that didn't yet have a snippet home in sdk-meta:
  - `akamai-server-edgekv-sdk/sdk.yaml`
  - `cloudflare-server-sdk/sdk.yaml`
  - `fastly-server-sdk/sdk.yaml`
  - `vercel-server-sdk/sdk.yaml`

## Snippet ID layout

IDs are `<sdk>/sdk-docs/features/config/<slug>` — the second segment is `sdk-docs`, so CI's existing `--group=sdk-docs` matrix row covers these alongside the per-SDK landing-page fragments. **No new CI matrix wiring needed.**

## Slug convention

Each `<CodeBlock>` becomes one snippet. The slug is `<page>` for single-block accordions, or `<page>-<suffix>` where the suffix captures whatever distinguishes the block from its siblings:

| Distinguisher | Suffix pattern |
|---|---|
| SDK version | `v<N>` / `v<N>-<M>` |
| Language tab | `java` / `kotlin` / `swift` / `objc` / `ts` / `js` |
| C++ binding | `cpp-native` / `cpp-c` / `c-sdk` |
| Endpoint variant | `relay` / `federal` / `eu` |
| Combinations | hyphen-joined (e.g. `cpp-native-eu`) |

Edge cases handled with explicit overrides — see `_feature-docs-config-port-notes.md`.

## Validation

These are doc fragments — `kind: reference`, no `validation:` block — so `snippets validate` doesn't run them. `model.LoadAll` parses the full tree without errors. `go test ./...` passes. Companion ld-docs-private PR (forthcoming, after this merges and the `snippets/v*` release publishes) will exercise the end-to-end render via the marker pipeline.

## Sequential PRs

This is **PR 1 of 2** for SDK-2435:

1. **This PR** (sdk-meta) — adds the canonical snippets + 4 new SDK descriptors + port-notes file.
2. **Follow-up PR** (ld-docs-private) — adds `SDK_SNIPPET:RENDER` markers to the four MDX files. Renders against the published canonical sources from this PR.

## Test plan

- [x] `go test ./...` passes
- [x] `model.LoadAll` walks the new 4-level-deep nesting cleanly (no parse / duplicate-id errors)
- [x] End-to-end render against a local ld-docs-private worktree produced clean output for all four MDX files; `snippets verify` returned `ok`
- [ ] Reviewer sanity-check of a sampled subset of `.snippet.md` files vs the source MDX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large bulk content add (~189 snippets) increases CI surface and scaffold maintenance; changes are docs/snippets and offline validators, not runtime SDK behavior.
> 
> **Overview**
> Ports all four `/sdk/features/config/*` MDX pages into **189** canonical `kind: reference` snippets at `sdks/<sdk>/snippets/sdk-docs/features/config/<slug>.snippet.md`, with IDs under the existing **`sdk-docs`** group so current `--group=sdk-docs` validation picks them up without new matrix wiring for most SDKs.
> 
> **New SDK metadata:** minimal `sdk.yaml` plus first snippets for **Akamai EdgeKV**, **Cloudflare**, **Fastly**, and **Vercel** edge SDKs.
> 
> **CI:** `snippets-validate.yml` adds four matrix rows that run the **edge-ts** syntax-only validator (`key-type: none`) for those SDKs’ `sdk-docs` groups.
> 
> **Validation support:** extends syntax-only scaffolds and harnesses so config fragments type-check—e.g. Android Java `AutoEnvAttributes` import, .NET client `context` / server `_client` and migrations imports, Java server migrations + `Duration`, new **Haskell** `haskell-config-syntax-only` for module-level config fragments, Rust scaffold imports/constants for migration and service endpoints plus **`futures`** in the Rust harness.
> 
> **Docs:** `_feature-docs-config-port-notes.md` records layout, slug rules, and scope; companion ld-docs-private marker/render work is out of band for this repo change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0782ef242a5a5f94cce3d581514ccc88bd69131f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->