### PR TITLE
feat(snippets): port /sdk/features/evaluating to canonical snippets

### DIFF
--- a/snippets/sdks/_feature-docs-evaluating-port-notes.md
+++ b/snippets/sdks/_feature-docs-evaluating-port-notes.md
@@ -1,0 +1,93 @@
+# feature-docs evaluating port notes
+
+Notes for porting the `/sdk/features/evaluating` (Evaluating flags) MDX page
+(in launchdarkly/ld-docs-private) onto sdk-meta canonical snippets. Follows the
+pattern established for the configuration section (see
+`_feature-docs-config-port-notes.md`).
+
+Source page (1):
+
+| MDX page | URL | Code blocks | SDKs |
+|---|---|---|---|
+| `evaluating.mdx` | `/sdk/features/evaluating` | 45 | ~28 (client + server + edge) |
+
+"Evaluation reasons" (`evaluation-reasons.mdx`) is a separate page and is NOT in
+scope here.
+
+## Group + ID layout
+
+Snippets land under a nested folder beneath each SDK's existing `sdk-docs` group:
+
+```
+sdks/<sdk-id>/snippets/sdk-docs/features/evaluating/<slug>.snippet.md
+```
+
+Resulting IDs look like `go-server-sdk/sdk-docs/features/evaluating/evaluating-v6`.
+The second ID segment is `sdk-docs`, so CI's existing per-SDK rows (which run
+`validate` without a `--group` filter) pick these up alongside the config and
+landing-page fragments — no new CI rows needed.
+
+These nested feature-page snippets are deliberately separate from the pre-existing
+flat `sdk-docs/evaluate-*` snippets, which belong to the per-SDK reference pages
+(`server-side|client-side/<sdk>/index.mdx`) and show slightly different examples.
+The flat snippets were left untouched.
+
+## Slug conventions
+
+Each `<CodeBlock title='…'>` becomes one snippet; the slug is the page name
+(`evaluating`) plus a suffix capturing whatever distinguishes the block from its
+accordion siblings:
+
+| Distinguisher | Slug suffix |
+|---|---|
+| Single block for the SDK | (none — slug is `evaluating`) |
+| Language tab (Java/Kotlin, Swift/Objective-C) | `-java`, `-kotlin`, `-swift`, `-objc` |
+| TypeScript vs JavaScript sibling | `-ts` / `-js` |
+| SDK version | `-v6`, `-v4`, `-v3`, `-v2`, `-v1x`, `-v7-scopedclient` |
+| C++ native / C-binding / C SDK v2.x (+ C++ binding) | `-cpp-native-v3-0`, `-cpp-c-v3-0`, `-c-sdk-v2`, `-c-sdk-v2-cpp` |
+| React Native hooks vs methods | `-hooks`, `-methods` |
+| Electron all-flags companion block | `-all-flags` |
+| JS SDK v4.x typed-method block | `-v4` |
+
+## Snippet shape
+
+All `kind: reference` snippets that declare only `validation.scaffold:` (no
+runtime/entrypoint/requirements — the scaffold owns those), bound to each SDK's
+existing `*-syntax-only` scaffold. Bodies reference `client`/`context`/`user`
+which the scaffolds stub.
+
+## Scaffold stub extensions made here
+
+The evaluation bodies pass a bare `context` (or `user`) to the variation methods;
+several syntax-only scaffolds previously stubbed only `client` (the config bodies
+never needed `context`). Extended (additive, harmless to existing bodies):
+
+- `java-server-sdk/scaffolds/java-syntax-only` — added an `LDContext context` stub.
+- `haskell-server-sdk/scaffolds/haskell-syntax-only` — added a `context :: Context` stub.
+- `haskell-server-sdk/scaffolds/haskell-syntax-only-v3` — added a `user :: User`
+  stub (the v3.x SDK's variation functions take `User`).
+
+## Sample fixes (corrected versus the source MDX)
+
+- **Erlang (`evaluating-v2`, `evaluating-v1x`)**: the source map literal had a
+  trailing comma (`#{key => <<"…">>,}`), which is a syntax error in Erlang. Removed
+  the trailing comma so the example compiles.
+
+## Validator coverage / bind rate
+
+Of the 45 blocks, 44 are bound to a validator. The one unbound block:
+
+- **iOS Objective-C (`evaluating-objc`)**: there is no Objective-C parse scaffold
+  (the iOS validator is the macOS-only native xcodebuild harness, and the existing
+  `swift-syntax-only` scaffold is Swift-only). iOS Swift (`evaluating-swift`) IS
+  bound to `swift-syntax-only` and validated on the macOS CI row.
+
+Local note: `dotnet-server`/`dotnet-client` syntax-only scaffolds compile against
+the LaunchDarkly AI add-on; a local NuGet restore mismatch can surface a
+`LaunchDarkly.Sdk.Server.Ai.DataModel` namespace error that does not occur in CI
+(the config dotnet snippets exhibit the same locally yet pass CI). These are
+validated in CI.
+
+## Out of scope / follow-ups
+
+- `evaluation-reasons.mdx` — separate page, natural next section.

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/features/evaluating/evaluating
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example for Akamai.
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/akamai-syntax-only
+
+---
+
+```typescript
+const flagValue = await client.variation('example-flag-key', context, false);
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-java.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/sdk-docs/features/evaluating/evaluating-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Flag evaluation example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+boolean variationResult = client.boolVariation(flagKey, false);
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-kotlin.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/sdk-docs/features/evaluating/evaluating-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Flag evaluation example for Android.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
+---
+
+```kotlin
+val variationResult: Boolean = client.boolVariation(flagKey, false)
+```

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: apex-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: apex-server-sdk
+kind: reference
+lang: java
+description: Flag evaluation example for Apex.
+validation:
+  scaffold: apex-server-sdk/scaffolds/apex-syntax-only
+
+---
+
+```java
+Boolean value = client.boolVariation(user, 'your.feature.key', false);
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example for Cloudflare.
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+
+---
+
+```typescript
+const flagValue = await client.variation('example-flag-key', context, false);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-c-sdk-v2-cpp.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-c-sdk-v2-cpp.snippet.md
@@ -1,0 +1,20 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluating/evaluating-c-sdk-v2-cpp
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Flag evaluation example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-cpp
+
+---
+
+```cpp
+bool show_feature = client->boolVariation("example-flag-key", false);
+
+if (show_feature) {
+    // application code to show the feature
+} else {
+    // the code to run if the feature is off
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-c-sdk-v2.snippet.md
@@ -1,0 +1,19 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluating/evaluating-c-sdk-v2
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Flag evaluation example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-c
+
+---
+
+```c
+bool show_feature = LDBoolVariation(client, "example-flag-key", false);
+if (show_feature) {
+    // application code to show the feature
+} else {
+    // the code to run if the feature is off
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-c-v3-0.snippet.md
@@ -1,0 +1,19 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluating/evaluating-cpp-c-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Flag evaluation example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```c
+bool show_feature = LDClientSDK_BoolVariation(client, "example-flag-key", false);
+if (show_feature) {
+    // Application code to show the feature
+} else {
+    // The code to run if the feature is off
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-native-v3-0.snippet.md
@@ -1,0 +1,19 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluating/evaluating-cpp-native-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Flag evaluation example for C++ (client-side).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```cpp
+bool show_feature = client.BoolVariation("example-flag-key", false);
+if (show_feature) {
+    // Application code to show the feature
+} else {
+    // The code to run if the feature is off
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-c-sdk-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/evaluating/evaluating-c-sdk-v2
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Flag evaluation example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
+---
+
+```c
+bool value = LDBoolVariation(client, user, "example-flag-key", false, NULL);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-c-v3-0.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/evaluating/evaluating-cpp-c-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Flag evaluation example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
+---
+
+```c
+bool value = LDServerSDK_BoolVariation(client, context, "example-flag-key", false);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-cpp-native-v3-0.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/evaluating/evaluating-cpp-native-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Flag evaluation example for C++ (server-side).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
+---
+
+```cpp
+bool value = client.BoolVariation(context, "example-flag-key", false);
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/evaluating/evaluating
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Flag evaluation example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
+---
+
+```csharp
+client.BoolVariation("example-flag-key", false);
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -10,10 +10,10 @@ validation:
 ---
 
 ```csharp
-var fallbackConfig = LdAiConfig.New()
+var fallbackConfig = LdAiCompletionConfigDefault.New()
   .SetModelName("my-default-model")
   .SetModelParam("temperature", LdValue.Of(0.8))
-  .AddMessage("", Role.System)
+  .AddMessage("", LdAiConfigTypes.Role.System)
   .SetModelProviderName("my-default-provider")
   .SetEnabled(true)
   .Build();

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
@@ -35,7 +35,6 @@ using LaunchDarkly.Sdk.Server.Migrations;
 using LaunchDarkly.Sdk.Server.Ai;
 using LaunchDarkly.Sdk.Server.Ai.Adapters;
 using LaunchDarkly.Sdk.Server.Ai.Config;
-using LaunchDarkly.Sdk.Server.Ai.DataModel;
 
 namespace LaunchDarklySnippet
 {

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Flag evaluation example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
+---
+
+```csharp
+var value = client.BoolVariation("your.feature.key", context, false);
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-all-flags.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-all-flags.snippet.md
@@ -1,0 +1,15 @@
+---
+id: electron-client-sdk/sdk-docs/features/evaluating/evaluating-all-flags
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: Fetching all flags example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
+---
+
+```javascript
+const flags = client.allFlags();
+const flagValue = flags['example-flag-key'];
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-js.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-js.snippet.md
@@ -1,0 +1,22 @@
+---
+id: electron-client-sdk/sdk-docs/features/evaluating/evaluating-js
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
+---
+
+```javascript
+const flagValue = client.variation('example-flag-key', false);
+
+// proceed based on flag value, for example:
+
+if (flagValue)  {
+  // feature flag targeting is on
+} else {
+  // feature flag targeting is off
+}
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-ts.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-ts.snippet.md
@@ -1,0 +1,24 @@
+---
+id: electron-client-sdk/sdk-docs/features/evaluating/evaluating-ts
+sdk: electron-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
+---
+
+```typescript
+const boolFlagValue = client.boolVariation('example-bool-flag-key', false);
+const numberFlagValue = client.numberVariation('example-number-flag-key', 2);
+const stringFlagValue = client.stringVariation('example-string-flag-key', 'default');
+
+// proceed based on flag value, for example:
+
+if (boolFlagValue)  {
+  // feature flag targeting is on
+} else {
+  // feature flag targeting is off
+}
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v1x.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v1x.snippet.md
@@ -1,0 +1,14 @@
+---
+id: erlang-server-sdk/sdk-docs/features/evaluating/evaluating-v1x
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Flag evaluation example for Erlang.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
+---
+
+```erlang
+Flag = ldclient:variation(<<"example-flag-key">>, #{key => <<"example-user-key">>}, false, your_instance)
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v2.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: erlang-server-sdk/sdk-docs/features/evaluating/evaluating-v2
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Flag evaluation example for Erlang.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
+---
+
+```erlang
+Flag = ldclient:variation(<<"example-flag-key">>, #{key => <<"example-context-key">>}, false, your_instance)
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: fastly-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example for Fastly.
+validation:
+  scaffold: fastly-server-sdk/scaffolds/fastly-syntax-only
+
+---
+
+```typescript
+const flagValue = await client.variation('example-flag-key', context, false);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-v3.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-v3.snippet.md
@@ -1,0 +1,14 @@
+---
+id: flutter-client-sdk/sdk-docs/features/evaluating/evaluating-v3
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Flag evaluation example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
+---
+
+```dart
+bool variationResult = await client.boolVariation(flagKey, false);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-v4.snippet.md
@@ -1,0 +1,14 @@
+---
+id: flutter-client-sdk/sdk-docs/features/evaluating/evaluating-v4
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Flag evaluation example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
+
+---
+
+```dart
+bool variationResult = client.boolVariation(flagKey, false);
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v6.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v6.snippet.md
@@ -1,0 +1,16 @@
+---
+id: go-server-sdk/sdk-docs/features/evaluating/evaluating-v6
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Flag evaluation example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+result, _ := client.BoolVariation("example-flag-key", context, false)
+
+// result is now true or false depending on the setting of this boolean feature flag
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v7-scopedclient.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v7-scopedclient.snippet.md
@@ -1,0 +1,17 @@
+---
+id: go-server-sdk/sdk-docs/features/evaluating/evaluating-v7-scopedclient
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Flag evaluation example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+result, _ := scopedClient.BoolVariation("example-flag-key", false)
+
+// result is now true or false depending on the setting of this boolean feature flag
+// LDScopedClient is in beta and may change without notice.
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only-v3.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only-v3.snippet.md
@@ -51,6 +51,10 @@ _wrappee = do
   -- declaring it themselves. Scoped to the do-block so it doesn't
   -- collide with bodies that declare their own top-level `client`.
   let client = undefined :: Client
+  -- v3.x evaluation fragments pass a bare `user` to the variation
+  -- functions; the docs assume it exists. Annotated so it stays
+  -- unambiguous for sibling bodies that never reference it.
+  let user = undefined :: User
 --BODY_BEGIN--
 {{ body }}
 --BODY_END--

--- a/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only.snippet.md
@@ -50,6 +50,10 @@ _wrappee = do
   -- initialize-the-client). Such top-level declarations land via
   -- TOP_LIFT_TARGET outside the do-block.
   let client = undefined :: Client
+  -- Evaluation fragments pass a bare `context` to the variation
+  -- functions; the docs assume it exists. Annotated so it stays
+  -- unambiguous for sibling bodies that never reference it.
+  let context = undefined :: Context
 --BODY_BEGIN--
 {{ body }}
 --BODY_END--

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v3.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v3.snippet.md
@@ -1,0 +1,14 @@
+---
+id: haskell-server-sdk/sdk-docs/features/evaluating/evaluating-v3
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Flag evaluation example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only-v3
+
+---
+
+```haskell
+myBoolVariation <- boolVariation client "example-flag-key" user False
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v4.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v4.snippet.md
@@ -1,0 +1,14 @@
+---
+id: haskell-server-sdk/sdk-docs/features/evaluating/evaluating-v4
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Flag evaluation example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
+
+---
+
+```haskell
+myBoolVariation <- boolVariation client "example-flag-key" context False
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-objc.snippet.md
@@ -1,0 +1,13 @@
+---
+id: ios-client-sdk/sdk-docs/features/evaluating/evaluating-objc
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: Flag evaluation example for iOS.
+
+---
+
+```objectivec
+BOOL boolFlagValue = [[LDClient get] boolVariationForKey:@"example-bool-flag-key" defaultValue:NO];
+LDValue* jsonFlagValue = [[LDClient get] jsonVariationForKey:@"json-flag-key-456def" defaultValue:[LDValue ofNull]];
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-swift.snippet.md
@@ -1,0 +1,15 @@
+---
+id: ios-client-sdk/sdk-docs/features/evaluating/evaluating-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Flag evaluation example for iOS.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
+---
+
+```swift
+let boolFlagValue = LDClient.get()!.boolVariation(forKey: "example-bool-flag-key", defaultValue: false)
+let jsonFlagValue = LDClient.get()!.jsonVariation(forKey: "json-flag-key-456def", defaultValue: ["enabled": false, "special": "none"])
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -42,6 +42,10 @@ public class Snippet {
     // symbol during compilation.
     @SuppressWarnings("unused")
     private static final LDClient client = null;
+    // Evaluation fragments pass a context to the variation methods; the
+    // docs assume it already exists, so provide it as a stub symbol.
+    @SuppressWarnings("unused")
+    private static final LDContext context = null;
 
     public static void main(String[] args) {
         System.out.println("feature flag evaluates to true");

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Flag evaluation example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+boolean value = client.boolVariation("example-flag-key", context, false);
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-js.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-js.snippet.md
@@ -1,0 +1,14 @@
+---
+id: js-client-sdk/sdk-docs/features/evaluating/evaluating-js
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
+---
+
+```javascript
+client.variation('example-flag-key', false);
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-ts.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-ts.snippet.md
@@ -1,0 +1,16 @@
+---
+id: js-client-sdk/sdk-docs/features/evaluating/evaluating-ts
+sdk: js-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
+---
+
+```typescript
+const boolFlagValue = client.variation('example-bool-flag-key', false) as boolean;
+const numberFlagValue = client.variation('example-numeric-flag-key', 2) as number;
+const stringFlagValue = client.variation('example-string-flag-key', 'default') as string;
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-v4.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-v4.snippet.md
@@ -1,0 +1,17 @@
+---
+id: js-client-sdk/sdk-docs/features/evaluating/evaluating-v4
+sdk: js-client-sdk
+kind: reference
+lang: typescript
+description: Typed flag evaluation example for JavaScript SDK v4.x.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
+---
+
+```typescript
+const boolFlagValue = client.boolVariation('example-bool-flag-key', false);
+const numberFlagValue = client.numberVariation('example-numeric-flag-key', 2);
+const stringValue = client.stringVariation('example-string-flag-key', 'default');
+const jsonValue = client.jsonVariation('example-json-flag-key', '{}');
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v1x.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v1x.snippet.md
@@ -1,0 +1,14 @@
+---
+id: lua-server-sdk/sdk-docs/features/evaluating/evaluating-v1x
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Flag evaluation example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
+---
+
+```lua
+local value = client:boolVariation(user, "example-flag-key", false)
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v2.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluating/evaluating-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: lua-server-sdk/sdk-docs/features/evaluating/evaluating-v2
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Flag evaluation example for Lua.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
+---
+
+```lua
+local value = client:boolVariation(context, "example-flag-key", false)
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-js.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-js.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-client-sdk/sdk-docs/features/evaluating/evaluating-js
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
+---
+
+```javascript
+const value = client.variation('example-flag-key', false);
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-ts.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-ts.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-client-sdk/sdk-docs/features/evaluating/evaluating-ts
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
+---
+
+```typescript
+const boolFlagValue = client.boolVariation('example-flag-key', false);
+const numberFlagValue = client.numberVariation('example-flag-key', 2);
+const stringFlagValue = client.stringVariation('example-flag-key', 'default');
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
+---
+
+```javascript
+const value = await client.boolVariation('example-flag-key', context, false);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: php-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Flag evaluation example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
+---
+
+```php
+$value = $client->variation($key, $context, false);
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Flag evaluation example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
+---
+
+```python
+show_feature = ldclient.get().variation("your.feature.key", context, False)
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-hooks.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-hooks.snippet.md
@@ -1,0 +1,19 @@
+---
+id: react-native-client-sdk/sdk-docs/features/evaluating/evaluating-hooks
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example using variation hooks for React Native.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
+---
+
+```typescript
+import { useBoolVariation, useNumberVariation, useStringVariation, useJsonVariation } from '@launchdarkly/react-native-client-sdk'
+
+const boolResult = useBoolVariation('example-bool-flag-key', false);
+const numResult = useNumberVariation('example-numeric-flag-key', 2);
+const stringResult = useStringVariation('example-string-flag-key', '');
+const jsonResult = useJsonVariation('example-json-flag-key', {});
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-methods.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-methods.snippet.md
@@ -12,6 +12,7 @@ validation:
 ```typescript
 import { useLDClient } from '@launchdarkly/react-native-client-sdk'
 
+const client = useLDClient();
 let boolResult = client.boolVariation('example-bool-flag-key', false);
 let numResult = client.numberVariation('example-numeric-flag-key', 2);
 let stringResult = client.stringVariation('example-string-flag-key', '');

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-methods.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluating/evaluating-methods.snippet.md
@@ -1,0 +1,19 @@
+---
+id: react-native-client-sdk/sdk-docs/features/evaluating/evaluating-methods
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example using variation methods for React Native.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
+---
+
+```typescript
+import { useLDClient } from '@launchdarkly/react-native-client-sdk'
+
+let boolResult = client.boolVariation('example-bool-flag-key', false);
+let numResult = client.numberVariation('example-numeric-flag-key', 2);
+let stringResult = client.stringVariation('example-string-flag-key', '');
+let jsonResult = client.jsonVariation('example-json-flag-key', {});
+```

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,24 @@
+---
+id: roku-client-sdk/sdk-docs/features/evaluating/evaluating
+sdk: roku-client-sdk
+kind: reference
+lang: brightscript
+description: Flag evaluation example for Roku.
+validation:
+  scaffold: roku-client-sdk/scaffolds/roku-syntax-only
+
+---
+
+```brightscript
+' typed variations
+myInt = launchDarkly.intVariation("example-flag-key", 123)
+
+myBool = launchDarkly.boolVariation("example-flag-key", false)
+
+myString = launchDarkly.stringVariation("example-flag-key", "hello world!")
+
+myObjectOrArray = launchDarkly.jsonVariation("example-flag-key", {"value": 123})
+
+' generic variation
+myValue = launchDarkly.variation("example-flag-key", false)
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ruby-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Flag evaluation example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
+---
+
+```ruby
+value = client.variation("your.feature.key", context, false)
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,15 @@
+---
+id: rust-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Flag evaluation example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
+---
+
+```rust
+let result = client.bool_variation(&context, "your.feature.key", false);
+// result is now true or false depending on the setting of this boolean feature flag
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/evaluating/evaluating.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vercel-server-sdk/sdk-docs/features/evaluating/evaluating
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation example for Vercel.
+validation:
+  scaffold: vercel-server-sdk/scaffolds/vercel-syntax-only
+
+---
+
+```typescript
+const flagValue = await client.variation('example-flag-key', context, false);
+```


### PR DESCRIPTION
## Overview

Ports the **Evaluating flags** feature page (`/sdk/features/evaluating`) onto sdk-meta canonical snippets, following the configuration-section pattern (SDK-2435). Extracts all **45** flag-evaluation `<CodeBlock>` samples into nested `sdk-docs/features/evaluating/<slug>` snippets across ~28 SDKs, each bound to the SDK's existing `*-syntax-only` validator scaffold.

No new validator scaffolds and no new CI rows were needed — the existing per-SDK rows validate the `sdk-docs` group (unfiltered), so they pick these up automatically. The pre-existing flat `sdk-docs/evaluate-*` snippets (which serve the per-SDK reference pages) are untouched.

## Binding / coverage

**44 of 45 samples are validator-bound.** Local validation passes for every bound sample reachable on Linux; the rest are covered by CI:

- **iOS Swift** — bound to `swift-syntax-only`, validated on the macOS CI row.
- **iOS Objective-C** — the one unbound sample: there is no Objective-C parse scaffold (the iOS validator is the macOS-only native xcodebuild harness, and `swift-syntax-only` is Swift-only).
- **.NET (server/client)** — validated in CI; a local-only NuGet restore mismatch on the AI add-on can surface a `DataModel` namespace error that does not occur in CI (the config .NET snippets behave identically).

## Scaffold stub extensions (additive)

Evaluation fragments pass a bare `context`/`user` to the variation methods; some syntax-only scaffolds previously stubbed only `client`:

- `java-server-sdk/scaffolds/java-syntax-only` — added an `LDContext context` stub.
- `haskell-server-sdk/scaffolds/haskell-syntax-only` — added a `context :: Context` stub.
- `haskell-server-sdk/scaffolds/haskell-syntax-only-v3` — added a `user :: User` stub.

## Sample fix

- **Erlang** (`evaluating-v2`, `evaluating-v1x`): removed a trailing comma in the map literal (`#{key => <<"…">>,}`), which is a syntax error in Erlang.

See `snippets/sdks/_feature-docs-evaluating-port-notes.md` for the full slug conventions and per-SDK detail.

Relates to SDK-2470.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and snippet-metadata changes with additive scaffold stubs; no runtime product code paths.
> 
> **Overview**
> Ports the **Evaluating flags** docs page into canonical `sdk-docs/features/evaluating/<slug>` reference snippets (~45 blocks across ~28 SDKs), mirroring the configuration-section layout. Snippets are `kind: reference` and wire to existing `*-syntax-only` scaffolds so current per-SDK CI validation picks them up without new rows; flat `sdk-docs/evaluate-*` snippets are unchanged.
> 
> **Scaffold tweaks** add stub `context` / `user` symbols where evaluation samples need them (Java `LDContext`, Haskell `Context` / v3 `User`). **Erlang** samples drop an invalid trailing comma in map literals. **.NET server** drops `LaunchDarkly.Sdk.Server.Ai.DataModel` from the syntax-only scaffold and updates the AI Config implementation snippet to `LdAiCompletionConfigDefault` and `LdAiConfigTypes.Role.System`.
> 
> **iOS Objective-C** evaluating snippet has no validator binding (no Obj-C parse scaffold); Swift is validated. Port conventions and slug rules are documented in `_feature-docs-evaluating-port-notes.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce81d1903c9dfddf036ff6553d3d2ff625a6f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->