### PR TITLE
fix(snippets): update dotnet AI Configs snippets for ServerSdk.Ai v0.10.0

### DIFF
--- a/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/ai-configs/implementation.snippet.md
@@ -10,10 +10,10 @@ validation:
 ---
 
 ```csharp
-var fallbackConfig = LdAiConfig.New()
+var fallbackConfig = LdAiCompletionConfigDefault.New()
   .SetModelName("my-default-model")
   .SetModelParam("temperature", LdValue.Of(0.8))
-  .AddMessage("", Role.System)
+  .AddMessage("", LdAiConfigTypes.Role.System)
   .SetModelProviderName("my-default-provider")
   .SetEnabled(true)
   .Build();

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
@@ -35,7 +35,6 @@ using LaunchDarkly.Sdk.Server.Migrations;
 using LaunchDarkly.Sdk.Server.Ai;
 using LaunchDarkly.Sdk.Server.Ai.Adapters;
 using LaunchDarkly.Sdk.Server.Ai.Config;
-using LaunchDarkly.Sdk.Server.Ai.DataModel;
 
 namespace LaunchDarklySnippet
 {


### PR DESCRIPTION
## Overview

The `dotnet-server-sdk` validation row is red because the AI Configs doc snippets drifted from the current published `LaunchDarkly.ServerSdk.Ai` (v0.10.0). This is pre-existing: the `snippets-validate` workflow only runs on PRs, so the breakage (introduced when v0.10.0 released after the ai-configs slice was first validated) surfaced on the next PR to touch dotnet-server.

This is a predecessor fix so the `/sdk/features/evaluating` port (SDK-2470, #459) can rebase onto it and go green.

## Changes

- **`csharp-syntax-only` scaffold**: drop `using LaunchDarkly.Sdk.Server.Ai.DataModel;` — that namespace no longer exists in v0.10.0 (CS0234), which failed *every* dotnet-server sdk-docs snippet that compiles through the scaffold. The remaining `Ai` / `Ai.Adapters` / `Ai.Config` usings are still valid.
- **`ai-configs/implementation`**: update to the v0.10.0 API — `LdAiConfig.New()` → `LdAiCompletionConfigDefault.New()`, `Role.System` → `LdAiConfigTypes.Role.System`. (`ai-configs/context` is pure `Context.Builder` and needed no change once the scaffold compiles.)

## Verification

Local `snippets validate --sdk=dotnet-server-sdk` passes for the full dotnet-server set, including `ai-configs/context`, `ai-configs/implementation`, and the config/evaluating sdk-docs snippets.

Relates to SDK-2473.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation snippet and compile-scaffold edits only; no runtime product code or security-sensitive paths.
> 
> **Overview**
> Aligns **dotnet-server-sdk** doc snippets with **LaunchDarkly.ServerSdk.Ai v0.10.0** so `snippets validate` compiles again.
> 
> The shared **`csharp-syntax-only`** scaffold drops `using LaunchDarkly.Sdk.Server.Ai.DataModel` because that namespace was removed in v0.10.0 (CS0234), which blocked every snippet that builds through that harness.
> 
> The **`ai-configs/implementation`** example updates fallback construction: `LdAiConfig.New()` → `LdAiCompletionConfigDefault.New()`, and `Role.System` → `LdAiConfigTypes.Role.System`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be34b03dcc02b7d1430d6f904b34bd87d4a0a0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->