### PR TITLE
fix(snippets): bind Android Java observability snippets (obs-android 0.54.0)

### DIFF
--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -58,6 +58,15 @@ import com.launchdarkly.sdk.android.*;
 // reach nested types, so config/init bodies referencing
 // `AutoEnvAttributes.Enabled` need this explicit import.
 import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes;
+// Observability plugin surfaces for the v5.x init / import fragments:
+// `Plugin` (integrations), the `Observability` plugin, and its
+// `ObservabilityOptions` (with the Java-friendly builder added in
+// launchdarkly-observability-android 0.54.0). `java.util.Collections`
+// covers the `Collections.<Plugin>singletonList(...)` plugin list.
+import com.launchdarkly.sdk.android.integrations.*;
+import com.launchdarkly.observability.plugin.*;
+import com.launchdarkly.observability.api.*;
+import java.util.Collections;
 
 // No `public` modifier: Java requires public top-level classes to
 // live in a file matching the class name. We need this scaffold's

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/import-the-sdk-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/import-the-sdk-java.snippet.md
@@ -4,15 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: "Java in section \"Import the SDK\""
-# TODO(snippet-bug): the last two `import` lines are missing trailing
-# semicolons (Kotlin-style imports mistakenly pasted into a Java
-# code block in the source MDX). javac rejects them at parse. Also
-# the observability AAR isn't on the android-client validator's
-# classpath, so even with semicolons the names wouldn't resolve.
-# Fix in the snippet-bugs PR: add semicolons and add the
-# launchdarkly-observability-android dependency to the validator's
-# pre-baked app/build.gradle, or split into separate Java vs Kotlin
-# snippets.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
 ---
 
 ```java
@@ -20,6 +13,6 @@ import com.launchdarkly.sdk.*;
 import com.launchdarkly.sdk.android.*;
 
 // optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
-import com.launchdarkly.observability.plugin.Observability
-import com.launchdarkly.sdk.android.integrations.Plugin
+import com.launchdarkly.observability.plugin.Observability;
+import com.launchdarkly.sdk.android.integrations.Plugin;
 ```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-java.snippet.md
@@ -4,13 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: java
 description: "Android SDK v5.x (Java) in section \"Initialize the client\""
-# TODO(snippet-bug): body has Kotlin syntax in a `java` code block:
-# (1) `Observability(this.getApplication())` — Java requires `new`
-# before a constructor call; (2)
-# `Collections.singletonList<Plugin>(...)` — Java type arguments
-# on a method call must precede the method name
-# (`Collections.<Plugin>singletonList(...)`), not follow it. Fix in
-# the snippet-bugs PR.
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
 ---
 
 ```java
@@ -18,7 +13,9 @@ LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
     .mobileKey("example-mobile-key")
     // optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
     .plugins(Components.plugins().setPlugins(
-      Collections.singletonList<Plugin>(Observability(this.getApplication()))
+      Collections.<Plugin>singletonList(
+        new Observability(this.getApplication(), "example-mobile-key", ObservabilityOptions.builder().build())
+      )
     ))
     // other options
     .build();

--- a/snippets/validators/languages/android-client/Dockerfile
+++ b/snippets/validators/languages/android-client/Dockerfile
@@ -43,7 +43,7 @@ ARG ROBOLECTRIC_VERSION=4.12.2
 # initialize-the-client-android-sdk-v5-x-* show the v5.9+ pattern
 # `Components.plugins().setPlugins(listOf(Observability(this@…)))`,
 # which references the launchdarkly-observability-android package.
-ARG LD_ANDROID_OBSERVABILITY_VERSION=0.49.0
+ARG LD_ANDROID_OBSERVABILITY_VERSION=0.54.0
 
 RUN git clone --depth 1 --branch "${HELLO_ANDROID_REF}" \
         https://github.com/launchdarkly/hello-android.git /opt/hello-android

--- a/snippets/validators/languages/android-client/harness/run.sh
+++ b/snippets/validators/languages/android-client/harness/run.sh
@@ -85,7 +85,16 @@ saw_func = False
 out = []
 for line in lines:
     s = line.strip()
-    if re.match(r"^\s*(override\s+)?fun\s+", line):
+    # Mark the end of the file-scope import region. Kotlin bodies open
+    # with `fun`/`override fun`; Java bodies have no `fun`, so also
+    # trip on the first type declaration (`class`/`object`/`interface`/
+    # `enum`). In both languages every legal file-scope import precedes
+    # the first such line, so any `import` after it is a misplaced body
+    # import to hoist.
+    if re.match(r"^\s*(override\s+)?fun\s+", line) or re.match(
+        r"^\s*((public|private|protected|final|abstract|open|internal|sealed|data|static)\s+)*(class|object|interface|enum)\s+",
+        line,
+    ):
         saw_func = True
     if saw_func:
         m = re.match(r"^\s*(import\s+[A-Za-z_][A-Za-z0-9_.]*\*?\s*;?\s*)$", line)
@@ -98,10 +107,14 @@ for line in lines:
             file_imports.add(m.group(1).rstrip(';').strip())
     out.append(line)
 
+# Imports are collected with their trailing `;` stripped (so Kotlin and
+# Java forms dedup against each other). Java requires the semicolon when
+# re-inserted at file scope; Kotlin must not have one.
+is_java = path.endswith(".java")
 new_top = []
 for imp in in_func_imports:
     if imp not in file_imports:
-        new_top.append(imp)
+        new_top.append(imp + ";" if is_java else imp)
         file_imports.add(imp)
 
 if new_top:


### PR DESCRIPTION
## Overview

The Android **Java** observability doc snippets were deferred during the sdk-docs port because `launchdarkly-observability-android` 0.49.0 had no Java-usable way to construct the optional `Observability` plugin (the constructor's `ObservabilityOptions` arg had no builder/no-arg ctor and there is no `@JvmOverloads`). **0.54.0** adds the Java-friendly `ObservabilityOptions.builder()`, so the plugin now has a valid Java form. This binds the two deferred Java snippets and validates them.

## Changes

- **Validator**: bump pinned `launchdarkly-observability-android` 0.49.0 → **0.54.0** (`validators/languages/android-client/Dockerfile`).
- **`java-syntax-only` scaffold**: add file-scope imports for `com.launchdarkly.sdk.android.integrations.*`, `com.launchdarkly.observability.plugin.*`, `com.launchdarkly.observability.api.*`, and `java.util.Collections` so the init/import bodies resolve.
- **`initialize-the-client-android-sdk-v5-x-java`**: use the valid 3-arg form `new Observability(this.getApplication(), "example-mobile-key", ObservabilityOptions.builder().build())` and the correct `Collections.<Plugin>singletonList(...)` type-argument placement (Java type args precede the method name); bind to the scaffold.
- **`import-the-sdk-java`**: add the two missing import semicolons; bind to the scaffold.
- **`android-client` harness import-lift**: the lift previously detected the function body via the Kotlin `fun` keyword only, so it never hoisted imports out of a Java method body. Now it also ends the file-scope import region at the first type declaration (`class`/`object`/`interface`/`enum`) and re-adds the trailing `;` when hoisting Java imports. Kotlin behavior is unchanged (verified: the Kotlin init/import snippets and an existing code-only Java snippet still pass).

## Verification

Local `snippets validate --sdk=android-client-sdk` passes for `initialize-the-client-android-sdk-v5-x-{java,kotlin}`, `import-the-sdk-{java,kotlin}`, and (regression) `features/config/app-config-java`.

## Note (separate, not fixed here)

The observability-sdk README's inline **Java** example shows the 2-arg `new Observability(this, mobileKey)`, which does not compile — the `Observability` constructor has no `@JvmOverloads`, so Java must pass the 3rd `ObservabilityOptions` arg (as the compiled `BaseApplication.java` example app does, and as this snippet now does). Worth a follow-up to add `@JvmOverloads` or fix that README block.

Relates to SDK-2487.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation snippets and validator/harness tooling only; no production app or auth/data-path changes.
> 
> **Overview**
> Enables **compile-time validation** of Android **Java** observability doc snippets by pinning **`launchdarkly-observability-android` 0.54.0** (Java `ObservabilityOptions.builder()`) in the android-client validator image and wiring the deferred snippets to the **`java-syntax-only`** scaffold with the needed integration/observability imports.
> 
> **Snippet fixes:** `import-the-sdk-java` gets proper Java import semicolons; **`initialize-the-client-android-sdk-v5-x-java`** uses valid Java (`new Observability(...)`, `Collections.<Plugin>singletonList(...)`) instead of Kotlin-style constructor/type-arg syntax.
> 
> **Harness:** import hoisting in **`run.sh`** now ends the file-scope import region at the first **`class`/`interface`/etc.** (not only Kotlin `fun`) and restores **`;`** when re-inserting hoisted Java imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a676309b4a97b773c82bf052b7728baa0f92fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->