### PR TITLE
feat(snippets): port /sdk/features/evaluation-reasons to canonical snippets

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -146,6 +146,18 @@ jobs:
             key-type: mobile
             label: android-client-sdk (sdk-docs)
             group: sdk-docs
+            snippet_skip: android-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4-java
+
+          # The v4-era Android fragment routes through the jvm
+          # validator (java-syntax-only-v4 stub scaffold — the v5 aar
+          # can't compile v4 API surfaces), and the jvm harness
+          # `require_env`s LAUNCHDARKLY_SDK_KEY. Split it onto its own
+          # row with a server key; the row above skips it.
+          - sdk: android-client-sdk
+            runs-on: ubuntu-latest
+            key-type: server
+            label: android-client-sdk (sdk-docs v4 jvm)
+            snippet: android-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4-java
 
           # SDKs whose sdk-docs slice picked up bound syntax-only
           # validators in the docs-validation pass (PR

--- a/snippets/sdks/_feature-docs-evaluation-reasons-port-notes.md
+++ b/snippets/sdks/_feature-docs-evaluation-reasons-port-notes.md
@@ -1,0 +1,92 @@
+# Port notes: /sdk/features/evaluation-reasons
+
+Source: `ld-docs-private` `fern/topics/sdk/features/evaluation-reasons.mdx`.
+55 code blocks extracted into `sdk-docs/features/evaluation-reasons/`
+snippets across 24 SDKs. All but one (iOS Objective-C) are bound to
+validators.
+
+## Content corrections
+
+Fixes applied where the published sample could not work as written.
+Everything else is verbatim from the MDX (modulo indentation flush to
+column 0).
+
+- **.NET (server) reason inspection** (`dotnet-server-sdk/.../print-reason`):
+  the published sample was Java translated to C# — `EvaluationReason`
+  has no nested `RuleMatch` / `PrerequisiteFailed` / `Error` classes to
+  cast to, enum members are PascalCase (`EvaluationReasonKind.Off`),
+  and one line still read `System.out.println(...)`. Rewritten against
+  the real flat `EvaluationReason` API (`reason.RuleIndex`, etc.).
+- **Java reason inspection** (`java-server-sdk/.../print-reason`): the
+  nested-class casts (`(EvaluationReason.RuleMatch) reason`) are from
+  the v4-era API; since v5 `EvaluationReason` is a single flat class.
+  Rewritten to the flat getters (`reason.getRuleIndex()`, ...).
+- **Android reason inspection** (`android-client-sdk/.../print-reason-java`):
+  same nested-class-era code; same flat-getter rewrite. Timber calls
+  kept (the validator's gradle project now includes Timber).
+- **Python reason inspection** (`python-server-sdk/.../print-reason`):
+  Python 2 `print` statements — a syntax error on any supported
+  Python. Converted to `print(...)` calls.
+- **Go reason inspection** (`go-server-sdk/.../print-reason`): the
+  switch referenced an undefined variable `r`; the parameter is
+  `reason`.
+- **JavaScript SDK v4.x example** (`js-client-sdk/.../evaluation-reasons-v4`):
+  the published block was initialization-status boilerplate that never
+  called a `*variationDetail` method. Replaced with a v4
+  `boolVariationDetail` example paralleling the v3.x block.
+- **Flutter v4 example** (`flutter-client-sdk/.../evaluation-reasons-v4`):
+  `detail.variationIndex` and `detail.reason` are nullable in v4;
+  declared as `int?` / `LDEvaluationReason?` so the sample compiles.
+- **Flutter reason inspection** (`flutter-client-sdk/.../print-reason`):
+  `LDKind` members are lowerCamelCase in v4 (`LDKind.off`), not
+  SCREAMING_CASE, and there is no `LDKind.UNKNOWN`; rewritten
+  accordingly (exhaustive switch, no default).
+- **Lua examples** (`lua-server-sdk/.../evaluation-reasons-v2`, `-v1x`):
+  the colon call passed `client` again as the first argument
+  (`client:boolVariationDetail(client, context, ...)` — colon syntax
+  already supplies self), and `details.reason == "FLAG_NOT_FOUND"`
+  compared a table to a string. Fixed to
+  `client:boolVariationDetail(context, "example-flag-key", false)` and
+  `details.reason.kind == "ERROR" and details.reason.errorKind == "FLAG_NOT_FOUND"`,
+  matching the shape `LuaPushDetails` actually returns.
+- **C client SDK v2.x examples** (`cpp-client-sdk/.../evaluation-reasons-c-sdk-v2`,
+  `-c-sdk-v2-cpp`): `details->reason` on a stack struct (must be
+  `details.reason`) and `LDFreeDetailContents(&details)` (the real v2
+  header takes the struct by value).
+
+## Validation routing added in this port
+
+- `android-client-sdk/scaffolds/java-syntax-only-v4` — jvm-routed stub
+  scaffold for v4-era Android fragments (`new LDConfig.Builder()` has
+  no v5 equivalent; the android-client container only carries the v5
+  aar). Follows the C-v2 stub-header approach: only the
+  `com.launchdarkly.sdk.android` surface is stubbed, shared
+  `com.launchdarkly.sdk` types are real.
+- `android-client-sdk/scaffolds/java-syntax-only-members`,
+  `java-server-sdk/scaffolds/java-syntax-only-members`,
+  `dotnet-server-sdk/scaffolds/csharp-syntax-only-members` —
+  class-member-scope variants for fragments that are method
+  declarations (no local methods in Java/C#).
+- `haskell-server-sdk/scaffolds/haskell-syntax-only-toplevel` (+`-v3`) —
+  module-scope splice with module-scope `client`/`context` (v3:
+  `user`) stubs, for fragments that are top-level bindings.
+- `cpp-server-sdk/scaffolds/cpp-syntax-only-v2-cpp` + the
+  `cpp-server-v2-cpp` validator — g++ pass over the same stub
+  `<launchdarkly/api.h>` as `cpp-server-v2-c`, for the v2 server
+  fragments written as C++.
+- Stub-surface extensions: detail-variation members on the v2 C/C++
+  stub headers and the v3 `_AnyClient` stubs; `LDDetails` /
+  `LDEvalReason` on the server v2 stub header (variation signatures
+  corrected from `struct LDJSON **` to the real `struct LDDetails *`);
+  `context`/`secondsToBlock` fields on the android `java-syntax-only`
+  scaffold; `myContext` on `csharp-syntax-only`; `ldConfig`/`context`
+  on `swift-syntax-only`; `Reason` import on `rust-syntax-only`;
+  Timber dependency in the android-client validator image.
+
+## Known non-binds
+
+- `ios-client-sdk/.../evaluation-reasons-objc` — no Objective-C parse
+  scaffold exists; the iOS validator is the macOS-only native harness
+  (same blocker as the evaluating port's objc snippet). Wiring it up
+  requires either an Objective-C target in the xcodegen scaffold or a
+  clang -fsyntax-only stub harness.

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,14 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for Akamai.
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/akamai-syntax-only
+
+---
+
+```typescript
+const { value, variationIndex, reason } = await client.variationDetail(flagKey, context, false);
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only-members.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only-members.snippet.md
@@ -1,0 +1,45 @@
+---
+id: android-client-sdk/scaffolds/java-syntax-only-members
+sdk: android-client-sdk
+kind: scaffold
+lang: java
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.java
+description: |
+  Class-member-scope sibling of `java-syntax-only`. That scaffold
+  splices the body inside `onCreate()`, which breaks for fragments
+  that are themselves method declarations (Java has no local
+  methods). This variant splices the body at class scope instead.
+
+  Same `android-client` validator container in `SNIPPET_CHECK=parse`
+  mode, so the body compiles against the real
+  `launchdarkly-android-client-sdk` aar (plus Timber, which the
+  validator's pre-baked gradle project includes for log-statement
+  fragments).
+
+  No `public` modifier on the class and a class name that differs
+  from the staged file name — same package-private trick as the
+  sibling scaffold, so the harness's `Snippet.java` staging glob
+  picks the file up.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, spliced at class scope.
+validation:
+  runtime: android-client
+  entrypoint: app/src/main/java/com/launchdarkly/hello_android/Snippet.java
+  env:
+    SNIPPET_CHECK: parse
+---
+
+```java
+package com.launchdarkly.hello_android;
+
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.android.*;
+import timber.log.Timber;
+
+@SuppressWarnings("unused")
+class SnippetMembers {
+{{ body }}
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only-v4.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only-v4.snippet.md
@@ -1,0 +1,90 @@
+---
+id: android-client-sdk/scaffolds/java-syntax-only-v4
+sdk: android-client-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/Snippet.java
+description: |
+  Parse-and-type-check validator for Android Java doc fragments that
+  target the v4.x API surface (`new LDConfig.Builder()` with no
+  arguments — v5 made the `AutoEnvAttributes` constructor argument
+  mandatory, so v4-era fragments cannot compile against the v5 aar
+  the `android-client` validator container pre-bakes).
+
+  Routes through the `jvm` validator instead, following the same stub
+  approach as the legacy C SDK validators (cpp-client-v2-c and
+  friends): nested stub classes declare just the v4 android surface
+  the fragments reference. The shared `com.launchdarkly.sdk` types
+  (`EvaluationDetail`, `EvaluationReason`, `LDContext`) come from the
+  real java-sdk-common classes on the jvm validator's classpath —
+  only the `com.launchdarkly.sdk.android` types are stubbed, since
+  the android aar itself can't be resolved by the jvm validator's
+  Maven path.
+
+  The nested `LDConfig` / `LDClient` classes shadow any same-named
+  imports inside the wrappee body, and `getApplication()` /
+  `context` / `secondsToBlock` mirror the ambient names the doc
+  fragments assume an Activity host provides.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+validation:
+  runtime: jvm
+  entrypoint: src/main/java/com/launchdarkly/Snippet.java
+---
+
+```java
+package com.launchdarkly;
+
+import com.launchdarkly.sdk.*;
+
+public class Snippet {
+    // Stub of the v4 android LDConfig builder chain. Only the members
+    // the doc fragments call are declared; everything returns a stub
+    // so the chained-builder shape type-checks.
+    static class LDConfig {
+        static class Builder {
+            Builder() {}
+            Builder mobileKey(String key) { return this; }
+            Builder evaluationReasons(boolean enabled) { return this; }
+            LDConfig build() { return new LDConfig(); }
+        }
+    }
+
+    // Stub of the v4 android LDClient surface. The application
+    // parameter is typed Object so `this.getApplication()` (stubbed
+    // below) satisfies it without an android.app.Application class.
+    static class LDClient {
+        static LDClient init(Object application, LDConfig config, LDContext context, int secondsToBlock) {
+            return new LDClient();
+        }
+        EvaluationDetail<Boolean> boolVariationDetail(String key, boolean defaultValue) {
+            return null;
+        }
+        EvaluationDetail<String> stringVariationDetail(String key, String defaultValue) {
+            return null;
+        }
+    }
+
+    // Ambient names the doc fragments assume an Activity host
+    // provides.
+    @SuppressWarnings("unused")
+    private static final LDContext context = null;
+    @SuppressWarnings("unused")
+    private static final int secondsToBlock = 0;
+
+    private Object getApplication() { return null; }
+
+    public static void main(String[] args) {
+        System.out.println("feature flag evaluates to true");
+    }
+
+    @SuppressWarnings({"unused", "ConstantConditions"})
+    private void wrappee() {
+        try {
+{{ body }}
+        } catch (Throwable ignored) { }
+    }
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -91,6 +91,10 @@ class SnippetActivity extends Activity {
     // `onCreate()` being an instance method.
     LDClient client;
     String flagKey;
+    // Evaluation fragments pass a context and an init-blocking
+    // timeout the docs assume already exist.
+    LDContext context;
+    int secondsToBlock;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4-java.snippet.md
@@ -1,0 +1,26 @@
+---
+id: android-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Flag evaluation reason example for Android SDK v4.x (Java).
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only-v4
+
+---
+
+```java
+LDConfig ldConfig = new LDConfig.Builder()
+  .mobileKey("example-mobile-key")
+  .evaluationReasons(true)
+  .build();
+LDClient client = LDClient.init(this.getApplication(), ldConfig, context, secondsToBlock);
+
+EvaluationDetail<Boolean> detail =
+  client.boolVariationDetail("example-flag-key", false);
+  // or stringVariationDetail for a string-valued flag, etc.
+
+boolean value = detail.getValue();
+Integer index = detail.getVariationIndex();
+EvaluationReason reason = detail.getReason();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v5-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v5-java.snippet.md
@@ -1,0 +1,26 @@
+---
+id: android-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v5-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Flag evaluation reason example for Android SDK v5.x (Java).
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+  .mobileKey("example-mobile-key")
+  .evaluationReasons(true)
+  .build();
+LDClient client = LDClient.init(this.getApplication(), ldConfig, context, secondsToBlock);
+
+EvaluationDetail<Boolean> detail =
+  client.boolVariationDetail("example-flag-key", false);
+  // or stringVariationDetail for a string-valued flag, etc.
+
+boolean value = detail.getValue();
+Integer index = detail.getVariationIndex();
+EvaluationReason reason = detail.getReason();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason-java.snippet.md
@@ -1,0 +1,38 @@
+---
+id: android-client-sdk/sdk-docs/features/evaluation-reasons/print-reason-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Reason-object inspection example for Android (Java).
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only-members
+
+---
+
+```java
+void printReason(EvaluationReason reason) {
+  switch (reason.getKind()) {
+    case OFF:
+      Timber.d("it's off");
+      break;
+    case FALLTHROUGH:
+      Timber.d("fell through");
+      break;
+    case TARGET_MATCH:
+      Timber.d("targeted");
+      break;
+    case RULE_MATCH:
+      Timber.d("matched rule %d/%s",
+               reason.getRuleIndex(),
+               reason.getRuleId());
+      break;
+    case PREREQUISITE_FAILED:
+      Timber.d("prereq failed: %s", reason.getPrerequisiteKey());
+      break;
+    case ERROR:
+      Timber.d("error: %s", reason.getErrorKind());
+  }
+  // or, if all you want is a simple descriptive string:
+  Timber.d(reason.toString());
+}
+```

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,21 @@
+---
+id: apex-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: apex-server-sdk
+kind: reference
+lang: java
+description: Flag evaluation reason example for Apex.
+validation:
+  scaffold: apex-server-sdk/scaffolds/apex-syntax-only
+
+---
+
+```java
+LDClient.EvaluationDetail details = new LDClient.EvaluationDetail();
+
+Boolean value = client.boolVariation(user, 'your.feature.key', false, details);
+
+/* inspect details here */
+if (details.getReason().getKind() == EvaluationReason.Kind.OFF) {
+    /* ... */
+}
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for Cloudflare.
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+
+---
+
+```typescript
+const { value, variationIndex, reason } = await client.variationDetail(flagKey, context, false);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only-v2-c.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only-v2-c.snippet.md
@@ -34,6 +34,7 @@ static struct LDClient *client;
 static struct LDUser *user;
 static struct LDConfig *config;
 static unsigned int maxwait;
+static unsigned int maxwaitmilliseconds;
 
 static void _wrappee(void) {
 {{ body }}

--- a/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only-v2-cpp.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only-v2-cpp.snippet.md
@@ -35,6 +35,7 @@ static LDClientCPP *client;
 static LDUser *user;
 static LDConfig *config;
 static unsigned int maxwait;
+static unsigned int maxwaitmilliseconds;
 
 static void _wrappee() {
 {{ body }}

--- a/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
@@ -31,8 +31,10 @@ validation:
 
 ```cpp
 #include <chrono>
+#include <cstdio>
 #include <future>
 #include <iostream>
+#include <optional>
 #include <string>
 // Native C++ headers.
 #include <launchdarkly/client_side/client.hpp>
@@ -59,6 +61,11 @@ struct _AnyClient {
     // variadic stubs below.
     const _AnyClient* operator->() const { return this; }
     template <typename... Args> bool BoolVariation(Args&&...) const { return false; }
+    // Detail-variation stub returning a real EvaluationDetail so the
+    // body's `detail.Value()` / `detail.Reason()` chains type-check.
+    template <typename... Args> auto BoolVariationDetail(Args&&...) const {
+        return launchdarkly::EvaluationDetail<bool>(false, std::nullopt, std::nullopt);
+    }
     template <typename... Args> int IntVariation(Args&&...) const { return 0; }
     template <typename... Args> double DoubleVariation(Args&&...) const { return 0; }
     template <typename... Args> std::string StringVariation(Args&&...) const { return {}; }

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2-cpp.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2-cpp.snippet.md
@@ -1,0 +1,27 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2-cpp
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Flag evaluation reason example for the C client SDK v2.x (C++ binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-cpp
+
+---
+
+```cpp
+struct LDConfig *config = LDConfigNew("example-mobile-key");
+LDConfigSetUseEvaluationReasons(config, LDBooleanTrue);
+LDClientCPP *client = LDClientCPP::Init(config, user, maxwaitmilliseconds);
+
+LDVariationDetails details;
+
+bool value = client->boolVariationDetail("your.feature.key", false, &details);
+
+/* inspect details.reason, which is a JSON object */
+if (strcmp(LDGetText(LDObjectLookup(details.reason, "errorKind")), "FLAG_NOT_FOUND") == 0) {
+/* ... */
+}
+
+LDFreeDetailContents(details);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2.snippet.md
@@ -1,0 +1,28 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Flag evaluation reason example for the C client SDK v2.x (native).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-c
+
+---
+
+```c
+struct LDConfig *config = LDConfigNew("example-mobile-key");
+LDConfigSetUseEvaluationReasons(config, LDBooleanTrue);
+struct LDClient *client = LDClientInit(config, user, maxwaitmilliseconds);
+
+LDVariationDetails details;
+LDBoolean value;
+
+value = LDBoolVariationDetail(client, "your.feature.key", LDBooleanFalse, &details);
+
+/* inspect details.reason, which is a JSON object */
+if (strcmp(LDGetText(LDObjectLookup(details.reason, "errorKind")), "FLAG_NOT_FOUND") == 0) {
+    /* ... */
+}
+
+LDFreeDetailContents(details);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-c-v3-0.snippet.md
@@ -1,0 +1,24 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-c-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Flag evaluation reason example for C++ (client-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```c
+LDEvalDetail detail;
+if (LDClientSDK_BoolVariationDetail(client, "example-flag-key", false, &detail)) {
+    printf("Value was true!\n");
+} else {
+    LDEvalReason reason;
+    if (LDEvalDetail_Reason(detail, &reason)) {
+       printf("Value was false because of %d\n", LDEvalReason_Kind(reason));
+    } else {
+       printf("No reason provided to explain why flag was false!\n");
+    }
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-native-v3-0.snippet.md
@@ -1,0 +1,25 @@
+---
+id: cpp-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-native-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Flag evaluation reason example for C++ (client-side) SDK v3.0 (native).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```cpp
+auto detail = client.BoolVariationDetail("example-flag-key", false);
+if (detail.Value()) {
+  std::cout << "Value was true!" << std::endl;
+} else {
+  // it was false, let's find out why.
+  if (auto reason = detail.Reason(); reason.has_value()) {
+    // reason might not be present, so we have to check
+    std::cout << "Value was false because of " << reason.value() << std::endl;
+  } else {
+    std::cout << "No reason provided to explain why flag was false!" << std::endl;
+  }
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only-v2-cpp.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only-v2-cpp.snippet.md
@@ -1,0 +1,42 @@
+---
+id: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-cpp
+sdk: cpp-server-sdk
+kind: scaffold
+lang: cpp
+file: snippet.cpp
+description: |
+  Parse-and-type-check validator for C++-flavored doc fragments of
+  the legacy v2.x C server SDK. The v2 server SDK had no separate C++
+  binding class — its "C++ binding" doc fragments call the C API from
+  C++ — so this scaffold mirrors `cpp-syntax-only-v2-c` but routes
+  through the `cpp-server-v2-cpp` validator, whose g++ pass accepts
+  the fragments' C++-isms (`bool`, unqualified struct names).
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+validation:
+  runtime: cpp-server-v2-cpp
+  entrypoint: snippet.cpp
+---
+
+```cpp
+#include <launchdarkly/api.h>
+
+/* File-scope stubs so fragments that read like statement bodies
+ * resolve at compile time. The doc fragments assume the reader's
+ * prior init snippets already declared these. */
+static struct LDClient *client;
+static struct LDUser *user;
+static struct LDConfig *config;
+static unsigned int maxwaitmilliseconds;
+
+static void _wrappee(void) {
+{{ body }}
+}
+
+int main(void) {
+    (void)_wrappee;
+    return 0;
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
@@ -17,8 +17,10 @@ validation:
 
 ```cpp
 #include <chrono>
+#include <cstdio>
 #include <future>
 #include <iostream>
+#include <optional>
 #include <string>
 // Native C++ headers.
 #include <launchdarkly/server_side/client.hpp>
@@ -45,6 +47,11 @@ struct _AnyClient {
     // the chained call dispatches to the same variadic stubs below.
     const _AnyClient* operator->() const { return this; }
     template <typename... Args> bool BoolVariation(Args&&...) const { return false; }
+    // Detail-variation stub returning a real EvaluationDetail so the
+    // body's `detail.Value()` / `detail.Reason()` chains type-check.
+    template <typename... Args> auto BoolVariationDetail(Args&&...) const {
+        return launchdarkly::EvaluationDetail<bool>(false, std::nullopt, std::nullopt);
+    }
     template <typename... Args> int IntVariation(Args&&...) const { return 0; }
     template <typename... Args> double DoubleVariation(Args&&...) const { return 0; }
     template <typename... Args> std::string StringVariation(Args&&...) const { return {}; }

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2-cpp.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2-cpp.snippet.md
@@ -1,0 +1,23 @@
+---
+id: cpp-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2-cpp
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Flag evaluation reason example for the C server SDK v2.x (C++ binding).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-cpp
+
+---
+
+```cpp
+LDDetails details;
+
+bool value = LDBoolVariation(client, user, "example-flag-key", false, &details);
+
+/* inspect details here */
+if (details.reason == LD_RULE_MATCH) {
+    /* ... */
+}
+
+LDDetailsClear(&details);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2.snippet.md
@@ -1,0 +1,24 @@
+---
+id: cpp-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-c-sdk-v2
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Flag evaluation reason example for the C server SDK v2.x (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
+---
+
+```c
+struct LDDetails details;
+LDBoolean value;
+
+value = LDBoolVariation(client, user, "example-flag-key", LDBooleanFalse, &details);
+
+/* inspect details here */
+if (details.reason == LD_RULE_MATCH) {
+    /* ... */
+}
+
+LDDetailsClear(&details);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-c-v3-0.snippet.md
@@ -1,0 +1,24 @@
+---
+id: cpp-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-c-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Flag evaluation reason example for C++ (server-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
+---
+
+```c
+LDEvalDetail detail;
+if (LDServerSDK_BoolVariationDetail(client, context, "example-flag-key", false, &detail)) {
+    printf("Value was true!\n");
+} else {
+    LDEvalReason reason;
+    if (LDEvalDetail_Reason(detail, &reason)) {
+       printf("Value was false because of %d\n", LDEvalReason_Kind(reason));
+    } else {
+       printf("No reason provided to explain why flag was false!\n");
+    }
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-native-v3-0.snippet.md
@@ -1,0 +1,25 @@
+---
+id: cpp-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-cpp-native-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Flag evaluation reason example for C++ (server-side) SDK v3.0 (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
+---
+
+```cpp
+auto detail = client.BoolVariationDetail(context, "example-flag-key", false);
+if (detail.Value()) {
+  std::cout << "Value was true!" << std::endl;
+} else {
+  // it was false, let's find out why
+  if (auto reason = detail.Reason(); reason.has_value()) {
+    // reason might not be present, so we have to check
+    std::cout << "Value was false because of " << reason.value() << std::endl;
+  } else {
+    std::cout << "No reason provided to explain why flag was false!" << std::endl;
+  }
+}
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only-v3.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/scaffolds/csharp-client-syntax-only-v3.snippet.md
@@ -44,6 +44,9 @@ namespace LaunchDarklySnippet
         // different shapes, and the scaffold is parse-only.
         #pragma warning disable CS8625, CS0414, CS0649
         private static dynamic client = null;
+        // Evaluation/init fragments pass an ambient `context`; the
+        // docs assume it already exists.
+        private static dynamic context = null;
         #pragma warning restore CS8625, CS0414, CS0649
 
         public static void Main(string[] args)

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
@@ -1,0 +1,26 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Flag evaluation reason example for .NET (client-side) v3.0.
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only-v3
+
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key")
+    .EvaluationReasons(true)
+    .Build();
+LdClient client = LdClient.Init(config, context, TimeSpan.FromSeconds(10));
+
+EvaluationDetail<bool> detail =
+    client.BoolVariationDetail("example-bool-flag-key", false);
+    // or StringVariationDetail for a string-valued flag, and so on.
+
+bool value = detail.Value;
+int? index = detail.VariationIndex;
+EvaluationReason reason = detail.Reason;
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
@@ -1,0 +1,26 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Flag evaluation reason example for .NET (client-side) v4.0.
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
+---
+
+```csharp
+var config = Configuration
+    .Builder("example-mobile-key", ConfigurationBuilder.AutoEnvAttributes.Enabled)
+    .EvaluationReasons(true)
+    .Build();
+LdClient client = LdClient.Init(config, context, TimeSpan.FromSeconds(10));
+
+EvaluationDetail<bool> detail =
+    client.BoolVariationDetail("example-bool-flag-key", false);
+    // or StringVariationDetail for a string-valued flag, and so on.
+
+bool value = detail.Value;
+int? index = detail.VariationIndex;
+EvaluationReason reason = detail.Reason;
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only-members.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only-members.snippet.md
@@ -1,0 +1,45 @@
+---
+id: dotnet-server-sdk/scaffolds/csharp-syntax-only-members
+sdk: dotnet-server-sdk
+kind: scaffold
+lang: csharp
+file: Program.cs
+description: |
+  Class-member-scope sibling of `csharp-syntax-only`. That scaffold
+  splices the body inside `Wrappee()`, which breaks for fragments
+  that are themselves method declarations (C# local functions can't
+  carry the doc fragments' plain method shape with comments between
+  members). This variant splices the body at class scope instead.
+
+  Same `dotnet-server` validator container, so the body compiles
+  against the real `LaunchDarkly.ServerSdk` package.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, spliced at class scope.
+validation:
+  runtime: dotnet-server
+  entrypoint: Program.cs
+  requirements: |
+    LaunchDarkly.ServerSdk
+---
+
+```csharp
+// USING_LIFT_MARKER
+using System;
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
+namespace LaunchDarklySnippet
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            System.Console.WriteLine("feature flag evaluates to true");
+        }
+
+{{ body }}
+    }
+}
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/csharp-syntax-only.snippet.md
@@ -57,6 +57,9 @@ namespace LaunchDarklySnippet
         private static dynamic aiClient = null;
         private static User user = null;
         private static Context context = default;
+        // Evaluation fragments pass `myContext` to the variation
+        // methods; the docs assume it already exists.
+        private static Context myContext = default;
 #pragma warning restore CS0414, CS0649
 
         public static void Main(string[] args)

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,20 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Flag evaluation reason example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
+---
+
+```csharp
+EvaluationDetail<bool> detail =
+    client.BoolVariationDetail("example-flag-key", myContext, false);
+    // or StringVariationDetail for a string-valued flag, etc.
+
+bool value = detail.Value;
+int? index = detail.VariationIndex;
+EvaluationReason reason = detail.Reason;
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,39 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Reason-object inspection example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only-members
+
+---
+
+```csharp
+void PrintReason(EvaluationReason reason)
+{
+  switch (reason.Kind)
+  {
+    case EvaluationReasonKind.Off:
+      Console.WriteLine("it's off");
+      break;
+    case EvaluationReasonKind.Fallthrough:
+      Console.WriteLine("fell through");
+      break;
+    case EvaluationReasonKind.TargetMatch:
+      Console.WriteLine("targeted");
+      break;
+    case EvaluationReasonKind.RuleMatch:
+      Console.WriteLine("matched rule " + reason.RuleIndex + "/" + reason.RuleId);
+      break;
+    case EvaluationReasonKind.PrerequisiteFailed:
+      Console.WriteLine("prereq failed: " + reason.PrerequisiteKey);
+      break;
+    case EvaluationReasonKind.Error:
+      Console.WriteLine("error: " + reason.ErrorKind);
+      break;
+  }
+  // or, if all you want is a simple descriptive string:
+  Console.WriteLine(reason.ToString());
+}
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-js.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-js.snippet.md
@@ -1,0 +1,14 @@
+---
+id: electron-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-js
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation reason example for Electron (JavaScript).
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
+---
+
+```javascript
+const { value, variationIndex, reason } = client.variationDetail('example-flag-key', false);
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-ts.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-ts.snippet.md
@@ -1,0 +1,14 @@
+---
+id: electron-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-ts
+sdk: electron-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for Electron (TypeScript).
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
+---
+
+```typescript
+const { value, variationIndex, reason } = client.variationDetail('example-flag-key', false);
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v1x.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v1x.snippet.md
@@ -1,0 +1,14 @@
+---
+id: erlang-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v1x
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Flag evaluation reason example for Erlang SDK v1.x.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
+---
+
+```erlang
+Flag = ldclient:variation_detail(<<"example-flag-key">>, #{key => <<"example-user-key">>}, false)
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v2.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: erlang-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v2
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Flag evaluation reason example for Erlang SDK v2.0+.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
+---
+
+```erlang
+Flag = ldclient:variation_detail(<<"example-flag-key">>, #{key => <<"example-context-key">>}, false)
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,14 @@
+---
+id: fastly-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for Fastly.
+validation:
+  scaffold: fastly-server-sdk/scaffolds/fastly-syntax-only
+
+---
+
+```typescript
+const { value, variationIndex, reason } = await client.variationDetail('example-flag-key', context, false);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
@@ -1,0 +1,26 @@
+---
+id: flutter-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Flag evaluation reason example for Flutter SDK v3.x.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
+---
+
+```dart
+LDConfig config = LDConfigBuilder('example-mobile-key', AutoEnvAttributes.Enabled)
+    .evaluationReasons(true)
+    .build();
+
+// initialize client and context
+
+LDEvaluationDetail<bool> detail =
+  await LDClient.boolVariationDetail('example-flag-key', false);
+  // or stringVariationDetail for a string-valued flag, and so on.
+
+bool value = detail.value;
+int index = detail.variationIndex;
+LDEvaluationReason reason = detail.reason;
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
@@ -1,0 +1,30 @@
+---
+id: flutter-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Flag evaluation reason example for Flutter SDK v4.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
+
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  AutoEnvAttributes.enabled,
+  dataSourceConfig: DataSourceConfig(
+    evaluationReasons: true
+  ),
+);
+
+// initialize client and context
+
+LDEvaluationDetail<bool> detail =
+  client.boolVariationDetail('example-flag-key', false);
+  // or stringVariationDetail for a string-valued flag, and so on.
+
+bool value = detail.value;
+int? index = detail.variationIndex;
+LDEvaluationReason? reason = detail.reason;
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,35 @@
+---
+id: flutter-client-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Reason-object inspection example for Flutter (Dart).
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
+
+---
+
+```dart
+void printReason(LDEvaluationReason reason) {
+  switch (reason.kind) {
+    case LDKind.off:
+      print("it's off");
+      break;
+    case LDKind.fallthrough:
+      print('fell through');
+      break;
+    case LDKind.targetMatch:
+      print('targeted');
+      break;
+    case LDKind.ruleMatch:
+      print('matched rule: ${reason.ruleIndex} ${reason.ruleId}');
+      break;
+    case LDKind.prerequisiteFailed:
+      print('prereq failed: ${reason.prerequisiteKey}');
+      break;
+    case LDKind.error:
+      print('error: ${reason.errorKind}');
+      break;
+  }
+}
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v6.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v6.snippet.md
@@ -1,0 +1,18 @@
+---
+id: go-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v6
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Flag evaluation reason example for Go SDK v6+ (LDClient).
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+value, detail, err := client.BoolVariationDetail("example-flag-key", context, false)
+// or StringVariationDetail for a string-valued flag, etc.
+
+index := detail.VariationIndex
+reason := detail.Reason
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v7-scopedclient.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v7-scopedclient.snippet.md
@@ -1,0 +1,19 @@
+---
+id: go-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v7-scopedclient
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Flag evaluation reason example for Go SDK v7.13.4+ (LDScopedClient).
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+value, detail, err := scopedClient.BoolVariationDetail("example-flag-key", false)
+// or StringVariationDetail for a string-valued flag, etc.
+// LDScopedClient is in beta and may change without notice.
+
+index := detail.VariationIndex
+reason := detail.Reason
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,35 @@
+---
+id: go-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Reason-object inspection example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+import (
+    "github.com/launchdarkly/go-sdk-common/v3/ldreason"
+)
+
+func PrintReason(reason ldreason.EvaluationReason) {
+  switch reason.GetKind() {
+  case ldreason.EvalReasonOff:
+    fmt.Println("it's off")
+  case ldreason.EvalReasonFallthrough:
+    fmt.Println("fell through")
+  case ldreason.EvalReasonTargetMatch:
+    fmt.Println("targeted")
+  case ldreason.EvalReasonRuleMatch:
+    fmt.Printf("matched rule %d/%s\n", reason.GetRuleIndex(), reason.GetRuleID())
+  case ldreason.EvalReasonPrerequisiteFailed:
+    fmt.Printf("prereq failed: %s\n", reason.GetPrerequisiteKey())
+  case ldreason.EvalReasonError:
+    fmt.Printf("error: %s\n", reason.GetErrorKind())
+  }
+  // or, if all you want is a simple descriptive string:
+  fmt.Println(reason)
+}
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only-toplevel-v3.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only-toplevel-v3.snippet.md
@@ -1,0 +1,39 @@
+---
+id: haskell-server-sdk/scaffolds/haskell-syntax-only-toplevel-v3
+sdk: haskell-server-sdk
+kind: scaffold
+lang: haskell
+file: app/Main.hs
+description: |
+  v3.x flavor of `haskell-syntax-only-toplevel` — identical splice
+  shape, but routes through the `haskell-server-v3` validator (which
+  pins the 3.x package) and stubs `user` instead of `context`, since
+  v3-era fragments pass a bare `user` to the variation functions.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, spliced at module scope.
+validation:
+  runtime: haskell-server-v3
+  entrypoint: app/Main.hs
+---
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import LaunchDarkly.Server
+
+-- Module-scope stubs for the ambient bindings the doc fragments
+-- assume earlier init snippets created.
+client :: Client
+client = undefined
+
+user :: User
+user = undefined
+
+{{ body }}
+
+main :: IO ()
+main = putStrLn "feature flag evaluates to true"
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only-toplevel.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/scaffolds/haskell-syntax-only-toplevel.snippet.md
@@ -1,0 +1,44 @@
+---
+id: haskell-server-sdk/scaffolds/haskell-syntax-only-toplevel
+sdk: haskell-server-sdk
+kind: scaffold
+lang: haskell
+file: app/Main.hs
+description: |
+  Module-scope sibling of `haskell-syntax-only`. That scaffold places
+  the body inside `_wrappee`'s do-block (with let-bound `client` /
+  `context` stubs), and the harness lifts top-level-shaped lines out
+  to module scope — where the do-block stubs aren't visible. Bodies
+  that are entirely top-level declarations referencing an ambient
+  `client` / `context` (e.g. `details :: IO (EvaluationDetail Bool)`
+  with its binding) therefore need the stubs at module scope, which
+  is what this variant provides. The body is spliced directly at
+  module scope, so no lift markers are involved.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, spliced at module scope.
+validation:
+  runtime: haskell-server
+  entrypoint: app/Main.hs
+---
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import LaunchDarkly.Server
+
+-- Module-scope stubs for the ambient bindings the doc fragments
+-- assume earlier init snippets created.
+client :: Client
+client = undefined
+
+context :: Context
+context = undefined
+
+{{ body }}
+
+main :: IO ()
+main = putStrLn "feature flag evaluates to true"
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
@@ -1,0 +1,15 @@
+---
+id: haskell-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Flag evaluation reason example for Haskell SDK v3.x.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only-toplevel-v3
+
+---
+
+```haskell
+details :: IO (EvaluationDetail Bool)
+details = boolVariationDetail client "example-flag-key" user False
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
@@ -1,0 +1,15 @@
+---
+id: haskell-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Flag evaluation reason example for Haskell SDK v4.0.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only-toplevel
+
+---
+
+```haskell
+details :: IO (EvaluationDetail Bool)
+details = boolVariationDetail client "example-flag-key" context False
+```

--- a/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/scaffolds/swift-syntax-only.snippet.md
@@ -61,6 +61,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // resolve at compile time. Never invoked.
     var client: LDClient! = nil
 
+    // Stubs for fragments that mutate an ambient config or pass an
+    // ambient context to `LDClient.start` — the docs assume earlier
+    // init snippets created them.
+    var ldConfig = LDConfig(mobileKey: "stub-mobile-key", autoEnvAttributes: .disabled)
+    var context = try! LDContextBuilder(key: "stub-context-key").build().get()
+
     // Wrappee body — references to client/context here resolve
     // through the stubs above; xcodebuild type-checks but doesn't
     // run.

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-objc.snippet.md
@@ -1,0 +1,19 @@
+---
+id: ios-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-objc
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: Flag evaluation reason example for iOS (Objective-C).
+
+---
+
+```objectivec
+config.evaluationReasons = true;
+[LDClient startWithConfiguration:config context:result.success completion: nil];
+
+LDBoolEvaluationDetail *detail = [[LDClient get] boolVariationDetailForKey:@"example-flag-key" defaultValue:NO];
+
+BOOL value = detail.value;
+NSInteger variationIndex = detail.variationIndex;
+NSDictionary<NSString*, LDValue*> *reason = detail.reason;
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-swift.snippet.md
@@ -1,0 +1,21 @@
+---
+id: ios-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Flag evaluation reason example for iOS (Swift).
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
+---
+
+```swift
+ldConfig.evaluationReasons = true
+LDClient.start(config: ldConfig, context: context)
+
+let detail = client.boolVariationDetail(forKey: "example-flag-key", defaultValue: false);
+
+let value: Bool = detail.value
+let variationIndex: Int? = detail.variationIndex
+let reason: [String: LDValue]? = detail.reason
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only-members.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/java-syntax-only-members.snippet.md
@@ -1,0 +1,38 @@
+---
+id: java-server-sdk/scaffolds/java-syntax-only-members
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/Snippet.java
+description: |
+  Class-member-scope sibling of `java-syntax-only`. That scaffold
+  splices the body inside `wrappee()`, which breaks for fragments
+  that are themselves method declarations (Java has no local
+  methods). This variant splices the body at class scope instead.
+
+  Same `jvm` validator, so the body compiles against the real
+  `launchdarkly-java-server-sdk` from Maven Central.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, spliced at class scope.
+validation:
+  runtime: jvm
+  entrypoint: src/main/java/com/launchdarkly/Snippet.java
+---
+
+```java
+package com.launchdarkly;
+
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+
+@SuppressWarnings("unused")
+public class Snippet {
+    public static void main(String[] args) {
+        System.out.println("feature flag evaluates to true");
+    }
+
+{{ body }}
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,22 @@
+---
+id: java-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Flag evaluation reason example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+import com.launchdarkly.sdk.*;
+
+EvaluationDetail<Boolean> detail =
+  client.boolVariationDetail("example-flag-key", context, false);
+  // or stringVariationDetail for a string-valued flag, and so on.
+
+boolean value = detail.getValue();
+int index = detail.getVariationIndex();       // will be < 0 if evaluation failed
+EvaluationReason reason = detail.getReason();
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,37 @@
+---
+id: java-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Reason-object inspection example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only-members
+
+---
+
+```java
+void printReason(EvaluationReason reason) {
+  switch (reason.getKind()) {
+    case OFF:
+      System.out.println("it's off");
+      break;
+    case FALLTHROUGH:
+      System.out.println("fell through");
+      break;
+    case TARGET_MATCH:
+      System.out.println("targeted");
+      break;
+    case RULE_MATCH:
+      System.out.println("matched rule " + reason.getRuleIndex()
+        + "/" + reason.getRuleId());
+      break;
+    case PREREQUISITE_FAILED:
+      System.out.println("prereq failed: " + reason.getPrerequisiteKey());
+      break;
+    case ERROR:
+      System.out.println("error: " + reason.getErrorKind());
+  }
+  // or, if all you want is a simple descriptive string:
+  System.out.println(reason.toString());
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3.snippet.md
@@ -1,0 +1,31 @@
+---
+id: js-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v3
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation reason example for JavaScript SDK v3.x.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
+---
+
+```javascript
+const options = { evaluationReasons: true };
+const client = LDClient.initialize('example-client-side-id', context, options);
+
+try {
+    client.waitForInitialization(5);
+
+    // proceed with successfully initialized client:
+
+    const detail = client.variationDetail('example-flag-key', false);
+
+    const value = detail.value;
+    const index = detail.variationIndex;
+    const reason = detail.reason;
+
+} catch(err) {
+    // Client failed to initialize or timed out
+    // variation() calls return fallback values until initialization completes
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
@@ -1,0 +1,25 @@
+---
+id: js-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4
+sdk: js-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for JavaScript SDK v4.x.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
+---
+
+```typescript
+const options = { evaluationReasons: true };
+const client = createClient('example-client-side-id', context, options);
+client.start();
+
+await client.waitForInitialization({ timeout: 5 });
+
+const detail = client.boolVariationDetail('example-flag-key', false);
+// or stringVariationDetail for a string-valued flag, and so on.
+
+const value = detail.value;
+const index = detail.variationIndex;
+const reason = detail.reason;
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v1x.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v1x.snippet.md
@@ -1,0 +1,18 @@
+---
+id: lua-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v1x
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Flag evaluation reason example for Lua SDK v1.x.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
+---
+
+```lua
+local details = client:boolVariationDetail(user, "example-flag-key", false);
+
+-- inspect details here
+if details.reason.kind == "ERROR" and details.reason.errorKind == "FLAG_NOT_FOUND" then
+end
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v2.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v2.snippet.md
@@ -1,0 +1,18 @@
+---
+id: lua-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v2
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: Flag evaluation reason example for Lua SDK v2.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
+---
+
+```lua
+local details = client:boolVariationDetail(context, "example-flag-key", false);
+
+-- inspect details here
+if details.reason.kind == "ERROR" and details.reason.errorKind == "FLAG_NOT_FOUND" then
+end
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,21 @@
+---
+id: node-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation reason example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
+---
+
+```javascript
+const options = { evaluationReasons: true };
+const client = LDClient.initialize('example-client-side-id', user, options);
+
+const detail = client.variationDetail('example-flag-key', false);
+
+const value = detail.value;
+const index = detail.variationIndex;
+const reason = detail.reason;
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-js.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-js.snippet.md
@@ -1,0 +1,18 @@
+---
+id: node-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-js
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+description: Flag evaluation reason example for Node.js (server-side, JavaScript).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
+---
+
+```javascript
+var detail = client.variationDetail('example-flag-key', context, false);
+
+var value = detail.value;
+var index = detail.variationIndex;
+var reason = detail.reason;
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-ts.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-ts.snippet.md
@@ -1,0 +1,19 @@
+---
+id: node-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-ts
+sdk: node-server-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for Node.js (server-side, TypeScript).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
+---
+
+```typescript
+client.variationDetail('example-flag-key', context, false,
+  (detail) => {
+    const detailValue = detail.value;
+    const detailIndex = detail.variationIndex;
+    const detailReason = detail.reason;
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,35 @@
+---
+id: node-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+description: Reason-object inspection example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
+---
+
+```javascript
+function printReason(reason) {
+  switch(reason.kind) {
+    case "OFF":
+      console.log("it's off");
+      break;
+    case "FALLTHROUGH":
+      console.log("fell through");
+      break;
+    case "TARGET_MATCH":
+      console.log("targeted");
+      break;
+    case "RULE_MATCH":
+      console.log("matched rule " + reason.ruleIndex + ", "  + reason.ruleId);
+      break;
+    case "PREREQUISITE_FAILED":
+      console.log("prereq failed: " + reason.prerequisiteKey);
+      break;
+    case "ERROR":
+      console.log("error: " + reason.errorKind);
+      break;
+  }
+}
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,18 @@
+---
+id: php-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Flag evaluation reason example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
+---
+
+```php
+$detail = $client->variationDetail("example-flag-key", $myContext, false);
+
+$value = $detail->getValue();
+$index = $detail->getVariationIndex();
+$reason = $detail->getReason();
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,38 @@
+---
+id: php-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: Reason-object inspection example for PHP.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
+---
+
+```php
+function printReason($reason) {
+  switch ($reason->getKind()) {
+    case EvaluationReason::OFF:
+      echo("it's off");
+      break;
+    case EvaluationReason::FALLTHROUGH:
+      echo("fell through");
+      break;
+    case EvaluationReason::TARGET_MATCH:
+      echo("targeted");
+      break;
+    case EvaluationReason::RULE_MATCH:
+      echo("matched rule " . $reason->getRuleIndex() .
+        "/" . $reason->getRuleId());
+      break;
+    case EvaluationReason::PREREQUISITE_FAILED:
+      echo("prereq failed: " . $reason->getPrerequisiteKey());
+      break;
+    case EvaluationReason::ERROR:
+      echo("error: " . $reason->getErrorKind());
+      break;
+  }
+  // or, if all you want is a simple descriptive string:
+  echo $reason;
+}
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,17 @@
+---
+id: python-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Flag evaluation reason example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
+---
+
+```python
+detail = client.variation_detail("example-flag-key", my_context, False)
+value = detail.value
+index = detail.variation_index
+reason = detail.reason
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,27 @@
+---
+id: python-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Reason-object inspection example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
+---
+
+```python
+def print_reason(reason):
+  kind = reason["kind"]
+  if kind == "OFF":
+    print("it's off")
+  elif kind == "FALLTHROUGH":
+    print("fell through")
+  elif kind == "TARGET_MATCH":
+    print("targeted")
+  elif kind == "RULE_MATCH":
+    print("matched rule %d/%s" % (reason["ruleIndex"], reason["ruleId"]))
+  elif kind == "PREREQUISITE_FAILED":
+    print("prereq failed: %s" % reason["prerequisiteKey"])
+  elif kind == "ERROR":
+    print("error: %s" % reason["errorKind"])
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-hooks.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-hooks.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-native-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-hooks
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for React Native SDK v10 (variation hooks).
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
+---
+
+```typescript
+const { reason, value, variationIndex } = useBoolVariationDetail('example-flag-key', false);
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-methods.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-methods.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-native-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-methods
+sdk: react-native-client-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for React Native SDK v10 (variation methods).
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
+---
+
+```typescript
+const { reason, value, variationIndex } = client.boolVariationDetail('example-flag-key', false);
+```

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,16 @@
+---
+id: roku-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: roku-client-sdk
+kind: reference
+lang: brightscript
+description: Flag evaluation reason example for Roku (BrightScript).
+validation:
+  scaffold: roku-client-sdk/scaffolds/roku-syntax-only
+
+---
+
+```brightscript
+config.setUseEvaluationReasons(true)
+
+details = launchDarkly.intVariationDetail("example-flag-key", 123)
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,17 @@
+---
+id: ruby-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Flag evaluation reason example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
+---
+
+```ruby
+detail = client.variation_detail("example-flag-key", my_context, false)
+value = detail.value
+index = detail.variation_index
+reason = detail.reason
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,29 @@
+---
+id: ruby-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Reason-object inspection example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
+---
+
+```ruby
+def print_reason(reason)
+  case reason[:kind]
+  when "OFF"
+    puts "it's off"
+  when "FALLTHROUGH"
+    puts "fell through"
+  when "TARGET_MATCH"
+    puts "targeted"
+  when "RULE_MATCH"
+    puts "matched rule #{reason[:ruleIndex]}/#{reason[:ruleId]}"
+  when "PREREQUISITE_FAILED"
+    puts "prereq failed: #{reason[:prerequisiteKey]}"
+  when "ERROR"
+    puts "error: #{reason[:errorKind]}"
+  end
+end
+```

--- a/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
@@ -23,7 +23,7 @@ validation:
 #[allow(unused_imports)]
 use launchdarkly_server_sdk::{
     ApplicationInfo, AttributeValue, Client, ConfigBuilder, Context, ContextBuilder,
-    MultiContextBuilder, Reference, ServiceEndpointsBuilder,
+    MultiContextBuilder, Reason, Reference, ServiceEndpointsBuilder,
     MigratorBuilder, ExecutionOrder,
 };
 #[allow(unused_imports)]

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,18 @@
+---
+id: rust-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Flag evaluation reason example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
+---
+
+```rust
+let detail = client.bool_variation_detail(&context, "example-flag-key", false);
+
+let value = detail.value;
+let index = detail.variation_index;
+let reason = detail.reason;
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/evaluation-reasons/print-reason.snippet.md
@@ -1,0 +1,29 @@
+---
+id: rust-server-sdk/sdk-docs/features/evaluation-reasons/print-reason
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Reason-object inspection example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
+---
+
+```rust
+fn print_reason(reason: Reason) {
+    match reason {
+        Reason::Off => println!("it's off"),
+        Reason::Fallthrough { .. } => println!("fell through"),
+        Reason::TargetMatch => println!("targeted"),
+        Reason::RuleMatch {
+            rule_index,
+            rule_id,
+            ..
+        } => println!("matched rule {}/{}", rule_index, rule_id),
+        Reason::PrerequisiteFailed { prerequisite_key } => {
+            println!("prereq failed: {}", prerequisite_key)
+        }
+        Reason::Error { error } => println!("error: {:?}", error),
+    };
+}
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vercel-server-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+description: Flag evaluation reason example for Vercel.
+validation:
+  scaffold: vercel-server-sdk/scaffolds/vercel-syntax-only
+
+---
+
+```typescript
+const { value, variationIndex, reason } = await client.variationDetail(flagKey, context, false);
+```

--- a/snippets/validators/languages/android-client/Dockerfile
+++ b/snippets/validators/languages/android-client/Dockerfile
@@ -50,14 +50,15 @@ RUN git clone --depth 1 --branch "${HELLO_ANDROID_REF}" \
 
 WORKDIR /opt/hello-android
 
-# Patch the LD SDK version, add the observability AAR to
-# `implementation`, and add Robolectric to `testImplementation`.
+# Patch the LD SDK version, add the observability AAR and Timber
+# (referenced by log-statement doc fragments) to `implementation`,
+# and add Robolectric to `testImplementation`.
 # Also bump compileSdk/targetSdk to 35 because the v0.49.0
 # observability AAR transitively depends on androidx.core 1.16+,
 # which requires API 35.
 RUN sed -i "s|com.launchdarkly:launchdarkly-android-client-sdk:[0-9.]*|com.launchdarkly:launchdarkly-android-client-sdk:${LD_ANDROID_SDK_VERSION}|" app/build.gradle \
     && sed -i "s|compileSdk 34|compileSdk 35|; s|targetSdkVersion(34)|targetSdkVersion(35)|" app/build.gradle \
-    && sed -i "/^dependencies {$/a\\    implementation 'com.launchdarkly:launchdarkly-observability-android:${LD_ANDROID_OBSERVABILITY_VERSION}'\\n    testImplementation 'org.robolectric:robolectric:${ROBOLECTRIC_VERSION}'\\n    testImplementation 'junit:junit:4.13.2'\\n    testImplementation 'androidx.test:core:1.5.0'\\n    testImplementation 'androidx.test.ext:junit:1.1.5'" app/build.gradle
+    && sed -i "/^dependencies {$/a\\    implementation 'com.launchdarkly:launchdarkly-observability-android:${LD_ANDROID_OBSERVABILITY_VERSION}'\\n    implementation 'com.jakewharton.timber:timber:5.0.1'\\n    testImplementation 'org.robolectric:robolectric:${ROBOLECTRIC_VERSION}'\\n    testImplementation 'junit:junit:4.13.2'\\n    testImplementation 'androidx.test:core:1.5.0'\\n    testImplementation 'androidx.test.ext:junit:1.1.5'" app/build.gradle
 
 # Robolectric needs testOptions { unitTests.includeAndroidResources } to
 # resolve R.string / R.id at test time. Forward stdout/stderr so the

--- a/snippets/validators/languages/cpp-client-v2-c/api.h
+++ b/snippets/validators/languages/cpp-client-v2-c/api.h
@@ -12,6 +12,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,6 +91,67 @@ static inline char *LDStringVariation(struct LDClient *client,
     (void)client;
     (void)flagKey;
     return (char *)fallback;
+}
+
+static inline void LDConfigSetUseEvaluationReasons(struct LDConfig *config,
+                                                   LDBoolean reasons) {
+    (void)config;
+    (void)reasons;
+}
+
+/* Detail-variation surface. `LDVariationDetails` is filled by the
+ * evaluation call; `reason` is a JSON object inspected through
+ * LDObjectLookup / LDGetText. LDFreeDetailContents takes the struct
+ * by value, matching the real v2 header. */
+typedef struct {
+    int            variationIndex;
+    struct LDJSON *reason;
+} LDVariationDetails;
+
+static inline LDBoolean LDBoolVariationDetail(struct LDClient *client,
+                                              const char *flagKey,
+                                              LDBoolean fallback,
+                                              LDVariationDetails *details) {
+    (void)client;
+    (void)flagKey;
+    (void)details;
+    return fallback;
+}
+
+static inline int LDIntVariationDetail(struct LDClient *client,
+                                       const char *flagKey,
+                                       int fallback,
+                                       LDVariationDetails *details) {
+    (void)client;
+    (void)flagKey;
+    (void)details;
+    return fallback;
+}
+
+static inline double LDDoubleVariationDetail(struct LDClient *client,
+                                             const char *flagKey,
+                                             double fallback,
+                                             LDVariationDetails *details) {
+    (void)client;
+    (void)flagKey;
+    (void)details;
+    return fallback;
+}
+
+static inline struct LDJSON *LDObjectLookup(const struct LDJSON *object,
+                                            const char *key) {
+    (void)object;
+    (void)key;
+    return (struct LDJSON *)0;
+}
+
+static inline const char *LDGetText(const struct LDJSON *json) {
+    (void)json;
+    return "";
+}
+
+static inline void LDFreeDetailContents(LDVariationDetails details) {
+    (void)details;
 }
 
 #ifdef __cplusplus

--- a/snippets/validators/languages/cpp-client-v2-cpp/api.hpp
+++ b/snippets/validators/languages/cpp-client-v2-cpp/api.hpp
@@ -12,14 +12,18 @@
 
 #include <cstdbool>
 #include <cstddef>
+#include <cstring>
 
 /* C-flavored types live in the global namespace, matching the
  * v2 SDK's actual layout (the C and C++ headers shared a translation
  * unit). */
 typedef bool LDBoolean;
+#define LDBooleanTrue  ((LDBoolean)1)
+#define LDBooleanFalse ((LDBoolean)0)
 
 struct LDConfig;
 struct LDUser;
+struct LDJSON;
 
 inline LDConfig *LDConfigNew(const char *key) {
     (void)key;
@@ -35,6 +39,36 @@ inline void LDUserFree(LDUser *user) {
     (void)user;
 }
 
+inline void LDConfigSetUseEvaluationReasons(LDConfig *config,
+                                            LDBoolean reasons) {
+    (void)config;
+    (void)reasons;
+}
+
+/* Detail-variation surface shared with the C API. `reason` is a JSON
+ * object inspected through LDObjectLookup / LDGetText.
+ * LDFreeDetailContents takes the struct by value, matching the real
+ * v2 header. */
+struct LDVariationDetails {
+    int     variationIndex;
+    LDJSON *reason;
+};
+
+inline LDJSON *LDObjectLookup(const LDJSON *object, const char *key) {
+    (void)object;
+    (void)key;
+    return nullptr;
+}
+
+inline const char *LDGetText(const LDJSON *json) {
+    (void)json;
+    return "";
+}
+
+inline void LDFreeDetailContents(LDVariationDetails details) {
+    (void)details;
+}
+
 /* `LDClientCPP` is the v2 C++ binding's RAII client class. Member
  * stubs covered by variadic templates so any arg list (string flag
  * key + fallback, etc.) resolves at parse time. The class is never
@@ -43,6 +77,9 @@ class LDClientCPP {
 public:
     template <typename... Args> static LDClientCPP *Init(Args&&...) { return nullptr; }
     template <typename... Args> bool boolVariation(Args&&...) { return false; }
+    template <typename... Args> bool boolVariationDetail(Args&&...) { return false; }
+    template <typename... Args> int intVariationDetail(Args&&...) { return 0; }
+    template <typename... Args> double doubleVariationDetail(Args&&...) { return 0; }
     template <typename... Args> int intVariation(Args&&...) { return 0; }
     template <typename... Args> double doubleVariation(Args&&...) { return 0; }
     template <typename... Args> const char *stringVariation(Args&&...) { return ""; }

--- a/snippets/validators/languages/cpp-server-v2-c/api.h
+++ b/snippets/validators/languages/cpp-server-v2-c/api.h
@@ -24,6 +24,34 @@ struct LDClient;
 struct LDUser;
 struct LDJSON;
 
+/* Evaluation-reason surface. Mirrors the real v2 header's enum order
+ * and the LDDetails fields the doc fragments touch (the real struct
+ * carries an additional per-kind `extra` union the fragments never
+ * reference). */
+enum LDEvalReason {
+    LD_UNKNOWN = 0,
+    LD_ERROR,
+    LD_OFF,
+    LD_PREREQUISITE_FAILED,
+    LD_TARGET_MATCH,
+    LD_RULE_MATCH,
+    LD_FALLTHROUGH
+};
+
+struct LDDetails {
+    unsigned int variationIndex;
+    LDBoolean hasVariation;
+    enum LDEvalReason reason;
+};
+
+static inline void LDDetailsInit(struct LDDetails *details) {
+    (void)details;
+}
+
+static inline void LDDetailsClear(struct LDDetails *details) {
+    (void)details;
+}
+
 static inline struct LDConfig *LDConfigNew(const char *key) {
     (void)key;
     return (struct LDConfig *)0;
@@ -78,7 +106,7 @@ static inline LDBoolean LDBoolVariation(struct LDClient *client,
                                         struct LDUser *user,
                                         const char *flagKey,
                                         LDBoolean fallback,
-                                        struct LDJSON **details) {
+                                        struct LDDetails *details) {
     (void)client;
     (void)user;
     (void)flagKey;
@@ -90,7 +118,7 @@ static inline int LDIntVariation(struct LDClient *client,
                                  struct LDUser *user,
                                  const char *flagKey,
                                  int fallback,
-                                 struct LDJSON **details) {
+                                 struct LDDetails *details) {
     (void)client;
     (void)user;
     (void)flagKey;
@@ -102,7 +130,7 @@ static inline double LDDoubleVariation(struct LDClient *client,
                                        struct LDUser *user,
                                        const char *flagKey,
                                        double fallback,
-                                       struct LDJSON **details) {
+                                       struct LDDetails *details) {
     (void)client;
     (void)user;
     (void)flagKey;
@@ -114,7 +142,7 @@ static inline char *LDStringVariation(struct LDClient *client,
                                       struct LDUser *user,
                                       const char *flagKey,
                                       const char *fallback,
-                                      struct LDJSON **details) {
+                                      struct LDDetails *details) {
     (void)client;
     (void)user;
     (void)flagKey;

--- a/snippets/validators/languages/cpp-server-v2-cpp/Dockerfile
+++ b/snippets/validators/languages/cpp-server-v2-cpp/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:bookworm-slim
+
+# Parse-and-type-check validator for C++-flavored fragments of the
+# legacy v2.x C server SDK (launchdarkly/c-server-sdk). The v2 server
+# SDK had no separate C++ binding class — its docs simply call the C
+# API from C++ (`LDDetails details; bool value = LDBoolVariation(...)`),
+# so those fragments need g++ rather than the cpp-server-v2-c
+# validator's C11 gcc pass (`bool`, unqualified struct names, and other
+# C++-isms reject under -std=c11).
+#
+# Reuses the cpp-server-v2-c stub <launchdarkly/api.h> — same API
+# surface, compiled as C++. Parse + type-check are the goal here; no
+# real flag evaluation runs.
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        g++ libc6-dev ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/local/include/launchdarkly
+COPY languages/cpp-server-v2-c/api.h /usr/local/include/launchdarkly/api.h
+
+WORKDIR /work
+
+COPY shared /harness-shared
+COPY languages/cpp-server-v2-cpp/harness /harness
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/snippets/validators/languages/cpp-server-v2-cpp/harness/run.sh
+++ b/snippets/validators/languages/cpp-server-v2-cpp/harness/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Parse-and-type-check the staged C++ file against the stub
+# <launchdarkly/api.h>. Success = g++ accepts the syntax.
+set -eu
+
+. /harness-shared/lib.sh
+require_env SNIPPET_ENTRYPOINT
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+cp "/snippet/$SNIPPET_ENTRYPOINT" "$WORK/main.cpp"
+cd "$WORK"
+
+LOG=$(mktemp)
+if g++ -std=c++17 -fsyntax-only -Wall main.cpp >"$LOG" 2>&1; then
+    echo "feature flag evaluates to true"
+    echo "validator: ok (g++ -fsyntax-only against v2 C server SDK stub headers succeeded)"
+    exit 0
+fi
+fail_with_log "$LOG" "c-server v2 SDK C++ parse/type-check failed"

--- a/snippets/validators/languages/cpp-server-v2-cpp/runner.yaml
+++ b/snippets/validators/languages/cpp-server-v2-cpp/runner.yaml
@@ -1,0 +1,3 @@
+mode: docker
+runs-on: ubuntu-latest
+image-prefix: sdk-snippets/cpp-server-v2-cpp-validator


### PR DESCRIPTION
Ports `/sdk/features/evaluation-reasons` from ld-docs-private into canonical snippets — the follow-on to the config (#448) and evaluating (#459) ports.

## What's here

- **55 snippets** under `sdk-docs/features/evaluation-reasons/` across 24 SDKs, extracted from `fern/topics/sdk/features/evaluation-reasons.mdx`.
- **54 bound to validators**; 53 validated locally (iOS Swift runs on the macOS CI row). The one non-bind is iOS Objective-C — no Objective-C parse scaffold exists (same blocker as the evaluating port).

## New validation routing

| Addition | Why |
|---|---|
| `android .../java-syntax-only-v4` (jvm + stubs) | v4 fragments use `new LDConfig.Builder()`, which the v5 aar removed; stubs only the `com.launchdarkly.sdk.android` surface, real `com.launchdarkly.sdk` types |
| `java/csharp/android .../-members` scaffolds | the reason-inspection fragments are method declarations; Java/C# have no local methods, so these splice at class scope |
| `haskell-syntax-only-toplevel` (+`-v3`) | the Haskell fragments are top-level bindings referencing ambient `client`/`context` (v3: `user`); stubs must live at module scope |
| `cpp-server-v2-cpp` validator + scaffold | the v2 C server SDK "C++ binding" fragments are C API called from C++; g++ pass over the same stub header as `cpp-server-v2-c` |
| Stub extensions | detail-variation members (v2 headers, v3 `_AnyClient`), `LDDetails`/`LDEvalReason` on the server v2 header (signature corrected to `struct LDDetails *`), ambient-name stubs (android, .NET, iOS), `Reason` import (rust), Timber in the android image |

## Content corrections

The page had several samples that could not work as written; each is fixed in its snippet and documented in `sdks/_feature-docs-evaluation-reasons-port-notes.md`:

- .NET / Java / Android reason-inspection samples used the v4-era nested-class API (`(EvaluationReason.RuleMatch) reason`) that no longer exists; rewritten to the flat getters. The .NET one also contained `System.out.println`.
- Python sample used Python 2 `print` statements (a syntax error today).
- Go sample referenced an undefined variable `r`.
- JS v4.x block was initialization boilerplate that never called a `*variationDetail` method; replaced with a `boolVariationDetail` example paralleling the v3 block.
- Flutter v4: nullable `variationIndex`/`reason`; `LDKind` members are lowerCamelCase.
- Lua: colon call passed `client` again as the first arg; `details.reason` is a table, not a string.
- C client v2: `details->reason` on a stack struct; `LDFreeDetailContents` takes the struct by value.
- .NET client: synchronous `LdClient.Init` requires the timeout argument (matches the config-port fix).

## Validation

All bound snippets pass `snippets validate` locally (Linux), including regression runs over existing snippets that share the modified scaffolds/headers (android java+kotlin, dotnet app-config, rust config, cpp evaluating v3 + v2, dotnet-client v3 init).

Docs PR (markers + render) follows after this merges and a snippets release is cut.


SDK-2507

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and offline syntax-validation only; no runtime product or auth changes. Shared scaffolds were extended with regression coverage noted in the PR.
> 
> **Overview**
> Ports **`/sdk/features/evaluation-reasons`** into **55 canonical snippets** across 24 SDKs (54 validator-bound; iOS Objective-C remains unbound). Adds **`_feature-docs-evaluation-reasons-port-notes.md`** documenting content fixes and new validation routing.
> 
> **Validation infrastructure:** New scaffolds include **`java-syntax-only-v4`** (JVM stubs for Android v4 API), **`-members`** splices for Java/C#/Android method-shaped fragments, **Haskell toplevel** (+ v3), **`cpp-server-v2-cpp`** validator (g++ over v2 server stub header), and stub/header extensions for **`variationDetail`**, **`LDDetails`**, ambient **`context`** fields, Rust **`Reason`**, and **Timber** in the Android validator image.
> 
> **CI:** Android **sdk-docs** row skips **`evaluation-reasons-v4-java`**; a dedicated row validates that snippet via JVM with a **server** key.
> 
> **Snippet fixes** (where published samples were wrong): flat **`EvaluationReason`** APIs for .NET/Java/Android, Python 3 **`print`**, Go variable name, JS v4 **`boolVariationDetail`**, Flutter nullability/`LDKind`, Lua colon-call and reason shape, C v2 struct/free APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa910823da0454b1c6b485782eaf77f4fb145d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->