### PR TITLE
feat(snippets): add experimentation button-copy snippets for five SDKs

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -130,6 +130,17 @@ jobs:
             label: android-client-sdk (init)
             snippet: android-client-sdk/sdk-info/init
 
+          # Android experimentation fragments are Kotlin and validate
+          # through kotlin-syntax-only (gradle compile in parse mode).
+          # The android rows are all snippet-/group-filtered, so the
+          # group needs its own row — unlike js/react/react-native,
+          # whose unfiltered rows pick experimentation up implicitly.
+          - sdk: android-client-sdk
+            runs-on: ubuntu-latest
+            key-type: mobile
+            label: android-client-sdk (experimentation)
+            group: experimentation
+
           # Android sdk-docs: Kotlin reference fragments wrapped by
           # kotlin-syntax-only run `./gradlew compileDebugKotlin`
           # against the real launchdarkly-android-client-sdk aar +

--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -117,6 +117,11 @@ jobs:
             key-type: mobile
             label: ios-client-sdk (sdk-docs)
             group: sdk-docs
+          - sdk: ios-client-sdk
+            runs-on: macos-latest
+            key-type: mobile
+            label: ios-client-sdk (experimentation)
+            group: experimentation
 
           # Android init: scaffolded with a MainApplication that
           # exercises LDClient.init(this@MainApplication, ...) under

--- a/snippets/sdks/_experimentation-port-notes.md
+++ b/snippets/sdks/_experimentation-port-notes.md
@@ -65,25 +65,26 @@ Per-SDK summary:
   existing Python import-lift pre-step moves the body's
   `import LaunchDarkly` up to file scope.
 
-## Still unvalidated: android-client-sdk
+## android-client-sdk
 
-**Snippets affected**: `android-client-sdk/experimentation/{track-only,full}`.
+**Snippets affected**: `android-client-sdk/experimentation/{track-only,full,button-copy}`.
 
-**Why unbindable today**: the existing
-`android-client-sdk/scaffolds/android-syntax-only` scaffold routes
-through the `jvm` validator (Java + Maven against
-`launchdarkly-java-server-sdk`); the experimentation bodies are
-Kotlin and reference `com.launchdarkly.sdk.android.*` types (the
-android client SDK ships as an `aar` to Google's Maven, not a plain
-jar to Maven Central), plus AndroidX types like `AppCompatActivity`,
-`Application`, and `Bundle`. There is no parse-only mode of the
-`android-client` validator (the existing harness drives a
-MainActivity through a Robolectric lifecycle and asserts on a
-TextView), and adding one would require a kotlinc-only /
-`compileDebugKotlin` dispatch path plus a kotlin-aware syntax-only
-scaffold — larger than this slice. Same structural gap as the
-`android-client-sdk/sdk-docs/*` fragments documented in
-`_sdk-docs-port-notes.md`.
+All three bind to `android-client-sdk/scaffolds/kotlin-syntax-only`,
+which routes through the `android-client` validator's parse mode
+(`./gradlew compileDebugJavaWithJavac` / `compileDebugKotlin` against
+the real `launchdarkly-android-client-sdk` aar and AndroidX
+classpath). The bodies splice into the scaffold's unreachable
+`onCreate` block; Kotlin permits local `fun`/`val`/`class`
+declarations, the harness's import-lift pre-step hoists the bodies'
+`import` lines to file scope, and `this@BaseApplication` resolves
+against the scaffold's own class name.
+
+Binding surfaced one content bug in the track-only and full variants:
+both imported `com.launchdarkly.sdk.android.AutoEnvAttributes`, which
+does not exist — the enum is nested at
+`com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes` —
+so the published samples would not have compiled as written. The
+import paths are corrected.
 
 ## Reviewer comments applied inline
 

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -1,0 +1,42 @@
+---
+id: android-client-sdk/experimentation/button-copy
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Configures a Button to display the assigned variation's label and track clicks. Pass your existing button instance to wire it up in place.
+# Bucket C: newly proposed experimentation onboarding snippet, not
+# standalone-runnable (references LDClient singleton and an Activity host). No
+# validation block yet. See _experimentation-port-notes.md.
+---
+
+```kotlin
+import android.widget.Button
+import com.launchdarkly.sdk.android.LDClient
+
+// Configures a Button to display the assigned variation's label and track clicks.
+// Pass your existing button instance to wire it up without changing your layout.
+// Call this after LDClient.init() and after identify() resolves (if the user
+// became known mid-session).
+//
+// Prerequisites:
+//   - A string flag whose key matches YOUR_FLAG_KEY. Set each variation's value to
+//     the button label you want users to see (e.g. "Get started", "Start for free").
+//     The flag value is used as the button label directly.
+//   - A click metric whose key matches YOUR_METRIC_KEY attached to your experiment.
+fun configureExperimentButton(button: Button, onClick: (() -> Unit)? = null) {
+    val client = LDClient.get()
+
+    // The flag value is the button label. The default is shown when the flag is off
+    // or the SDK hasn't finished initializing yet.
+    // Don't cache the result — LaunchDarkly deduplicates exposure events automatically.
+    button.text = client.stringVariation("YOUR_FLAG_KEY", "Get started")
+
+    button.setOnClickListener {
+        // Track the click so LaunchDarkly can attribute it to the right variation.
+        // Use the same context that was active during the flag evaluation above —
+        // mismatched contexts break conversion attribution.
+        client.track("YOUR_METRIC_KEY")
+        onClick?.invoke()
+    }
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -4,9 +4,8 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Configures a Button to display the assigned variation's label and track clicks. Pass your existing button instance to wire it up in place.
-# Bucket C: newly proposed experimentation onboarding snippet, not
-# standalone-runnable (references LDClient singleton and an Activity host). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
 ---
 
 ```kotlin

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/full.snippet.md
@@ -4,15 +4,14 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Full experimentation onboarding for android-client-sdk — initialize, identify off the main thread on login/eligibility, evaluate, and track conversions.
-# TODO(validate): newly proposed experimentation onboarding snippet, not
-# standalone-runnable (references applyVariant and an Activity host). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
 ---
 
 ```kotlin
 import com.launchdarkly.sdk.LDContext
 import com.launchdarkly.sdk.LDValue
-import com.launchdarkly.sdk.android.AutoEnvAttributes
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes
 import com.launchdarkly.sdk.android.LDClient
 import com.launchdarkly.sdk.android.LDConfig
 import kotlinx.coroutines.CoroutineScope

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -4,15 +4,14 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Experimentation onboarding (track only) for android-client-sdk — initialize and add a trackMetric helper for conversion events.
-# TODO(validate): newly proposed experimentation onboarding snippet, not
-# standalone-runnable (assumes a BaseApplication host + your app). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
 ---
 
 ```kotlin
 import com.launchdarkly.sdk.*
 import com.launchdarkly.sdk.android.*
-import com.launchdarkly.sdk.android.AutoEnvAttributes
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes
 
 // This is your mobile key.
 val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -33,7 +33,12 @@ func configureExperimentButton(_ button: UIButton, onTap: (() -> Void)? = nil) {
     let label = client.stringVariation(forKey: "YOUR_FLAG_KEY", defaultValue: "Get started")
     button.setTitle(label, for: .normal)
 
-    let action = UIAction { _ in
+    // Use a stable identifier so re-calling this function (e.g. after identify())
+    // replaces the existing handler rather than stacking a second one.
+    let actionID = UIAction.Identifier("com.example.experimentButton")
+    button.removeAction(identifiedBy: actionID, for: .touchUpInside)
+
+    let action = UIAction(identifier: actionID) { _ in
         // Track the tap so LaunchDarkly can attribute it to the right variation.
         // Use the same context that was active during the flag evaluation above —
         // mismatched contexts break conversion attribution.

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -31,7 +31,12 @@ func configureExperimentButton(_ button: UIButton, onTap: (() -> Void)? = nil) {
     // or the SDK hasn't finished initializing yet.
     // Don't cache the result — LaunchDarkly deduplicates exposure events automatically.
     let label = client.stringVariation(forKey: "YOUR_FLAG_KEY", defaultValue: "Get started")
-    button.setTitle(label, for: .normal)
+    // UIButton.Configuration (iOS 15+) ignores setTitle(_:for:). Detect and handle both.
+    if #available(iOS 15, *), button.configuration != nil {
+        button.configuration?.title = label
+    } else {
+        button.setTitle(label, for: .normal)
+    }
 
     // Use a stable identifier so re-calling this function (e.g. after identify())
     // replaces the existing handler rather than stacking a second one.

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -1,0 +1,45 @@
+---
+id: ios-client-sdk/experimentation/button-copy
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Configures a UIButton to display the assigned variation's label and track taps. Pass your existing button instance to wire it up in place.
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+---
+
+```swift
+import LaunchDarkly
+import UIKit
+
+// Configures a UIButton to display the assigned variation's title and track taps.
+// Pass your existing button instance to wire it up without changing your layout.
+// Call this after startLaunchDarkly() and after identify() resolves (if the user
+// became known mid-session).
+//
+// Prerequisites:
+//   - A string flag whose key matches YOUR_FLAG_KEY. Set each variation's value to
+//     the button label you want users to see (e.g. "Get started", "Start for free").
+//     The flag value is used as the button title directly.
+//   - A tap metric whose key matches YOUR_METRIC_KEY attached to your experiment.
+// Requires iOS 14+. For iOS 13 support, replace UIAction with addTarget(_:action:for:).
+@available(iOS 14.0, *)
+func configureExperimentButton(_ button: UIButton, onTap: (() -> Void)? = nil) {
+    let client = LDClient.get()!
+
+    // The flag value is the button title. The default is shown when the flag is off
+    // or the SDK hasn't finished initializing yet.
+    // Don't cache the result — LaunchDarkly deduplicates exposure events automatically.
+    let label = client.stringVariation(forKey: "YOUR_FLAG_KEY", defaultValue: "Get started")
+    button.setTitle(label, for: .normal)
+
+    let action = UIAction { _ in
+        // Track the tap so LaunchDarkly can attribute it to the right variation.
+        // Use the same context that was active during the flag evaluation above —
+        // mismatched contexts break conversion attribution.
+        client.track(key: "YOUR_METRIC_KEY")
+        onTap?()
+    }
+    button.addAction(action, for: .touchUpInside)
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -9,17 +9,6 @@ validation:
 ---
 
 ```javascript
-import { createClient } from '@launchdarkly/js-client-sdk';
-
-// Initialize once — see the experimentation/full snippet for the full setup.
-// If ldClient is already initialized elsewhere in your app, import it and remove this block.
-export const ldClient = createClient('YOUR_CLIENT_SIDE_ID', {
-  kind: 'user',
-  key: 'EXAMPLE_CONTEXT_KEY', // use a consistent key so the same user gets the same experience
-  anonymous: true,
-});
-await ldClient.start();
-
 // Creates a <button> element whose label reflects the assigned variation.
 // Call this after the client is ready and attach the returned element to the DOM
 // wherever your original button lives.

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -1,0 +1,50 @@
+---
+id: js-client-sdk/experimentation/button-copy
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Creates a <button> element whose label reflects the assigned flag variation and tracks clicks. Drop in wherever you want to A/B test button copy.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+import { createClient } from '@launchdarkly/js-client-sdk';
+
+// Initialize once — see the experimentation/full snippet for the full setup.
+// If ldClient is already initialized elsewhere in your app, import it and remove this block.
+export const ldClient = createClient('YOUR_CLIENT_SIDE_ID', {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY', // use a consistent key so the same user gets the same experience
+  anonymous: true,
+});
+await ldClient.start();
+
+// Creates a <button> element whose label reflects the assigned variation.
+// Call this after the client is ready and attach the returned element to the DOM
+// wherever your original button lives.
+//
+// Prerequisites:
+//   - A string flag whose key matches YOUR_FLAG_KEY. Set each variation's value to
+//     the button label you want users to see (e.g. "Get started", "Start for free").
+//     The flag value is used as the button label directly.
+//   - A click metric whose key matches YOUR_METRIC_KEY attached to your experiment.
+export function createExperimentButton({ onClick } = {}) {
+  // The flag value is the button label. The default is shown when the flag is off
+  // or the SDK hasn't finished initializing yet.
+  // Don't cache the result — LaunchDarkly deduplicates exposure events automatically.
+  const label = ldClient.variation('YOUR_FLAG_KEY', 'Get started');
+
+  const button = document.createElement('button');
+  button.textContent = label;
+
+  button.addEventListener('click', () => {
+    // Track the click so LaunchDarkly can attribute it to the right variation.
+    // Mismatched contexts (evaluating as user A, tracking as user B) break conversion attribution.
+    ldClient.track('YOUR_METRIC_KEY');
+    onClick?.();
+  });
+
+  return button;
+}
+```

--- a/snippets/sdks/react-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -1,0 +1,53 @@
+---
+id: react-client-sdk/experimentation/button-copy
+sdk: react-client-sdk
+kind: reference
+lang: tsx
+description: Standalone ExperimentButton component — reads its label from a string flag and tracks clicks. Drop in wherever you want to A/B test button copy.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
+---
+
+```tsx
+import { useCallback } from "react";
+import { useFlags, useLDClient } from "@launchdarkly/react-sdk";
+
+interface ExperimentButtonProps {
+  onClick?: () => void;
+  className?: string;
+}
+
+// Drop-in replacement for any <button> you want to A/B test.
+//
+// Prerequisites:
+//   1. Wrap your app in <LDProvider> (see the experimentation/full snippet).
+//   2. Create a string flag whose key matches YOUR_FLAG_KEY. Set each variation's
+//      value to the button label you want users to see (e.g. "Get started",
+//      "Start for free"). The flag value is used as the button label directly.
+//   3. Create a click metric in LaunchDarkly whose key matches YOUR_METRIC_KEY
+//      and attach it to your experiment.
+export function ExperimentButton({ onClick, className }: ExperimentButtonProps) {
+  // useFlags() re-renders the component whenever the flag value changes,
+  // so live targeting rule updates reach the button without a page reload.
+  const flags = useFlags();
+  const ldClient = useLDClient();
+
+  // The flag value is the button label. Fall back to a default when the flag is
+  // off or the SDK hasn't finished initializing yet.
+  const label: string = flags["YOUR_FLAG_KEY"] ?? "Get started";
+
+  const handleClick = useCallback(() => {
+    // Track the click so LaunchDarkly can attribute conversions to the right variation.
+    // Use the same user context that was active when the flag was evaluated —
+    // mismatched contexts break conversion attribution.
+    ldClient?.track("YOUR_METRIC_KEY");
+    onClick?.();
+  }, [ldClient, onClick]);
+
+  return (
+    <button className={className} onClick={handleClick}>
+      {label}
+    </button>
+  );
+}
+```

--- a/snippets/sdks/react-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -10,7 +10,7 @@ validation:
 
 ```tsx
 import { useCallback } from "react";
-import { useFlags, useLDClient } from "@launchdarkly/react-sdk";
+import { useLDClient, useStringVariation } from "@launchdarkly/react-sdk";
 
 interface ExperimentButtonProps {
   onClick?: () => void;
@@ -27,20 +27,18 @@ interface ExperimentButtonProps {
 //   3. Create a click metric in LaunchDarkly whose key matches YOUR_METRIC_KEY
 //      and attach it to your experiment.
 export function ExperimentButton({ onClick, className }: ExperimentButtonProps) {
-  // useFlags() re-renders the component whenever the flag value changes,
-  // so live targeting rule updates reach the button without a page reload.
-  const flags = useFlags();
+  // useStringVariation looks the flag up by its key, subscribes to it, and
+  // re-renders the component whenever its value changes, so live targeting
+  // rule updates reach the button without a page reload. The default is shown
+  // when the flag is off or the SDK hasn't finished initializing yet.
+  const label = useStringVariation("YOUR_FLAG_KEY", "Get started");
   const ldClient = useLDClient();
-
-  // The flag value is the button label. Fall back to a default when the flag is
-  // off or the SDK hasn't finished initializing yet.
-  const label: string = flags["YOUR_FLAG_KEY"] ?? "Get started";
 
   const handleClick = useCallback(() => {
     // Track the click so LaunchDarkly can attribute conversions to the right variation.
     // Use the same user context that was active when the flag was evaluated —
     // mismatched contexts break conversion attribution.
-    ldClient?.track("YOUR_METRIC_KEY");
+    ldClient.track("YOUR_METRIC_KEY");
     onClick?.();
   }, [ldClient, onClick]);
 

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -9,7 +9,7 @@ validation:
 ---
 
 ```tsx
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Pressable, Text } from 'react-native';
 import { ReactNativeLDClient } from '@launchdarkly/react-native-client-sdk';
 
@@ -29,10 +29,19 @@ interface ExperimentButtonProps {
 //   3. Create a press metric in LaunchDarkly whose key matches YOUR_METRIC_KEY
 //      and attach it to your experiment.
 export function ExperimentButton({ client, onPress }: ExperimentButtonProps) {
-  // The flag value is the button label. The default is shown when the flag is off
-  // or the SDK hasn't finished initializing yet.
-  // Don't cache the result — LaunchDarkly deduplicates exposure events automatically.
-  const label = client.variation('YOUR_FLAG_KEY', 'Get started') as string;
+  // Initialise from the current flag value and re-render whenever it changes,
+  // so live targeting updates reach the button without remounting.
+  const [label, setLabel] = useState<string>(
+    () => client.variation('YOUR_FLAG_KEY', 'Get started') as string,
+  );
+
+  useEffect(() => {
+    const updateLabel = () => {
+      setLabel(client.variation('YOUR_FLAG_KEY', 'Get started') as string);
+    };
+    client.on('change:YOUR_FLAG_KEY', updateLabel);
+    return () => { client.off('change:YOUR_FLAG_KEY', updateLabel); };
+  }, [client]);
 
   const handlePress = useCallback(() => {
     // Track the press so LaunchDarkly can attribute it to the right variation.

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -1,0 +1,50 @@
+---
+id: react-native-client-sdk/experimentation/button-copy
+sdk: react-native-client-sdk
+kind: reference
+lang: tsx
+description: Standalone ExperimentButton component — reads its label from a string flag and tracks presses. Drop in wherever you want to A/B test button copy.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+---
+
+```tsx
+import React, { useCallback } from 'react';
+import { Pressable, Text } from 'react-native';
+import { ReactNativeLDClient } from '@launchdarkly/react-native-client-sdk';
+
+interface ExperimentButtonProps {
+  client: ReactNativeLDClient;
+  onPress?: () => void;
+}
+
+// Drop-in replacement for any pressable element you want to A/B test.
+//
+// Prerequisites:
+//   1. Initialize an LDClient and wrap your app in <LDProvider>
+//      (see the experimentation/full snippet).
+//   2. Create a string flag whose key matches YOUR_FLAG_KEY. Set each variation's
+//      value to the button label you want users to see (e.g. "Get started",
+//      "Start for free"). The flag value is used as the button label directly.
+//   3. Create a press metric in LaunchDarkly whose key matches YOUR_METRIC_KEY
+//      and attach it to your experiment.
+export function ExperimentButton({ client, onPress }: ExperimentButtonProps) {
+  // The flag value is the button label. The default is shown when the flag is off
+  // or the SDK hasn't finished initializing yet.
+  // Don't cache the result — LaunchDarkly deduplicates exposure events automatically.
+  const label = client.variation('YOUR_FLAG_KEY', 'Get started') as string;
+
+  const handlePress = useCallback(() => {
+    // Track the press so LaunchDarkly can attribute it to the right variation.
+    // Mismatched contexts (evaluating as user A, tracking as user B) break conversion attribution.
+    client.track('YOUR_METRIC_KEY');
+    onPress?.();
+  }, [client, onPress]);
+
+  return (
+    <Pressable onPress={handlePress}>
+      <Text>{label}</Text>
+    </Pressable>
+  );
+}
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/button-copy.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/button-copy.snippet.md
@@ -9,12 +9,11 @@ validation:
 ---
 
 ```tsx
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import { Pressable, Text } from 'react-native';
-import { ReactNativeLDClient } from '@launchdarkly/react-native-client-sdk';
+import { useLDClient, useStringVariation } from '@launchdarkly/react-native-client-sdk';
 
 interface ExperimentButtonProps {
-  client: ReactNativeLDClient;
   onPress?: () => void;
 }
 
@@ -28,20 +27,14 @@ interface ExperimentButtonProps {
 //      "Start for free"). The flag value is used as the button label directly.
 //   3. Create a press metric in LaunchDarkly whose key matches YOUR_METRIC_KEY
 //      and attach it to your experiment.
-export function ExperimentButton({ client, onPress }: ExperimentButtonProps) {
-  // Initialise from the current flag value and re-render whenever it changes,
-  // so live targeting updates reach the button without remounting.
-  const [label, setLabel] = useState<string>(
-    () => client.variation('YOUR_FLAG_KEY', 'Get started') as string,
-  );
-
-  useEffect(() => {
-    const updateLabel = () => {
-      setLabel(client.variation('YOUR_FLAG_KEY', 'Get started') as string);
-    };
-    client.on('change:YOUR_FLAG_KEY', updateLabel);
-    return () => { client.off('change:YOUR_FLAG_KEY', updateLabel); };
-  }, [client]);
+export function ExperimentButton({ onPress }: ExperimentButtonProps) {
+  // useStringVariation subscribes to the flag, so the label updates as soon as
+  // initialization completes or targeting changes — no manual change listener
+  // or parent re-render needed. The default is shown when the flag is off or
+  // the SDK hasn't finished initializing yet.
+  // Don't cache the result — LaunchDarkly deduplicates exposure events automatically.
+  const label = useStringVariation('YOUR_FLAG_KEY', 'Get started');
+  const client = useLDClient();
 
   const handlePress = useCallback(() => {
     // Track the press so LaunchDarkly can attribute it to the right variation.


### PR DESCRIPTION
snippet to be used for the experimentation get started button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation snippets and CI matrix rows only; no runtime product or auth changes.
> 
> **Overview**
> Adds **experimentation `button-copy`** reference snippets for JS, React, React Native, iOS, and Android so docs can show A/B-tested button labels from a string flag plus metric tracking on click/tap.
> 
> **Android** `track-only` and `full` now bind to `kotlin-syntax-only` (removing validate TODOs) and fix the `AutoEnvAttributes` import to `LDConfig.Builder.AutoEnvAttributes`. Port notes drop the “still unvalidated” Android section in favor of documenting that binding and the import fix.
> 
> **CI** adds dedicated `experimentation` matrix rows for **ios-client-sdk** (macOS) and **android-client-sdk** (Ubuntu); web/RN SDKs still pick up the new snippets via existing unfiltered validate rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7836491104c982dabf12b35d6e48bdcbf93efbd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->