### PR TITLE
feat(snippets): bind android experimentation track-only and full snippets

### DIFF
--- a/snippets/sdks/_experimentation-port-notes.md
+++ b/snippets/sdks/_experimentation-port-notes.md
@@ -65,25 +65,26 @@ Per-SDK summary:
   existing Python import-lift pre-step moves the body's
   `import LaunchDarkly` up to file scope.
 
-## Still unvalidated: android-client-sdk
+## android-client-sdk
 
-**Snippets affected**: `android-client-sdk/experimentation/{track-only,full}`.
+**Snippets affected**: `android-client-sdk/experimentation/{track-only,full,button-copy}`.
 
-**Why unbindable today**: the existing
-`android-client-sdk/scaffolds/android-syntax-only` scaffold routes
-through the `jvm` validator (Java + Maven against
-`launchdarkly-java-server-sdk`); the experimentation bodies are
-Kotlin and reference `com.launchdarkly.sdk.android.*` types (the
-android client SDK ships as an `aar` to Google's Maven, not a plain
-jar to Maven Central), plus AndroidX types like `AppCompatActivity`,
-`Application`, and `Bundle`. There is no parse-only mode of the
-`android-client` validator (the existing harness drives a
-MainActivity through a Robolectric lifecycle and asserts on a
-TextView), and adding one would require a kotlinc-only /
-`compileDebugKotlin` dispatch path plus a kotlin-aware syntax-only
-scaffold — larger than this slice. Same structural gap as the
-`android-client-sdk/sdk-docs/*` fragments documented in
-`_sdk-docs-port-notes.md`.
+All three bind to `android-client-sdk/scaffolds/kotlin-syntax-only`,
+which routes through the `android-client` validator's parse mode
+(`./gradlew compileDebugJavaWithJavac` / `compileDebugKotlin` against
+the real `launchdarkly-android-client-sdk` aar and AndroidX
+classpath). The bodies splice into the scaffold's unreachable
+`onCreate` block; Kotlin permits local `fun`/`val`/`class`
+declarations, the harness's import-lift pre-step hoists the bodies'
+`import` lines to file scope, and `this@BaseApplication` resolves
+against the scaffold's own class name.
+
+Binding surfaced one content bug in the track-only and full variants:
+both imported `com.launchdarkly.sdk.android.AutoEnvAttributes`, which
+does not exist — the enum is nested at
+`com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes` —
+so the published samples would not have compiled as written. The
+import paths are corrected.
 
 ## Reviewer comments applied inline
 

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/full.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/full.snippet.md
@@ -4,15 +4,14 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Full experimentation onboarding for android-client-sdk — initialize, identify off the main thread on login/eligibility, evaluate, and track conversions.
-# TODO(validate): newly proposed experimentation onboarding snippet, not
-# standalone-runnable (references applyVariant and an Activity host). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
 ---
 
 ```kotlin
 import com.launchdarkly.sdk.LDContext
 import com.launchdarkly.sdk.LDValue
-import com.launchdarkly.sdk.android.AutoEnvAttributes
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes
 import com.launchdarkly.sdk.android.LDClient
 import com.launchdarkly.sdk.android.LDConfig
 import kotlinx.coroutines.CoroutineScope

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -4,15 +4,14 @@ sdk: android-client-sdk
 kind: reference
 lang: kotlin
 description: Experimentation onboarding (track only) for android-client-sdk — initialize and add a trackMetric helper for conversion events.
-# TODO(validate): newly proposed experimentation onboarding snippet, not
-# standalone-runnable (assumes a BaseApplication host + your app). No
-# validation block yet. See _experimentation-port-notes.md.
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
 ---
 
 ```kotlin
 import com.launchdarkly.sdk.*
 import com.launchdarkly.sdk.android.*
-import com.launchdarkly.sdk.android.AutoEnvAttributes
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes
 
 // This is your mobile key.
 val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)


### PR DESCRIPTION
Binds the two remaining unbound Android experimentation snippets, `track-only` and `full`, to `kotlin-syntax-only`. The scaffold landed after those snippets did; it compiles Kotlin fragments against the real android aar (android-client validator, parse mode), and Kotlin permits the bodies' local `fun`/`val`/`class` declarations, so they validate with no structural changes.

Binding surfaced a content bug in both: they imported `com.launchdarkly.sdk.android.AutoEnvAttributes`, which doesn't exist — the enum is nested at `com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes` — so the published samples wouldn't have compiled as written. The import paths are corrected.

Also rewrites the now-stale "Still unvalidated: android-client-sdk" section of `_experimentation-port-notes.md` to describe the bindings.

All three android experimentation snippets (`track-only`, `full`, plus #469's `button-copy`) pass `snippets validate` locally.

Based on #469 — it needs that PR's `android-client-sdk (experimentation)` CI matrix row for these snippets to run in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and snippet-validation wiring only; changes fix incorrect imports so samples compile, with no runtime or service impact.
> 
> **Overview**
> Hooks the Android experimentation **`track-only`** and **`full`** snippets into **`kotlin-syntax-only`** validation (same path as **`button-copy`**), replacing the prior TODO-only state.
> 
> Fixes a compile error in both samples: **`AutoEnvAttributes`** is imported from **`LDConfig.Builder.AutoEnvAttributes`**, not a non-existent top-level **`com.launchdarkly.sdk.android.AutoEnvAttributes`**.
> 
> Updates **`_experimentation-port-notes.md`** to document that all three Android experimentation snippets are bound via the android-client validator’s parse/compile path, instead of the old “still unvalidated” note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93884ed6211979b2f00bb2f170d66ade6f8721fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->