### PR TITLE
feat(snippets): port /sdk/features/shutdown to canonical snippets

### DIFF
--- a/snippets/sdks/_feature-docs-shutdown-port-notes.md
+++ b/snippets/sdks/_feature-docs-shutdown-port-notes.md
@@ -1,0 +1,62 @@
+# Port notes: /sdk/features/shutdown
+
+Source: `ld-docs-private` `fern/topics/sdk/features/shutdown.mdx`.
+27 code blocks extracted into `sdk-docs/features/shutdown/` snippets
+across 22 SDKs. All but two (iOS Objective-C, Erlang) are bound to
+validators.
+
+## Content corrections
+
+None. Every body is verbatim from the MDX. The shutdown calls are all
+one-liners against APIs that still exist as published (`Dispose()`,
+`close()`/`close`, `LDClientSDK_Free` / `LDServerSDK_Free` /
+`LDClientClose`, `ldclient.get().close()`, `close client`,
+`ldclient:stop_*`), verified against the local SDK checkouts.
+
+## Validation routing added in this port
+
+Every bound snippet routes through a scaffold that already existed
+before this port:
+
+- `*-syntax-only` scaffolds for the single-call fragments (the bodies
+  reference a bare `client`, which every scaffold already stubs).
+- `cpp-client-syntax-only-v2-c` / `cpp-client-syntax-only-v2-cpp` /
+  `cpp-syntax-only-v2-c` for the C SDK v2.x blocks; the stub
+  `<launchdarkly/api.h>` / `<launchdarkly/api.hpp>` headers already
+  declare `LDClientClose` and `LDClientCPP::close`.
+- `android-client-sdk/scaffolds/java-syntax-only` (v5 aar) for the
+  Android Java block — `client.close()` is valid on the v5 API, so the
+  v4 jvm-routed stub scaffold is not needed here.
+
+One scaffold extension (additive):
+
+- `android-client-sdk/scaffolds/java-syntax-only` — the unreachable
+  `if (false)` body is now additionally wrapped in
+  `try { … } catch (Exception e) { }` (mirroring the
+  `csharp-syntax-only` scaffold's shape). The Android `client.close()`
+  fragment calls a checked-exception API (`java.io.Closeable.close()`
+  throws `IOException`), and the body's host method `onCreate`
+  overrides `Activity.onCreate`, so a `throws` clause can't be added
+  there. Catching `Exception` is legal even when the body throws no
+  checked exception, so previously bound fragments are unaffected
+  (re-validated `evaluation-reasons/print-reason-java` to confirm).
+
+## Known non-binds
+
+- `ios-client-sdk/.../shutdown-objc` — no Objective-C parse scaffold
+  exists; the iOS validator is the macOS-only native harness (same
+  blocker as the evaluating and evaluation-reasons ports' objc
+  snippets). Wiring it up requires either an Objective-C target in the
+  xcodegen scaffold or a clang -fsyntax-only stub harness.
+- `erlang-server-sdk/.../shutdown` — the block shows three
+  *alternative* calls (`stop_all_instances()`, `stop_instance()`,
+  `stop_instance(my_instance)`) separated by comment lines, which is
+  not a valid Erlang expression sequence inside the parse scaffold's
+  single function body (Erlang requires `,` separators, and adding
+  them would misrepresent the alternatives as one sequence). Same
+  shape, and same treatment, as the unbound
+  `erlang-server-sdk/sdk-docs/features/config/index` snippet. Wiring
+  it up requires either splitting the doc block into one block per
+  alternative (a docs content change) or teaching the erlang-server
+  harness a pre-rewrite that stages each blank-line-separated
+  expression as its own function clause.

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-syntax-only.snippet.md
@@ -99,8 +99,19 @@ class SnippetActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        // The unreachable body is additionally wrapped in try/catch
+        // (mirroring the csharp-syntax-only scaffold) so fragments that
+        // call checked-exception APIs -- e.g. client.close(), declared
+        // `throws IOException` via java.io.Closeable -- compile without
+        // each fragment carrying its own handler. onCreate overrides
+        // Activity.onCreate, so a `throws` clause can't be added here.
+        // catch (Exception) is legal even when the body throws nothing.
         if (false) {
+            try {
 {{ body }}
+            } catch (Exception e) {
+                // never reached
+            }
         }
     }
 }

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-java.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/sdk-docs/features/shutdown/shutdown-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: Client shutdown example for Android (Java).
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+client.close();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-kotlin.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/sdk-docs/features/shutdown/shutdown-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: Client shutdown example for Android (Kotlin).
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
+---
+
+```kotlin
+client.close()
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+description: Client shutdown example for Cloudflare.
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+
+---
+
+```typescript
+client.close();
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-c-sdk-v2-cpp.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-c-sdk-v2-cpp.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-client-sdk/sdk-docs/features/shutdown/shutdown-c-sdk-v2-cpp
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Client shutdown example for the C client SDK v2.x (C++ binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-cpp
+
+---
+
+```cpp
+client->close();
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-c-sdk-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-client-sdk/sdk-docs/features/shutdown/shutdown-c-sdk-v2
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Client shutdown example for the C client SDK v2.x (native).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-c
+
+---
+
+```c
+LDClientClose(client);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-cpp-c-v3-0.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-client-sdk/sdk-docs/features/shutdown/shutdown-cpp-c-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Client shutdown example for C++ (client-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```c
+LDClientSDK_Free(client);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/shutdown/shutdown-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/shutdown/shutdown-c-sdk-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/shutdown/shutdown-c-sdk-v2
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Client shutdown example for the C server SDK v2.x (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
+---
+
+```c
+LDClientClose(client);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/shutdown/shutdown-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/shutdown/shutdown-cpp-c-v3-0.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/shutdown/shutdown-cpp-c-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Client shutdown example for C++ (server-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
+---
+
+```c
+LDServerSDK_Free(client);
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/shutdown/shutdown
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: Client shutdown example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
+---
+
+```csharp
+client.Dispose();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: Client shutdown example for .NET (server-side).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
+---
+
+```csharp
+client.Dispose();
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: electron-client-sdk/sdk-docs/features/shutdown/shutdown
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: Client shutdown example for Electron.
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
+---
+
+```javascript
+await client.close();
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,18 @@
+---
+id: erlang-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: Client shutdown example for Erlang.
+
+---
+
+```erlang
+ldclient:stop_all_instances()
+
+% Stops the default instance
+ldclient:stop_instance()
+
+% Stops a named instance
+ldclient:stop_instance(my_instance)
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: fastly-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+description: Client shutdown example for Fastly.
+validation:
+  scaffold: fastly-server-sdk/scaffolds/fastly-syntax-only
+
+---
+
+```typescript
+client.close();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: flutter-client-sdk/sdk-docs/features/shutdown/shutdown
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Client shutdown example for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
+
+---
+
+```dart
+await client.close();
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: go-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: Client shutdown example for Go.
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+client.Close()
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: haskell-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: Client shutdown example for Haskell.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only
+
+---
+
+```haskell
+close client
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-objc.snippet.md
@@ -1,0 +1,12 @@
+---
+id: ios-client-sdk/sdk-docs/features/shutdown/shutdown-objc
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: Client shutdown example for iOS (Objective-C).
+
+---
+
+```objectivec
+[client close];
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/shutdown/shutdown-swift.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/shutdown/shutdown-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: Client shutdown example for iOS (Swift).
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
+---
+
+```swift
+client.close()
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: Client shutdown example for Java.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+client.close();
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: js-client-sdk/sdk-docs/features/shutdown/shutdown
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: Client shutdown example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
+---
+
+```javascript
+await client.close();
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-client-sdk/sdk-docs/features/shutdown/shutdown
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: Client shutdown example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
+---
+
+```javascript
+await client.close();
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+description: Client shutdown example for Node.js (server-side).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
+---
+
+```javascript
+client.close();
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: Client shutdown example for Python.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
+---
+
+```python
+ldclient.get().close()
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-native-client-sdk/sdk-docs/features/shutdown/shutdown
+sdk: react-native-client-sdk
+kind: reference
+lang: javascript
+description: Client shutdown example for React Native SDK v10.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
+---
+
+```javascript
+await client.close();
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ruby-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: Client shutdown example for Ruby.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
+---
+
+```ruby
+client.close
+```

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: rust-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: Client shutdown example for Rust.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
+---
+
+```rust
+client.close();
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/shutdown/shutdown.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vercel-server-sdk/sdk-docs/features/shutdown/shutdown
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+description: Client shutdown example for Vercel.
+validation:
+  scaffold: vercel-server-sdk/scaffolds/vercel-syntax-only
+
+---
+
+```typescript
+client.close();
+```


### PR DESCRIPTION
Ports the `/sdk/features/shutdown` feature-docs page (ld-docs-private `fern/topics/sdk/features/shutdown.mdx`) to canonical sdk-meta snippets, following the pattern of the evaluation-reasons port (#466).

## Counts

- 27 code blocks extracted into `sdks/<sdk>/snippets/sdk-docs/features/shutdown/` across 22 SDKs.
- 25 of 27 bound to validators via each SDK's existing scaffolds.
- 2 intentional non-binds (see below).
- 0 content corrections — every body is verbatim from the published MDX. The shutdown APIs (`Dispose()`, `close()`/`close`, `LDClientSDK_Free` / `LDServerSDK_Free` / `LDClientClose`, `ldclient.get().close()`, `close client`, `ldclient:stop_*`) were verified against the local SDK checkouts and all exist as published.

## Bindings

All bound snippets route through scaffolds that already existed before this port — no new scaffolds, no validator or CI workflow changes:

- `*-syntax-only` scaffolds for the single-call fragments (every scaffold already stubs a bare `client`).
- `cpp-client-syntax-only-v2-c` / `cpp-client-syntax-only-v2-cpp` / `cpp-syntax-only-v2-c` for the C SDK v2.x blocks (stub headers already declare `LDClientClose` / `LDClientCPP::close`).
- `android-client-sdk/scaffolds/java-syntax-only` (v5 aar) for the Android Java block — `client.close()` is valid on the v5 API, so the v4 jvm-routed scaffold is not needed and no CI matrix split is required.

One scaffold extension (additive): `android-client-sdk/scaffolds/java-syntax-only` now wraps the unreachable `if (false)` body in `try { … } catch (Exception e) { }`, mirroring `csharp-syntax-only`. The Android `client.close()` fragment calls a checked-exception API (`Closeable.close()` throws `IOException`) and the host method overrides `Activity.onCreate`, so a `throws` clause was not an option. Previously bound fragments are unaffected — `evaluation-reasons/print-reason-java` was re-validated locally against the extended scaffold and passes.

## Intentional non-binds

- `ios-client-sdk/.../shutdown-objc` — no Objective-C parse scaffold exists (same blocker as the evaluating and evaluation-reasons ports). Wiring it up requires an Objective-C target in the xcodegen scaffold or a clang -fsyntax-only stub harness.
- `erlang-server-sdk/.../shutdown` — the block shows three *alternative* calls separated by comment lines, which is not a valid Erlang expression sequence inside the parse scaffold's single function body; adding `,` separators would misrepresent the alternatives as one sequence. Same shape and treatment as the unbound `erlang-server-sdk/sdk-docs/features/config/index` snippet.

## Local validation

All 25 bound snippets except iOS Swift were validated locally in containers and pass (24/24). iOS Swift (`shutdown-swift`) can only run on the macOS native harness — this PR's CI macOS row covers it.

Two notes from the local runs:

- The flutter snippet failed once at the headless-browser DOM check (the success-line text never rendered; a "GPU stall due to ReadPixels" warning suggests render starvation under heavy parallel container load) and passed cleanly on an identical re-run — environment flake, not a content issue.
- After extending `java-syntax-only`, both the new Android Java snippet and the previously bound `evaluation-reasons/print-reason-java` were validated against the modified scaffold.

Port notes: `snippets/sdks/_feature-docs-shutdown-port-notes.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/snippet additions plus a narrow Android parse scaffold change; no runtime SDK or CI workflow changes, and existing bound Java fragments were re-validated.
> 
> **Overview**
> Ports the **`/sdk/features/shutdown`** feature-docs page into **27 canonical snippets** under `sdk-docs/features/shutdown/` across **22 SDKs**, with bodies kept verbatim from the MDX.
> 
> **25 snippets** wire to existing `*-syntax-only` (and C/C++ v2/v3) validation scaffolds. **iOS Objective-C** and **Erlang** stay unbound for the same scaffold/harness limits as earlier feature-doc ports (no Obj-C parse scaffold; Erlang block is multiple alternatives in one body).
> 
> The only harness change is an **additive** wrap of the Android **`java-syntax-only`** scaffold’s unreachable `if (false)` body in **`try/catch (Exception)`** so **`client.close()`** (checked `IOException`) compiles inside **`onCreate`** without per-fragment handlers. Port notes live in **`_feature-docs-shutdown-port-notes.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c562b5c43f8d29b848fea617bfb99f02d272e612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->