### PR TITLE
feat(snippets): port /sdk/features/all-flags to canonical snippets

### DIFF
--- a/snippets/sdks/_feature-docs-allflags-port-notes.md
+++ b/snippets/sdks/_feature-docs-allflags-port-notes.md
@@ -1,0 +1,65 @@
+# Port notes: /sdk/features/all-flags
+
+Source: `ld-docs-private` `fern/topics/sdk/features/all-flags.mdx`.
+40 code blocks extracted into `sdk-docs/features/allflags/` snippets
+across 25 SDKs. All but one (iOS Objective-C) are bound to validators.
+
+## Content corrections
+
+Fixes applied where the published sample could not work as written.
+Everything else is verbatim from the MDX (including incidental
+formatting like doubled spaces and trailing comment lines).
+
+- **C++ (server-side) v3.0 native** (`cpp-server-sdk/.../allflags-cpp-native-v3-0`):
+  `if (all_flags.Valid() {` was missing the closing parenthesis on the
+  condition — a syntax error. Now `if (all_flags.Valid()) {`.
+- **C++ (client-side) v3.0 C binding** (`cpp-client-sdk/.../allflags-cpp-c-v3-0`):
+  the iterator constructor was written as `LDValue_CreateObjectIter`,
+  which has never existed in the C binding; the real function (and the
+  one the SDK's own header documentation uses) is
+  `LDValue_ObjectIter_New`.
+- **iOS Swift** (`ios-client-sdk/.../allflags-swift`): `LDClient.allFlags`
+  is declared `[LDFlagKey: LDValue]?` (nil when the client is not
+  started — exactly what the page's prose says), so assigning it to a
+  non-optional `[String: LDValue]` cannot compile. Declared the result
+  as `[String: LDValue]?`.
+- **Flutter v3.x** (`flutter-client-sdk/.../allflags-v3`): the v3 SDK's
+  `LDClient` is an all-static API (the instance client arrived in v4),
+  so `await client.allFlags()` has no `client` to call through.
+  Rewritten as `await LDClient.allFlags()`, matching the v3 examples on
+  the rest of the page family.
+
+## Validation routing added in this port
+
+No new scaffolds or validators; all 39 bound snippets route through
+scaffolds that already exist. Stub-surface extensions (additive):
+
+- `cpp-client-sdk/scaffolds/cpp-client-syntax-only` — `_AnyClient`'s
+  `AllFlags` stub now returns
+  `std::unordered_map<std::string, launchdarkly::Value>` (mirroring the
+  real client) so the range-for + structured-bindings fragment
+  compiles.
+- `cpp-server-sdk/scaffolds/cpp-syntax-only` — `_AnyClient`'s
+  `AllFlagsState` stub now returns a default-constructed (invalid)
+  `launchdarkly::server_side::AllFlagsState` so `.Valid()` /
+  `.Values()` chains compile.
+- `validators/languages/cpp-client-v2-c/api.h` — `LDAllFlags(client)`
+  plus the shared LDJSON collection helpers (`LDGetIter`, `LDIterNext`,
+  `LDIterKey`, `LDJSONSerialize`, `LDFree`, `LDJSONFree`) and
+  `<stdio.h>` for the fragment's `printf`.
+- `validators/languages/cpp-client-v2-cpp/api.hpp` — `getAllFlags()` on
+  `LDClientCPP`, the same LDJSON collection helpers, and `<iostream>`
+  for the fragment's `std::cout`.
+- `validators/languages/cpp-server-v2-c/api.h` —
+  `LDAllFlags(client, user)` (the server v2 two-argument form).
+- `rust-server-sdk/scaffolds/rust-syntax-only` — `FlagDetailConfig`
+  added to the prelude import; `ldclient` stubbed alongside `client`
+  (the all-flags fragment names the ambient client `ldclient`).
+
+## Known non-binds
+
+- `ios-client-sdk/.../allflags-objc` — no Objective-C parse scaffold
+  exists; the iOS validator is the macOS-only native harness (same
+  blocker as the evaluating and evaluation-reasons ports' objc
+  snippets). Wiring it up requires either an Objective-C target in the
+  xcodegen scaffold or a clang -fsyntax-only stub harness.

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/features/allflags/allflags
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: javascript
+description: All flags example for Akamai.
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/akamai-syntax-only
+
+---
+
+```js
+const allFlags = await client.allFlagsState(context);
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/allflags/allflags-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/allflags/allflags-java.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/sdk-docs/features/allflags/allflags-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: All flags example for Android (Java).
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+client.allFlags();
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/allflags/allflags-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/features/allflags/allflags-kotlin.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/sdk-docs/features/allflags/allflags-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: All flags example for Android (Kotlin).
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+
+---
+
+```kotlin
+client.allFlags()
+```

--- a/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/apex-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: apex-server-sdk/sdk-docs/features/allflags/allflags
+sdk: apex-server-sdk
+kind: reference
+lang: java
+description: All flags example for Apex.
+validation:
+  scaffold: apex-server-sdk/scaffolds/apex-syntax-only
+
+---
+
+```java
+Map<String, LDValue> values = client.allFlags(user);
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/features/allflags/allflags
+sdk: cloudflare-server-sdk
+kind: reference
+lang: javascript
+description: All flags example for Cloudflare (TypeScript).
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/cloudflare-syntax-only
+
+---
+
+```js
+const allFlags = await client.allFlagsState(context);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/scaffolds/cpp-client-syntax-only.snippet.md
@@ -36,6 +36,7 @@ validation:
 #include <iostream>
 #include <optional>
 #include <string>
+#include <unordered_map>
 // Native C++ headers.
 #include <launchdarkly/client_side/client.hpp>
 #include <launchdarkly/context_builder.hpp>
@@ -70,7 +71,12 @@ struct _AnyClient {
     template <typename... Args> double DoubleVariation(Args&&...) const { return 0; }
     template <typename... Args> std::string StringVariation(Args&&...) const { return {}; }
     template <typename... Args> auto JsonVariation(Args&&...) const { return launchdarkly::Value{}; }
-    template <typename... Args> auto AllFlags(Args&&...) const { return launchdarkly::Value{}; }
+    // The real client's AllFlags returns a flag-key-to-Value map; the
+    // stub matches so range-for fragments with structured bindings
+    // compile.
+    template <typename... Args> auto AllFlags(Args&&...) const {
+        return std::unordered_map<std::string, launchdarkly::Value>{};
+    }
     template <typename... Args> void TrackEvent(Args&&...) const {}
     template <typename... Args> void Identify(Args&&...) const {}
     template <typename... Args> auto StartAsync(Args&&...) const { return std::async(std::launch::deferred, []{ return false; }); }

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-c-sdk-v2-cpp.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-c-sdk-v2-cpp.snippet.md
@@ -1,0 +1,23 @@
+---
+id: cpp-client-sdk/sdk-docs/features/allflags/allflags-c-sdk-v2-cpp
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: All flags example for the C client SDK v2.x (C++ binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-cpp
+
+---
+
+```cpp
+LDJSON *allFlagsObject = client->getAllFlags();
+
+const LDJSON *iter;
+for (iter = LDGetIter(allFlagsObject); iter; iter = LDIterNext(iter)) {
+   char *serialized_value = LDJSONSerialize(iter);
+   std::cout << LDIterKey(iter) << ": " << serialized_value << std::endl;
+   LDFree(serialized_value);
+}
+
+LDJSONFree(allFlagsObject);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-c-sdk-v2.snippet.md
@@ -1,0 +1,23 @@
+---
+id: cpp-client-sdk/sdk-docs/features/allflags/allflags-c-sdk-v2
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: All flags example for the C client SDK v2.x (native).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only-v2-c
+
+---
+
+```c
+struct LDJSON *allFlagsObject = LDAllFlags(client);
+
+const struct LDJSON *iter;
+for (iter = LDGetIter(allFlagsObject); iter; iter = LDIterNext(iter)) {
+   char *serialized_value = LDJSONSerialize(iter);
+   printf("%s: %s\n", LDIterKey(iter), serialized_value);
+   LDFree(serialized_value);
+}
+
+LDJSONFree(allFlagsObject);
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-c-v3-0.snippet.md
@@ -1,0 +1,26 @@
+---
+id: cpp-client-sdk/sdk-docs/features/allflags/allflags-cpp-c-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: All flags example for C++ (client-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```c
+LDValue all_flags = LDClientSDK_AllFlags(client);
+
+LDValue_ObjectIter it;
+
+for (it = LDValue_ObjectIter_New(all_flags); !LDValue_ObjectIter_End(it); LDValue_ObjectIter_Next(it)) {
+
+  char const* flag_key = LDValue_ObjectIter_Key(it);
+  LDValue flag_val_ref = LDValue_ObjectIter_Value(it);
+
+  if (LDValue_Type(flag_val_ref) == LDValueType_Bool) {
+      printf("%s: %d\n", flag_key, LDValue_GetBool(flag_val_ref));
+  }
+}
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-native-v3-0.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cpp-client-sdk/sdk-docs/features/allflags/allflags-cpp-native-v3-0
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: All flags example for C++ (client-side) SDK v3.0 (native).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```cpp
+for (auto [flag_key, flag_value] : client.AllFlags()) {
+    std::cout << flag_key << ": " << flag_value << std::endl;
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only.snippet.md
@@ -56,7 +56,12 @@ struct _AnyClient {
     template <typename... Args> double DoubleVariation(Args&&...) const { return 0; }
     template <typename... Args> std::string StringVariation(Args&&...) const { return {}; }
     template <typename... Args> auto JsonVariation(Args&&...) const { return launchdarkly::Value{}; }
-    template <typename... Args> auto AllFlagsState(Args&&...) const { return false; }
+    // The real client's AllFlagsState returns the AllFlagsState class;
+    // the stub returns a default-constructed (invalid) instance so the
+    // body's `.Valid()` / `.Values()` chains compile.
+    template <typename... Args> auto AllFlagsState(Args&&...) const {
+        return launchdarkly::server_side::AllFlagsState{};
+    }
     template <typename... Args> void TrackEvent(Args&&...) const {}
     template <typename... Args> void Identify(Args&&...) const {}
     template <typename... Args> auto StartAsync(Args&&...) const { return std::async(std::launch::deferred, []{ return false; }); }

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/allflags/allflags-c-sdk-v2.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/allflags/allflags-c-sdk-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cpp-server-sdk/sdk-docs/features/allflags/allflags-c-sdk-v2
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: All flags example for the C server SDK v2.x (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-v2-c
+
+---
+
+```c
+struct LDJSON *allFlags = LDAllFlags(client, user);
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-c-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-c-v3-0.snippet.md
@@ -1,0 +1,34 @@
+---
+id: cpp-server-sdk/sdk-docs/features/allflags/allflags-cpp-c-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: All flags example for C++ (server-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
+---
+
+```c
+LDAllFlagsState state = LDServerSDK_AllFlagsState(client, context, LD_ALLFLAGSSTATE_DEFAULT);
+
+if (LDAllFlagsState_Valid(state)) {
+    /* all flags were evaluated successfully! */
+} else {
+    /* there was an issue, but it's still possible to serialize the (empty) state. */
+}
+
+/* Retrieve a specific flag's value */
+LDValue bool_value_reference = LDAllFlagsState_Value(state, "my-bool-flag");
+if (LDValue_GetBool(bool_value_reference)) {
+    /* value is true! */
+}
+
+/* Serialize the state, suitable for bootstrapping a client-side SDK e.g. JavaScript */
+char* json = LDAllFlagsState_SerializeJSON(state);
+
+LDMemory_FreeString(json);
+
+LDAllFlagsState_Free(state);
+
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-native-v3-0.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/allflags/allflags-cpp-native-v3-0.snippet.md
@@ -1,0 +1,21 @@
+---
+id: cpp-server-sdk/sdk-docs/features/allflags/allflags-cpp-native-v3-0
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: All flags example for C++ (server-side) SDK v3.0 (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only
+
+---
+
+```cpp
+auto const all_flags = client.AllFlagsState(context);
+if (all_flags.Valid()) {
+   for (auto const& [flag_key, flag_value] : all_flags.Values()) {
+       std::cout << flag_key << ": " << flag_value << std::endl;
+   }
+}  else {
+   /* error evaluating all flags! */
+}
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-client-sdk/sdk-docs/features/allflags/allflags
+sdk: dotnet-client-sdk
+kind: reference
+lang: csharp
+description: All flags example for .NET (client-side).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+
+---
+
+```csharp
+client.AllFlags();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-server-sdk/sdk-docs/features/allflags/allflags
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+description: All flags example for .NET (server-side) SDK v7.0 (C#).
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/csharp-syntax-only
+
+---
+
+```csharp
+var state = client.AllFlagsState(context);
+```

--- a/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/electron-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: electron-client-sdk/sdk-docs/features/allflags/allflags
+sdk: electron-client-sdk
+kind: reference
+lang: javascript
+description: All flags example for Electron (JavaScript).
+validation:
+  scaffold: electron-client-sdk/scaffolds/electron-syntax-only
+
+---
+
+```js
+let allFlagsResult = client.allFlags();
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/allflags/allflags-v1x.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/allflags/allflags-v1x.snippet.md
@@ -1,0 +1,14 @@
+---
+id: erlang-server-sdk/sdk-docs/features/allflags/allflags-v1x
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: All flags example for Erlang SDK v1.x.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
+---
+
+```erlang
+ldclient:all_flags_state(#{key => <<"example-user-key">>})
+```

--- a/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/allflags/allflags-v2.snippet.md
+++ b/snippets/sdks/erlang-server-sdk/snippets/sdk-docs/features/allflags/allflags-v2.snippet.md
@@ -1,0 +1,14 @@
+---
+id: erlang-server-sdk/sdk-docs/features/allflags/allflags-v2
+sdk: erlang-server-sdk
+kind: reference
+lang: erlang
+description: All flags example for Erlang SDK v2.0+.
+validation:
+  scaffold: erlang-server-sdk/scaffolds/erlang-syntax-only
+
+---
+
+```erlang
+ldclient:all_flags_state(#{key => <<"example-context-key">>})
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: fastly-server-sdk/sdk-docs/features/allflags/allflags
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+description: All flags example for Fastly (TypeScript).
+validation:
+  scaffold: fastly-server-sdk/scaffolds/fastly-syntax-only
+
+---
+
+```ts
+const allFlags = await client.allFlagsState(context);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/allflags/allflags-v3.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/allflags/allflags-v3.snippet.md
@@ -1,0 +1,14 @@
+---
+id: flutter-client-sdk/sdk-docs/features/allflags/allflags-v3
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: All flags example for Flutter SDK v3.x.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only-v3
+
+---
+
+```dart
+Map<String, LDValue> flagValues = await LDClient.allFlags();
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/allflags/allflags-v4.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/allflags/allflags-v4.snippet.md
@@ -1,0 +1,14 @@
+---
+id: flutter-client-sdk/sdk-docs/features/allflags/allflags-v4
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: All flags example for Flutter SDK v4.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
+
+---
+
+```dart
+Map<String, LDValue> flagValues = client.allFlags();
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/allflags/allflags-v6.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/allflags/allflags-v6.snippet.md
@@ -1,0 +1,18 @@
+---
+id: go-server-sdk/sdk-docs/features/allflags/allflags-v6
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: All flags example for Go SDK v6+ (LDClient).
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+import (
+    "github.com/launchdarkly/go-server-sdk/v6/interfaces/flagstate"
+)
+
+state := client.AllFlagsState(context, flagstate.OptionClientSideOnly())
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/allflags/allflags-v7-scopedclient.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/allflags/allflags-v7-scopedclient.snippet.md
@@ -1,0 +1,23 @@
+---
+id: go-server-sdk/sdk-docs/features/allflags/allflags-v7-scopedclient
+sdk: go-server-sdk
+kind: reference
+lang: go
+description: All flags example for Go SDK v7.13.4+ (LDScopedClient).
+validation:
+  scaffold: go-server-sdk/scaffolds/go-syntax-only
+
+---
+
+```go
+import (
+    "github.com/launchdarkly/go-server-sdk/v7/interfaces/flagstate"
+)
+
+// There is not an AllFlagsState method in the LDScopedClient,
+// so you need to access the method from the LDClient.
+// Then, pass in the scoped client's current context.
+// LDScopedClient is in beta and may change without notice.
+
+state := scopedClient.Client().AllFlagsState(scopedClient.CurrentContext(), flagstate.OptionClientSideOnly())
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/allflags/allflags-v3.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/allflags/allflags-v3.snippet.md
@@ -1,0 +1,14 @@
+---
+id: haskell-server-sdk/sdk-docs/features/allflags/allflags-v3
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: All flags example for Haskell SDK v3.x.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only-toplevel-v3
+
+---
+
+```haskell
+state = allFlags client user
+```

--- a/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/allflags/allflags-v4.snippet.md
+++ b/snippets/sdks/haskell-server-sdk/snippets/sdk-docs/features/allflags/allflags-v4.snippet.md
@@ -1,0 +1,14 @@
+---
+id: haskell-server-sdk/sdk-docs/features/allflags/allflags-v4
+sdk: haskell-server-sdk
+kind: reference
+lang: haskell
+description: All flags example for Haskell SDK v4.0.
+validation:
+  scaffold: haskell-server-sdk/scaffolds/haskell-syntax-only-toplevel
+
+---
+
+```haskell
+state = allFlagsState client context False False False
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/allflags/allflags-objc.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/allflags/allflags-objc.snippet.md
@@ -1,0 +1,12 @@
+---
+id: ios-client-sdk/sdk-docs/features/allflags/allflags-objc
+sdk: ios-client-sdk
+kind: reference
+lang: objectivec
+description: All flags example for iOS (Objective-C).
+
+---
+
+```objectivec
+NSDictionary<NSString*, LDValue*> * allFlags = [LDClient get].allFlags;
+```

--- a/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/allflags/allflags-swift.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/sdk-docs/features/allflags/allflags-swift.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ios-client-sdk/sdk-docs/features/allflags/allflags-swift
+sdk: ios-client-sdk
+kind: reference
+lang: swift
+description: All flags example for iOS (Swift).
+validation:
+  scaffold: ios-client-sdk/scaffolds/swift-syntax-only
+
+---
+
+```swift
+let allFlags: [String: LDValue]? = LDClient.get()!.allFlags
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/features/allflags/allflags
+sdk: java-server-sdk
+kind: reference
+lang: java
+description: All flags example for Java SDK v6.0.
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+
+---
+
+```java
+FeatureFlagsState state = client.allFlagsState(context);
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: js-client-sdk/sdk-docs/features/allflags/allflags
+sdk: js-client-sdk
+kind: reference
+lang: javascript
+description: All flags example for JavaScript.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+
+---
+
+```js
+let allFlagsResult = client.allFlags();
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/allflags/allflags-v1x.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/allflags/allflags-v1x.snippet.md
@@ -1,0 +1,19 @@
+---
+id: lua-server-sdk/sdk-docs/features/allflags/allflags-v1x
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: All flags example for Lua SDK v1.x.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
+---
+
+```lua
+local allFlags = client:allFlags(user)
+for flag, value in pairs(allFlags) do
+    print(flag, value)
+end
+--
+
+```

--- a/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/allflags/allflags-v2.snippet.md
+++ b/snippets/sdks/lua-server-sdk/snippets/sdk-docs/features/allflags/allflags-v2.snippet.md
@@ -1,0 +1,17 @@
+---
+id: lua-server-sdk/sdk-docs/features/allflags/allflags-v2
+sdk: lua-server-sdk
+kind: reference
+lang: lua
+description: All flags example for Lua SDK v2.
+validation:
+  scaffold: lua-server-sdk/scaffolds/lua-syntax-only
+
+---
+
+```lua
+local allFlags = client:allFlags(context)
+for flag, value in pairs(allFlags) do
+    print(flag, value)
+end
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-client-sdk/sdk-docs/features/allflags/allflags
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: All flags example for Node.js (client-side).
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+
+---
+
+```js
+let allFlagsResult = client.allFlags();
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-server-sdk/sdk-docs/features/allflags/allflags
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+description: All flags example for Node.js (server-side) SDK v7.x and later.
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+
+---
+
+```js
+client.allFlagsState(context, options, (err, flagsState) => {
+  // this object can be converted to JSON using toJSON()
+  // or can be queried for flag values using allValues() or getFlagValue(flag-key)
+});
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: php-server-sdk/sdk-docs/features/allflags/allflags
+sdk: php-server-sdk
+kind: reference
+lang: php
+description: All flags example for PHP SDK v5.0.
+validation:
+  scaffold: php-server-sdk/scaffolds/php-syntax-only
+
+---
+
+```php
+$state  = $client->allFlagsState($context);
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: python-server-sdk/sdk-docs/features/allflags/allflags
+sdk: python-server-sdk
+kind: reference
+lang: python
+description: All flags example for Python SDK v8.0.
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+
+---
+
+```python
+state = ldclient.get().all_flags_state(context)
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-client-sdk/sdk-docs/features/allflags/allflags
+sdk: react-client-sdk
+kind: reference
+lang: javascript
+description: All flags example for React Web.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
+
+---
+
+```js
+const allFlags = ldClient.allFlags();
+```

--- a/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: react-native-client-sdk/sdk-docs/features/allflags/allflags
+sdk: react-native-client-sdk
+kind: reference
+lang: javascript
+description: All flags example for React Native SDK v10.
+validation:
+  scaffold: react-native-client-sdk/scaffolds/react-native-syntax-only
+
+---
+
+```js
+let allFlagsResult = client.allFlags()
+```

--- a/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/roku-client-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,15 @@
+---
+id: roku-client-sdk/sdk-docs/features/allflags/allflags
+sdk: roku-client-sdk
+kind: reference
+lang: brightscript
+description: All flags example for Roku (BrightScript).
+validation:
+  scaffold: roku-client-sdk/scaffolds/roku-syntax-only
+
+---
+
+```brightscript
+allFlags = launchDarkly.allFlagsState()
+
+```

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: ruby-server-sdk/sdk-docs/features/allflags/allflags
+sdk: ruby-server-sdk
+kind: reference
+lang: ruby
+description: All flags example for Ruby SDK v7.0.
+validation:
+  scaffold: ruby-server-sdk/scaffolds/ruby-syntax-only
+
+---
+
+```ruby
+state = client.all_flags_state(context)
+```

--- a/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/scaffolds/rust-syntax-only.snippet.md
@@ -23,7 +23,7 @@ validation:
 #[allow(unused_imports)]
 use launchdarkly_server_sdk::{
     ApplicationInfo, AttributeValue, Client, ConfigBuilder, Context, ContextBuilder,
-    MultiContextBuilder, Reason, Reference, ServiceEndpointsBuilder,
+    FlagDetailConfig, MultiContextBuilder, Reason, Reference, ServiceEndpointsBuilder,
     MigratorBuilder, ExecutionOrder,
 };
 #[allow(unused_imports)]
@@ -89,6 +89,9 @@ macro_rules! hashmap {
 #[allow(dead_code, unused, unused_variables, unused_must_use)]
 async fn _wrappee() -> Result<(), Box<dyn std::error::Error>> {
     let client: Client = unimplemented!();
+    // Some doc fragments name the ambient client `ldclient` instead of
+    // `client`; stub both so either spelling resolves.
+    let ldclient: Client = unimplemented!();
     let context = ContextBuilder::new("stub").build()?;
 {{ body }}
     Ok(())

--- a/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/rust-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: rust-server-sdk/sdk-docs/features/allflags/allflags
+sdk: rust-server-sdk
+kind: reference
+lang: rust
+description: All flags example for Rust SDK v1.
+validation:
+  scaffold: rust-server-sdk/scaffolds/rust-syntax-only
+
+---
+
+```rust
+let state = ldclient.all_flags_detail(&context, FlagDetailConfig::new());
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/features/allflags/allflags.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vercel-server-sdk/sdk-docs/features/allflags/allflags
+sdk: vercel-server-sdk
+kind: reference
+lang: javascript
+description: All flags example for Vercel (TypeScript).
+validation:
+  scaffold: vercel-server-sdk/scaffolds/vercel-syntax-only
+
+---
+
+```js
+const allFlags = await client.allFlagsState(context);
+```

--- a/snippets/validators/languages/cpp-client-v2-c/api.h
+++ b/snippets/validators/languages/cpp-client-v2-c/api.h
@@ -12,6 +12,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -152,6 +153,42 @@ static inline const char *LDGetText(const struct LDJSON *json) {
 
 static inline void LDFreeDetailContents(LDVariationDetails details) {
     (void)details;
+}
+
+/* All-flags surface. The real v2 header returns an object-type LDJSON
+ * map of flag keys to values; iteration goes through the shared LDJSON
+ * collection helpers below. */
+static inline struct LDJSON *LDAllFlags(struct LDClient *client) {
+    (void)client;
+    return (struct LDJSON *)0;
+}
+
+static inline struct LDJSON *LDGetIter(const struct LDJSON *collection) {
+    (void)collection;
+    return (struct LDJSON *)0;
+}
+
+static inline struct LDJSON *LDIterNext(const struct LDJSON *iter) {
+    (void)iter;
+    return (struct LDJSON *)0;
+}
+
+static inline const char *LDIterKey(const struct LDJSON *iter) {
+    (void)iter;
+    return "";
+}
+
+static inline char *LDJSONSerialize(const struct LDJSON *json) {
+    (void)json;
+    return (char *)0;
+}
+
+static inline void LDFree(void *buffer) {
+    (void)buffer;
+}
+
+static inline void LDJSONFree(struct LDJSON *json) {
+    (void)json;
 }
 
 #ifdef __cplusplus

--- a/snippets/validators/languages/cpp-client-v2-cpp/api.hpp
+++ b/snippets/validators/languages/cpp-client-v2-cpp/api.hpp
@@ -13,6 +13,7 @@
 #include <cstdbool>
 #include <cstddef>
 #include <cstring>
+#include <iostream>
 
 /* C-flavored types live in the global namespace, matching the
  * v2 SDK's actual layout (the C and C++ headers shared a translation
@@ -69,6 +70,37 @@ inline void LDFreeDetailContents(LDVariationDetails details) {
     (void)details;
 }
 
+/* All-flags surface. getAllFlags on LDClientCPP returns an object-type
+ * LDJSON map of flag keys to values; iteration goes through the shared
+ * LDJSON collection helpers. */
+inline LDJSON *LDGetIter(const LDJSON *collection) {
+    (void)collection;
+    return nullptr;
+}
+
+inline LDJSON *LDIterNext(const LDJSON *iter) {
+    (void)iter;
+    return nullptr;
+}
+
+inline const char *LDIterKey(const LDJSON *iter) {
+    (void)iter;
+    return "";
+}
+
+inline char *LDJSONSerialize(const LDJSON *json) {
+    (void)json;
+    return nullptr;
+}
+
+inline void LDFree(void *buffer) {
+    (void)buffer;
+}
+
+inline void LDJSONFree(LDJSON *json) {
+    (void)json;
+}
+
 /* `LDClientCPP` is the v2 C++ binding's RAII client class. Member
  * stubs covered by variadic templates so any arg list (string flag
  * key + fallback, etc.) resolves at parse time. The class is never
@@ -83,6 +115,7 @@ public:
     template <typename... Args> int intVariation(Args&&...) { return 0; }
     template <typename... Args> double doubleVariation(Args&&...) { return 0; }
     template <typename... Args> const char *stringVariation(Args&&...) { return ""; }
+    LDJSON *getAllFlags() { return nullptr; }
     template <typename... Args> void identify(Args&&...) {}
     template <typename... Args> void track(Args&&...) {}
     template <typename... Args> void close(Args&&...) {}

--- a/snippets/validators/languages/cpp-server-v2-c/api.h
+++ b/snippets/validators/languages/cpp-server-v2-c/api.h
@@ -150,6 +150,15 @@ static inline char *LDStringVariation(struct LDClient *client,
     return (char *)fallback;
 }
 
+/* All-flags surface. The real v2 header returns an object-type LDJSON
+ * map of flag keys to values; doc fragments only bind the result. */
+static inline struct LDJSON *LDAllFlags(struct LDClient *client,
+                                        const struct LDUser *user) {
+    (void)client;
+    (void)user;
+    return (struct LDJSON *)0;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Ports every code block on the feature-docs page `/sdk/features/all-flags` (ld-docs-private `fern/topics/sdk/features/all-flags.mdx`) into canonical snippets, following the same process as the evaluation-reasons port (#466).

## Counts

- **40 code blocks** extracted into `sdk-docs/features/allflags/` snippets across **25 SDKs** (17 client-side, 19 server-side, 4 edge).
- **39 bound** to validators via existing scaffolds; **1 intentional non-bind** (iOS Objective-C — no Objective-C parse scaffold exists; same blocker documented in the evaluating and evaluation-reasons ports).
- Port notes: `snippets/sdks/_feature-docs-allflags-port-notes.md`.

## Content fixes

Four published samples could not work as written; everything else is verbatim from the MDX (inline review comments mark each fix):

1. **C++ (server-side) v3.0 native** — `if (all_flags.Valid() {` was missing the closing parenthesis (syntax error).
2. **C++ (client-side) v3.0 C binding** — `LDValue_CreateObjectIter` has never existed; the real iterator constructor is `LDValue_ObjectIter_New`.
3. **iOS Swift** — `LDClient.allFlags` is `[LDFlagKey: LDValue]?` (nil when the client is not started, exactly as the page's prose says), so the non-optional `[String: LDValue]` declaration cannot compile; declared the result optional.
4. **Flutter v3.x** — the v3 SDK's `LDClient` is an all-static API (the instance client arrived in v4), so `await client.allFlags()` has no instance to call through; rewritten as `await LDClient.allFlags()`.

## Scaffold / validator changes (all additive)

- `cpp-client-sdk/scaffolds/cpp-client-syntax-only` — `_AnyClient.AllFlags` stub now returns `std::unordered_map<std::string, launchdarkly::Value>` (mirrors the real client) so the range-for + structured-bindings fragment compiles.
- `cpp-server-sdk/scaffolds/cpp-syntax-only` — `_AnyClient.AllFlagsState` stub now returns a default-constructed `launchdarkly::server_side::AllFlagsState` so `.Valid()` / `.Values()` chains compile.
- `validators/languages/cpp-client-v2-c/api.h` — `LDAllFlags(client)` plus the shared LDJSON collection helpers (`LDGetIter`, `LDIterNext`, `LDIterKey`, `LDJSONSerialize`, `LDFree`, `LDJSONFree`) and `<stdio.h>`.
- `validators/languages/cpp-client-v2-cpp/api.hpp` — `getAllFlags()` on `LDClientCPP`, the same LDJSON collection helpers, and `<iostream>`.
- `validators/languages/cpp-server-v2-c/api.h` — `LDAllFlags(client, user)` (server v2 two-argument form).
- `rust-server-sdk/scaffolds/rust-syntax-only` — `FlagDetailConfig` added to the prelude import; `ldclient` stubbed alongside `client`.

No CI workflow changes: every new snippet is covered by an existing matrix row (per-SDK rows and the `(sdk-docs)`-labeled rows).

## Local validation

All 39 bound snippets validated locally in containers (`snippets validate --sdk=<sdk> --snippet=<id>`), **except** `ios-client-sdk/sdk-docs/features/allflags/allflags-swift`: the iOS validator is the native macOS harness and cannot run locally here. The `ios-client-sdk (sdk-docs)` CI row on this PR is the validation for that snippet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and snippet-validation only; no runtime SDK or CI workflow changes beyond compiling new examples through existing scaffolds.
> 
> **Overview**
> Ports the **all-flags** feature docs page into **40** canonical snippets under `sdk-docs/features/allflags/` across **25** SDKs, wired to existing syntax-only scaffolds so CI can validate doc samples (**39** bound; **iOS Objective-C** left unbound with no Obj-C parse scaffold, documented in port notes).
> 
> **Content fixes** where published MDX could not compile or run: C++ server native `Valid()` parenthesis, client C binding `LDValue_ObjectIter_New`, iOS Swift optional `allFlags` map, Flutter v3 static `LDClient.allFlags()`.
> 
> **Additive validation stubs** only: C++ client/server `_AnyClient` `AllFlags` / `AllFlagsState` return types, v2 C/C++ `LDAllFlags` and LDJSON iteration helpers, Rust `FlagDetailConfig` + `ldclient` alias. Adds `_feature-docs-allflags-port-notes.md` for the port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d7f568567787761f5ee7a2b06bd21b68dc0bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->