### PR TITLE
docs(snippets): add email attribute to track-only experimentation exa…

### DIFF
--- a/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -20,7 +20,7 @@ val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
 
 // A "context" is a data object representing users, devices, organizations, and other entities.
 val context = LDContext.builder("EXAMPLE_CONTEXT_KEY")
-    .set("email", "biz@face.dev")
+    .set("email", "EXAMPLE_EMAIL")
     .build()
 
 // If you don't want to block execution while the SDK tries to get

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -20,7 +20,7 @@ val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
 
 // A "context" is a data object representing users, devices, organizations, and other entities.
 val context = LDContext.builder("EXAMPLE_CONTEXT_KEY")
-    .email("biz@face.dev")
+    .set("email", "biz@face.dev")
     .build()
 
 // If you don't want to block execution while the SDK tries to get

--- a/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -19,7 +19,9 @@ val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
     .build()
 
 // A "context" is a data object representing users, devices, organizations, and other entities.
-val context = LDContext.create("EXAMPLE_CONTEXT_KEY")
+val context = LDContext.builder("EXAMPLE_CONTEXT_KEY")
+    .email("biz@face.dev")
+    .build()
 
 // If you don't want to block execution while the SDK tries to get
 // latest flags, move this code into an async IO task and await on its completion.

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -19,7 +19,7 @@ func startLaunchDarkly() {
 
     // A "context" is a data object representing users, devices, organizations, and other entities.
     var contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
-    contextBuilder.trySetValue("email", .string("biz@face.dev"))
+    contextBuilder.trySetValue("email", .string("EXAMPLE_EMAIL"))
     guard case .success(let context) = contextBuilder.build() else { return }
 
     LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in

--- a/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/ios-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -18,7 +18,8 @@ func startLaunchDarkly() {
     let config = LDConfig(mobileKey: "YOUR_MOBILE_KEY", autoEnvAttributes: .enabled)
 
     // A "context" is a data object representing users, devices, organizations, and other entities.
-    let contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
+    var contextBuilder = LDContextBuilder(key: "EXAMPLE_CONTEXT_KEY")
+    contextBuilder.trySetValue("email", .string("biz@face.dev"))
     guard case .success(let context) = contextBuilder.build() else { return }
 
     LDClient.start(config: config, context: context, startWaitSeconds: 5) { timedOut in

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -16,6 +16,7 @@ import { createClient } from '@launchdarkly/js-client-sdk';
 const context = {
   kind: 'user',
   key: 'EXAMPLE_CONTEXT_KEY',
+  email: 'biz@face.dev',
 };
 
 // This is your client-side ID.

--- a/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -16,7 +16,7 @@ import { createClient } from '@launchdarkly/js-client-sdk';
 const context = {
   kind: 'user',
   key: 'EXAMPLE_CONTEXT_KEY',
-  email: 'biz@face.dev',
+  email: 'EXAMPLE_EMAIL',
 };
 
 // This is your client-side ID.

--- a/snippets/sdks/react-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -31,7 +31,7 @@ function App() {
 const context = {
   kind: 'user',
   key: 'EXAMPLE_CONTEXT_KEY',
-  email: 'biz@face.dev',
+  email: 'EXAMPLE_EMAIL',
 };
 
 // Initialize the SDK so flag values are ready before your app renders.

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -26,7 +26,7 @@ const ldClient = new ReactNativeLDClient('YOUR_MOBILE_KEY', AutoEnvAttributes.En
 });
 
 // A "context" is a data object representing users, devices, organizations, and other entities.
-const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY' };
+const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY', email: 'biz@face.dev' };
 
 export default function App() {
   const [ready, setReady] = useState<boolean>(false);

--- a/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
+++ b/snippets/sdks/react-native-client-sdk/snippets/experimentation/track-only.snippet.md
@@ -26,7 +26,7 @@ const ldClient = new ReactNativeLDClient('YOUR_MOBILE_KEY', AutoEnvAttributes.En
 });
 
 // A "context" is a data object representing users, devices, organizations, and other entities.
-const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY', email: 'biz@face.dev' };
+const context = { kind: 'user', key: 'EXAMPLE_CONTEXT_KEY', email: 'EXAMPLE_EMAIL' };
 
 export default function App() {
   const [ready, setReady] = useState<boolean>(false);


### PR DESCRIPTION
…mples

make it consistent with https://github.com/launchdarkly/sdk-meta/blob/main/snippets/sdks/react-client-sdk/snippets/experimentation/track-only.snippet.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only snippet edits with no application or SDK runtime changes.
> 
> **Overview**
> Aligns **track-only experimentation** onboarding snippets across Android, iOS, JS, React, and React Native so every example includes an **`email`** field on the LaunchDarkly context.
> 
> Android switches from `LDContext.create` to the builder with `.set("email", "EXAMPLE_EMAIL")`. iOS uses `trySetValue("email", …)` on `LDContextBuilder`. JS and React Native add `email: 'EXAMPLE_EMAIL'` to the context object. React replaces the placeholder `biz@face.dev` with **`EXAMPLE_EMAIL`** to match the other SDKs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de525fed92b80c65180baacc3ad5c39263e1ab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->