### PR TITLE
fix(snippets): retry android validator sdkmanager install on corrupt download

### DIFF
--- a/snippets/validators/languages/android-client/Dockerfile
+++ b/snippets/validators/languages/android-client/Dockerfile
@@ -29,8 +29,24 @@ RUN mkdir -p ${ANDROID_HOME}/cmdline-tools \
     && mv ${ANDROID_HOME}/cmdline-tools/cmdline-tools ${ANDROID_HOME}/cmdline-tools/latest \
     && rm /tmp/tools.zip
 
-RUN yes | sdkmanager --licenses >/dev/null \
-    && sdkmanager --install "platforms;android-35" "platform-tools" "build-tools;35.0.0"
+# Installing the platform / platform-tools / build-tools components
+# occasionally fetches a corrupt component archive from Google's
+# repository ("java.util.zip.ZipException: Archive is not a ZIP
+# archive"), which aborts the whole image build. Retry the install a
+# few times, clearing any partial download state between attempts so a
+# single bad fetch doesn't fail the build. License acceptance is cheap
+# and idempotent, so it stays inside the loop too.
+RUN n=0; \
+    until [ "$n" -ge 4 ]; do \
+        yes | sdkmanager --licenses >/dev/null \
+            && sdkmanager --install "platforms;android-35" "platform-tools" "build-tools;35.0.0" \
+            && break; \
+        n=$((n + 1)); \
+        echo "sdkmanager install failed (attempt ${n}/4); clearing partial downloads and retrying..."; \
+        rm -rf "${ANDROID_HOME}/.temp" "${ANDROID_HOME}/.downloadIntermediates"; \
+        sleep 10; \
+    done; \
+    [ "$n" -lt 4 ]
 
 # Pre-bake a hello-android gradle scaffold. We clone the upstream
 # hello-android repo (LD's official getting-started reference) at a


### PR DESCRIPTION
The `android-client` validator image build runs a single `sdkmanager --install` for the platform, platform-tools, and build-tools components. Google's component repository intermittently returns a corrupt archive, which surfaces as:

```
Warning: An error occurred while preparing SDK package ...: Error on ZipFile unknown archive.
Caused by: java.util.zip.ZipException: Archive is not a ZIP archive
```

That aborts the whole image build, which fails the `android-client-sdk (sdk-docs)` (and sibling) validation jobs on an unrelated snippet — it has flaked builds on several recent PRs. The apt-get and cmdline-tools `curl` steps already retry; only this `sdkmanager` step did not.

This wraps the install in a bounded retry loop (4 attempts), clearing partial download state (`.temp` / `.downloadIntermediates`) between attempts so a re-fetch starts clean, and fails the build only if all attempts are exhausted. License acceptance stays in the loop (cheap and idempotent). No behavior change on a healthy first fetch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Docker build resilience change; no runtime snippet or SDK behavior change when the first fetch succeeds.
> 
> **Overview**
> The `android-client` validator **Dockerfile** no longer runs a one-shot `sdkmanager --install` for Android 35 platform, platform-tools, and build-tools. It now uses a **bounded retry loop** (up to 4 attempts) when Google’s repo returns a corrupt ZIP (`ZipException: Archive is not a ZIP archive`), which had been flaking CI image builds.
> 
> On failure it logs the attempt, removes partial state under `${ANDROID_HOME}/.temp` and `.downloadIntermediates`, waits 10 seconds, and retries. **`sdkmanager --licenses`** runs inside each attempt. The layer fails only if all four attempts fail; a successful first install is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab9ee0093bbc8166bbf41737439c7deab24deef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->