### PR TITLE
feat(snippets): add data-saving-mode snippets for the Flutter client SDK

### DIFF
--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/datasaving/fixed-connection-mode.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/datasaving/fixed-connection-mode.snippet.md
@@ -1,0 +1,19 @@
+---
+id: flutter-client-sdk/sdk-docs/features/datasaving/fixed-connection-mode
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Set a fixed connection mode with manual mode switching for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  AutoEnvAttributes.enabled,
+  dataSystem: const DataSystemConfig(
+    initialConnectionMode: ConnectionModeId.polling,
+  ),
+);
+```

--- a/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/datasaving/standard-setup.snippet.md
+++ b/snippets/sdks/flutter-client-sdk/snippets/sdk-docs/features/datasaving/standard-setup.snippet.md
@@ -1,0 +1,17 @@
+---
+id: flutter-client-sdk/sdk-docs/features/datasaving/standard-setup
+sdk: flutter-client-sdk
+kind: reference
+lang: dart
+description: Data saving mode standard setup for Flutter.
+validation:
+  scaffold: flutter-client-sdk/scaffolds/flutter-syntax-only
+---
+
+```dart
+final config = LDConfig(
+  CredentialSource.fromEnvironment(),
+  AutoEnvAttributes.enabled,
+  dataSystem: const DataSystemConfig(),
+);
+```

--- a/snippets/validators/languages/flutter-client/Dockerfile
+++ b/snippets/validators/languages/flutter-client/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSL "https://storage.googleapis.com/flutter_infra_release/releases/st
 # produces, with the SDK + provider deps already pinned. Per-validate
 # cycles overwrite lib/main.dart and re-run `flutter build web` against
 # the warmed pub cache + dart kernel cache.
-ARG LD_FLUTTER_SDK_VERSION=4.16.0
+ARG LD_FLUTTER_SDK_VERSION=4.20.0
 ARG PROVIDER_VERSION=6.1.2
 
 RUN flutter create --platforms=web --org com.launchdarkly /opt/hello_flutter


### PR DESCRIPTION
Adds the canonical data saving mode (FDv2) snippets for the Flutter client SDK, matching the structure already used by the other client SDKs (`js-client-sdk`, `react-native-client-sdk`, `android-client-sdk`):

- `flutter-client-sdk/sdk-docs/features/datasaving/standard-setup` — opt into FDv2 by providing a `DataSystemConfig`.
- `flutter-client-sdk/sdk-docs/features/datasaving/fixed-connection-mode` — set a sticky initial connection mode via `DataSystemConfig.initialConnectionMode`.

Both use the existing `flutter-client-sdk/scaffolds/flutter-syntax-only` scaffold and are picked up automatically by the existing `flutter-client-sdk` row in `snippets-validate.yml` (no matrix change needed).

Also bumps the `flutter-client` validator harness from `launchdarkly_flutter_client_sdk` 4.16.0 to **4.20.0** — the first published release with the FDv2 API (`DataSystemConfig`, `ConnectionModeId`, the `dataSystem` option) these snippets use. 4.20.0 keeps the same Dart/Flutter constraints, so the existing flutter sdk-docs snippets continue to validate.

These pair with the ld-docs-private data-saving-mode page (launchdarkly/ld-docs-private#7908), which references them through `SDK_SNIPPET:RENDER` markers; the `sync-ld-docs-snippets` action fills the bodies/version once this is released.