### PR TITLE
perf(snippets): cross-run Docker layer caching for validators

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -39,6 +39,15 @@ jobs:
   validate:
     name: ${{ matrix.label || matrix.sdk }}
     runs-on: ${{ matrix.runs-on }}
+    env:
+      # Cross-run Docker layer caching for the `mode: docker` validators,
+      # keyed per runtime. Enabled only on non-fork builds: a fork PR runs
+      # with a restricted token and must not be able to populate (or poison)
+      # the shared cache, and the gha cache backend needs the Actions runtime
+      # token that forks don't get. Empty disables caching entirely — the Go
+      # runner falls back to a plain `docker build` (also the local-dev path).
+      # `workflow_dispatch` and same-repo PRs are non-fork; fork PRs are not.
+      IMAGE_CACHE: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'gha' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -213,6 +222,20 @@ jobs:
         with:
           go-version: '1.24'
 
+      # Docker layer cache plumbing, only when IMAGE_CACHE is on (non-fork)
+      # and the validator builds images (the iOS rows run natively on macOS
+      # with no Docker). ghaction-github-runtime exports ACTIONS_RUNTIME_TOKEN
+      # + ACTIONS_CACHE_URL into the job env so `docker buildx` can reach the
+      # gha cache from inside the validate command; setup-buildx-action
+      # provisions a builder whose driver supports `--cache-to`.
+      - name: Export Actions cache runtime (non-fork)
+        if: env.IMAGE_CACHE != '' && matrix.runs-on != 'macos-latest'
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Set up Docker Buildx (non-fork)
+        if: env.IMAGE_CACHE != '' && matrix.runs-on != 'macos-latest'
+        uses: docker/setup-buildx-action@v3
+
       - name: Install iOS toolchain (macos only)
         if: matrix.runs-on == 'macos-latest'
         run: |
@@ -254,6 +277,7 @@ jobs:
           MATRIX_SNIPPET: ${{ matrix.snippet }}
           MATRIX_SNIPPET_SKIP: ${{ matrix.snippet_skip }}
           MATRIX_GROUP: ${{ matrix.group }}
+          MATRIX_IMAGE_CACHE: ${{ env.IMAGE_CACHE }}
         with:
           use_server_key: ${{ matrix.key-type == 'server' }}
           use_client_key: ${{ matrix.key-type == 'client' }}
@@ -266,6 +290,7 @@ jobs:
             [ -n "$MATRIX_SNIPPET" ] && args="$args --snippet=$MATRIX_SNIPPET"
             [ -n "$MATRIX_SNIPPET_SKIP" ] && args="$args --snippet-skip=$MATRIX_SNIPPET_SKIP"
             [ -n "$MATRIX_GROUP" ] && args="$args --group=$MATRIX_GROUP"
+            [ -n "$MATRIX_IMAGE_CACHE" ] && args="$args --image-cache=$MATRIX_IMAGE_CACHE"
             go run ./cmd/snippets validate $args \
               --sdks=./sdks --validators=./validators 2>&1 | tee /tmp/validate.log
 
@@ -277,6 +302,7 @@ jobs:
           MATRIX_SNIPPET: ${{ matrix.snippet }}
           MATRIX_SNIPPET_SKIP: ${{ matrix.snippet_skip }}
           MATRIX_GROUP: ${{ matrix.group }}
+          MATRIX_IMAGE_CACHE: ${{ env.IMAGE_CACHE }}
         run: |
           set -o pipefail
           cd snippets
@@ -284,6 +310,7 @@ jobs:
           [ -n "$MATRIX_SNIPPET" ] && args="$args --snippet=$MATRIX_SNIPPET"
           [ -n "$MATRIX_SNIPPET_SKIP" ] && args="$args --snippet-skip=$MATRIX_SNIPPET_SKIP"
           [ -n "$MATRIX_GROUP" ] && args="$args --group=$MATRIX_GROUP"
+          [ -n "$MATRIX_IMAGE_CACHE" ] && args="$args --image-cache=$MATRIX_IMAGE_CACHE"
           go run ./cmd/snippets validate $args \
             --sdks=./sdks --validators=./validators 2>&1 | tee /tmp/validate.log
 

--- a/snippets/CLAUDE.md
+++ b/snippets/CLAUDE.md
@@ -293,6 +293,8 @@ Stages snippet bodies, builds the per-language validator (Docker or native), run
 | `--group` | Optional. Filters on the middle segment of the snippet id (`sdk-info`, `sdk-docs`, ...). |
 | `--sdks` | Path to a working `sdks/` tree. Default: embedded snapshot. |
 | `--validators` | Path to the `validators/` directory. Default: `./validators`. Must be on disk (Docker `COPY` reads from it). |
+| `--jobs` | Max concurrent batch-harness invocations (batch-mode validators only). Default `0` = `NumCPU`. |
+| `--image-cache` | Cross-run Docker layer cache for `mode: docker` validators: `gha` (GitHub Actions cache) or a registry ref prefix (`type=registry`). Empty (default) = plain `docker build`, no buildx. CI sets it only on non-fork builds. |
 
 Behavior:
 

--- a/snippets/cmd/snippets/main.go
+++ b/snippets/cmd/snippets/main.go
@@ -202,6 +202,7 @@ func runValidate(args []string) {
 	sdks := fset.String("sdks", "", "path to a sdks/ directory (default: embedded)")
 	validators := fset.String("validators", "./validators", "path to the validators/ directory")
 	jobs := fset.Int("jobs", 0, "max concurrent validator invocations (batch-mode validators only; 0 = NumCPU)")
+	imageCache := fset.String("image-cache", "", "cross-run Docker layer cache for docker validators: `gha` or a registry ref prefix; empty = plain docker build (default)")
 	_ = fset.Parse(args)
 
 	if *sdk == "" {
@@ -216,6 +217,7 @@ func runValidate(args []string) {
 		SnippetSkip:   *snippetSkip,
 		Group:         *group,
 		Jobs:          *jobs,
+		ImageCache:    *imageCache,
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "validate failed: %v\n", err)
 		os.Exit(1)

--- a/snippets/internal/validate/imagecache_test.go
+++ b/snippets/internal/validate/imagecache_test.go
@@ -1,0 +1,60 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCacheScope(t *testing.T) {
+	cases := map[string]string{
+		"validators/languages/cpp-client":        "cpp-client",
+		"validators/languages/haskell-server-v3": "haskell-server-v3",
+		"validators/languages/dotnet-server":     "dotnet-server",
+		// Anything outside [a-z0-9._-] is replaced so the scope is a valid
+		// registry tag and gha scope.
+		"validators/languages/Weird Name!": "weird-name-",
+	}
+	for in, want := range cases {
+		if got := cacheScope(in); got != want {
+			t.Errorf("cacheScope(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCacheArgs(t *testing.T) {
+	// gha backend.
+	gha := cacheArgs("gha", "rust")
+	joined := strings.Join(gha, " ")
+	if !strings.Contains(joined, "type=gha,scope=rust") {
+		t.Errorf("gha cache-from missing scope: %v", gha)
+	}
+	if !strings.Contains(joined, "type=gha,scope=rust,mode=min") {
+		t.Errorf("gha cache-to missing scope/mode: %v", gha)
+	}
+
+	// registry backend: scope becomes the tag on the ref prefix.
+	reg := cacheArgs("ghcr.io/launchdarkly/sdk-meta/snippet-cache", "cpp-server")
+	joined = strings.Join(reg, " ")
+	if !strings.Contains(joined, "type=registry,ref=ghcr.io/launchdarkly/sdk-meta/snippet-cache:cpp-server") {
+		t.Errorf("registry cache ref wrong: %v", reg)
+	}
+	if !strings.Contains(joined, ",mode=min") {
+		t.Errorf("registry cache-to missing mode: %v", reg)
+	}
+
+	// Both backends emit one --cache-from and one --cache-to.
+	for _, args := range [][]string{gha, reg} {
+		from, to := 0, 0
+		for _, a := range args {
+			if a == "--cache-from" {
+				from++
+			}
+			if a == "--cache-to" {
+				to++
+			}
+		}
+		if from != 1 || to != 1 {
+			t.Errorf("want 1 cache-from + 1 cache-to, got %d/%d in %v", from, to, args)
+		}
+	}
+}

--- a/snippets/internal/validate/validate.go
+++ b/snippets/internal/validate/validate.go
@@ -25,6 +25,16 @@ type Config struct {
 	SnippetSkip   string // comma-separated snippet ids to skip (empty = none)
 	Group         string // snippet group to validate (empty = all; e.g. "sdk-info" or "sdk-docs")
 	Jobs          int    // max concurrent batch-harness invocations (0 = NumCPU); batch-mode validators only
+
+	// ImageCache turns on cross-run Docker layer caching for `mode: docker`
+	// validators. Empty (the default) keeps a plain `docker build`, which is
+	// what local runs and fork CI use — no buildx, no external cache. When
+	// set, the build runs through `docker buildx build` with a per-runtime
+	// layer cache:
+	//   "gha"                     — GitHub Actions cache (type=gha)
+	//   "<registry>/<repo>/<img>" — a registry cache ref (type=registry)
+	// CI sets this only on non-fork builds; see snippets-validate.yml.
+	ImageCache string
 }
 
 // envInputs holds the environment-derived input values that get substituted
@@ -602,17 +612,74 @@ func buildImage(cfg Config, runner *Runner, runnerDir string, out io.Writer) err
 	// rather than the interactive multi-line redraws) while leaving
 	// failure output visible — important for diagnosing apt/network
 	// failures inside the build that --quiet would otherwise swallow.
-	build := exec.Command("docker", "build", "--progress=plain",
-		"-f", dockerfile,
-		"-t", tag,
-		cfg.ValidatorsDir,
-	)
+	var build *exec.Cmd
+	if cfg.ImageCache == "" {
+		build = exec.Command("docker", "build", "--progress=plain",
+			"-f", dockerfile,
+			"-t", tag,
+			cfg.ValidatorsDir,
+		)
+	} else {
+		// buildx with a per-runtime layer cache. `--load` puts the built
+		// image into the local daemon so the subsequent `docker run` finds
+		// it. mode=min exports the final image's layers — these are
+		// single-stage Dockerfiles, so the layer that does the expensive
+		// work (compile the SDK, restore deps, warm the project) is part of
+		// the final image and gets cached. A buildx builder that supports
+		// cache export must already be configured (CI does this via
+		// docker/setup-buildx-action).
+		args := []string{"buildx", "build", "--progress=plain",
+			"-f", dockerfile,
+			"-t", tag,
+			"--load",
+		}
+		args = append(args, cacheArgs(cfg.ImageCache, cacheScope(runnerDir))...)
+		args = append(args, cfg.ValidatorsDir)
+		build = exec.Command("docker", args...)
+	}
 	build.Stdout = out
 	build.Stderr = out
 	if err := build.Run(); err != nil {
 		return fmt.Errorf("docker build failed: %w", err)
 	}
 	return nil
+}
+
+// cacheScope derives a stable per-runtime cache key from the runner
+// directory (e.g. validators/languages/cpp-client -> "cpp-client"). Each
+// validator gets its own cache so an edit to one doesn't invalidate the
+// others. The result is lowercased and stripped to [a-z0-9._-] so it's a
+// valid registry tag as well as a gha scope.
+func cacheScope(runnerDir string) string {
+	base := strings.ToLower(filepath.Base(runnerDir))
+	var b strings.Builder
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+// cacheArgs returns the --cache-from/--cache-to flags for buildx given the
+// configured cache backend and a per-runtime scope. "gha" selects the
+// GitHub Actions cache; anything else is treated as a registry ref prefix
+// and the scope becomes the tag.
+func cacheArgs(backend, scope string) []string {
+	if backend == "gha" {
+		return []string{
+			"--cache-from", "type=gha,scope=" + scope,
+			"--cache-to", "type=gha,scope=" + scope + ",mode=min",
+		}
+	}
+	ref := backend + ":" + scope
+	return []string{
+		"--cache-from", "type=registry,ref=" + ref,
+		"--cache-to", "type=registry,ref=" + ref + ",mode=min",
+	}
 }
 
 // runContainer runs harness/run.sh inside the validator image with the


### PR DESCRIPTION
**Draft** — measuring build-performance impact before marking ready.

## What

After the batch work landed (#526), per-snippet validation is cheap and the **per-job Docker image build is the dominant cost** — every CI run rebuilds each validator image from scratch (no cache between runs). The haskell job (~17m) is almost entirely the cabal compile of the SDK from source; cpp/flutter/android are similar.

This adds opt-in cross-run **Docker layer caching**:

- New `--image-cache` flag on the validator. When set, `buildImage` builds via `docker buildx build --load` with a per-runtime layer cache (`--cache-from`/`--cache-to`, `mode=min`). When empty — local dev and **fork** CI — it keeps the plain `docker build`, no buildx dependency. Supports `gha` (Actions cache) and registry refs.
- Workflow enables it **only on non-fork builds** (`workflow_dispatch` + same-repo PRs). Fork PRs run with a restricted token and must not populate/poison the shared cache, and the gha backend needs the Actions runtime token forks don't get. Non-fork docker jobs get a buildx builder + the exported runtime token; the native iOS rows skip it.

## Why gha (for now)

`type=gha` needs no registry, no `packages:write`, and is fork-isolated by GitHub. Its ~10GB/repo cap may limit hit rates for the largest images (flutter is ~4.6GB) — the trials below will show whether that bites; if so, switching the workflow's `IMAGE_CACHE` to a GHCR registry ref is a one-line change (the Go runner already supports `type=registry`).

## Verification

Mechanism proven locally against a throwaway registry: cold build pushes the cache, warm build reuses 24 layers and validates 47/47 (rust). Real wall-time impact is measured on CI — see trial results in comments below.

## Trials

Running the workflow multiple times via `workflow_dispatch`:
1. Cold (cache empty) — populates the cache.
2. Warm runs — measure steady-state.
Comparing warm wall time + slowest-job times against the pre-cache baseline (#526, ~18m). Results posted as a comment.