### PR TITLE
feat: Port OpenFeature SDK docs section to canonical snippets

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -62,14 +62,13 @@ jobs:
           # Mobile-key SDKs.
           - { sdk: dotnet-client-sdk, runs-on: ubuntu-latest, key-type: mobile }
 
-          # SDKs whose only validatable surface is the shell-install
-          # snippets — no init/flagEval bindings yet. The shell-install
-          # validator sniffs the body's leading token
-          # (npm/pnpm/yarn/pip/go/bower) and runs the real package
-          # manager in a clean working dir; no LaunchDarkly key is
-          # needed. We pass `key-type: server` so the verify-hello-app
-          # action injects an unused server key rather than failing on
-          # no-key-set.
+          # dotnet-server-sdk's validatable surface is the shell-install
+          # snippets (the shell-install validator sniffs the body's
+          # leading token — npm/pnpm/yarn/pip/go/bower/dotnet — and runs
+          # the real package manager in a clean working dir) plus the
+          # OpenFeature provider snippets, whose runners connect to the
+          # LD sandbox and assert a flag evaluation. The `key-type: server`
+          # supplies the SDK key those runners need.
           - { sdk: dotnet-server-sdk,       runs-on: ubuntu-latest, key-type: server }
 
           # Client/mobile-key SDKs with end-to-end init bindings.

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-context-runner.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-context-runner.snippet.md
@@ -1,0 +1,52 @@
+---
+id: dotnet-server-sdk/scaffolds/openfeature-csharp-context-runner
+sdk: dotnet-server-sdk
+kind: scaffold
+lang: csharp
+file: Program.cs
+description: |
+  Runs an OpenFeature "construct a context" fragment, which declares its
+  own `context` local. The scaffold registers a real LaunchDarkly
+  provider and binds `client` inside an async `Main`, but leaves
+  `context` for the fragment to declare; afterward it evaluates a flag
+  with the fragment's `context` and prints the success line. Separate
+  from `openfeature-csharp-runner` because C# forbids re-declaring a
+  local the scaffold already bound.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment; declares `context` and runs with `client` in scope.
+validation:
+  runtime: dotnet-server
+  entrypoint: Program.cs
+---
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server;
+using LaunchDarkly.OpenFeature.ServerProvider;
+using OpenFeature.Model;
+
+namespace LaunchDarklySnippet
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var config = Configuration.Builder(Environment.GetEnvironmentVariable("LAUNCHDARKLY_SDK_KEY"))
+                .StartWaitTime(TimeSpan.FromSeconds(10))
+                .Build();
+            var provider = new Provider(config);
+            await OpenFeature.Api.Instance.SetProviderAsync(provider);
+            var client = OpenFeature.Api.Instance.GetClient();
+
+{{ body }}
+
+            await client.GetBooleanValueAsync(
+                Environment.GetEnvironmentVariable("LAUNCHDARKLY_FLAG_KEY"), false, context);
+            Console.WriteLine("feature flag evaluates to true");
+        }
+    }
+}
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-init-runner.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-init-runner.snippet.md
@@ -1,0 +1,46 @@
+---
+id: dotnet-server-sdk/scaffolds/openfeature-csharp-init-runner
+sdk: dotnet-server-sdk
+kind: scaffold
+lang: csharp
+file: Program.cs
+description: |
+  Runs an OpenFeature "initialize the provider" fragment end-to-end
+  against a real LaunchDarkly environment. The fragment builds a
+  LaunchDarkly provider, registers it with the OpenFeature API, and
+  binds a `client`; this scaffold runs it inside an async `Main`, then
+  uses `client` to evaluate a flag and print the success line. The
+  fragment's `YOUR_SDK_KEY` literal is replaced with the real key via
+  `validation.placeholders`.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; registers the provider and binds `client`.
+validation:
+  runtime: dotnet-server
+  entrypoint: Program.cs
+---
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server;
+using LaunchDarkly.OpenFeature.ServerProvider;
+using OpenFeature.Model;
+
+namespace LaunchDarklySnippet
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+{{ body }}
+
+            await client.GetBooleanValueAsync(
+                Environment.GetEnvironmentVariable("LAUNCHDARKLY_FLAG_KEY"), false,
+                EvaluationContext.Builder().Set("targetingKey", "example-user-key").Build());
+            Console.WriteLine("feature flag evaluates to true");
+        }
+    }
+}
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-runner.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-runner.snippet.md
@@ -1,0 +1,54 @@
+---
+id: dotnet-server-sdk/scaffolds/openfeature-csharp-runner
+sdk: dotnet-server-sdk
+kind: scaffold
+lang: csharp
+file: Program.cs
+description: |
+  Runs an OpenFeature provider doc fragment that assumes a registered
+  provider and a bound `provider`, `client`, and `context` already
+  exist — the "evaluate a context" and "access the LaunchDarkly client"
+  fragments. The scaffold registers a real LaunchDarkly provider inside
+  an async `Main`, binds those names, runs the fragment, then evaluates
+  a flag and prints the success line. C# forbids re-declaring a local
+  the scaffold already bound, so fragments that declare their own
+  `context` use the `openfeature-csharp-context-runner` variant.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment, run with `provider`, `client`, and `context` in scope.
+validation:
+  runtime: dotnet-server
+  entrypoint: Program.cs
+---
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using LaunchDarkly.Sdk.Server;
+using LaunchDarkly.OpenFeature.ServerProvider;
+using OpenFeature.Model;
+
+namespace LaunchDarklySnippet
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var config = Configuration.Builder(Environment.GetEnvironmentVariable("LAUNCHDARKLY_SDK_KEY"))
+                .StartWaitTime(TimeSpan.FromSeconds(10))
+                .Build();
+            var provider = new Provider(config);
+            await OpenFeature.Api.Instance.SetProviderAsync(provider);
+            var client = OpenFeature.Api.Instance.GetClient();
+            var context = EvaluationContext.Builder().Set("targetingKey", "example-user-key").Build();
+
+{{ body }}
+
+            await client.GetBooleanValueAsync(
+                Environment.GetEnvironmentVariable("LAUNCHDARKLY_FLAG_KEY"), false, context);
+            Console.WriteLine("feature flag evaluates to true");
+        }
+    }
+}
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-toplevel.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/scaffolds/openfeature-csharp-toplevel.snippet.md
@@ -1,0 +1,39 @@
+---
+id: dotnet-server-sdk/scaffolds/openfeature-csharp-toplevel
+sdk: dotnet-server-sdk
+kind: scaffold
+lang: csharp
+file: Program.cs
+description: |
+  Resolves an OpenFeature provider doc fragment that is a set of `using`
+  directives. The harness lifts the body's `using …;` lines to file
+  scope at the USING_LIFT_MARKER, so the C# compiler resolves each
+  namespace against the OpenFeature package and the LaunchDarkly
+  provider baked into the validator image. A `using` that names a
+  namespace the packages don't ship fails compilation. The body does
+  not connect to LaunchDarkly.
+inputs:
+  body:
+    type: string
+    description: The wrappee's using directives; lifted to file scope by the harness.
+validation:
+  runtime: dotnet-server
+  entrypoint: Program.cs
+---
+
+```csharp
+// USING_LIFT_MARKER
+using System;
+
+namespace LaunchDarklySnippet
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+{{ body }}
+            Console.WriteLine("feature flag evaluates to true");
+        }
+    }
+}
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/access-the-launchdarkly-client.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/access-the-launchdarkly-client.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-server-sdk/sdk-docs/openfeature/access-the-launchdarkly-client
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+file: dotnet-server-sdk/sdk-docs/openfeature/access-the-launchdarkly-client.cs
+description: ".NET (server-side) OpenFeature provider in section \"Access the LaunchDarkly client\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/openfeature-csharp-runner
+---
+
+```csharp
+var ldClient = provider.GetClient();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
@@ -1,0 +1,17 @@
+---
+id: dotnet-server-sdk/sdk-docs/openfeature/construct-a-context-organization
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+file: dotnet-server-sdk/sdk-docs/openfeature/construct-a-context-organization.cs
+description: ".NET (server-side) OpenFeature provider in section \"Construct a context\" (organization)"
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/openfeature-csharp-context-runner
+---
+
+```csharp
+var context = EvaluationContext.Builder()
+  .Set("kind", "organization")
+  .Set("targetingKey", "example-organization-key") // Could also use "key" instead of "targetingKey".
+  .Build();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
@@ -1,0 +1,16 @@
+---
+id: dotnet-server-sdk/sdk-docs/openfeature/construct-a-context-user
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+file: dotnet-server-sdk/sdk-docs/openfeature/construct-a-context-user.cs
+description: ".NET (server-side) OpenFeature provider in section \"Construct a context\" (user)"
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/openfeature-csharp-context-runner
+---
+
+```csharp
+var context = EvaluationContext.Builder()
+  .Set("targetingKey", "example-user-key") // Could also use "key" instead of "targetingKey".
+  .Build();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
@@ -1,0 +1,14 @@
+---
+id: dotnet-server-sdk/sdk-docs/openfeature/evaluate-a-context
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+file: dotnet-server-sdk/sdk-docs/openfeature/evaluate-a-context.cs
+description: ".NET (server-side) OpenFeature provider in section \"Evaluate a context\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/openfeature-csharp-runner
+---
+
+```csharp
+var flagValue = await client.GetBooleanValueAsync("example-flag-key", false, context);
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
@@ -1,0 +1,16 @@
+---
+id: dotnet-server-sdk/sdk-docs/openfeature/import-the-namespaces
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+file: dotnet-server-sdk/sdk-docs/openfeature/import-the-namespaces.cs
+description: ".NET (server-side) OpenFeature provider in section \"Install the provider\" (imports)"
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/openfeature-csharp-toplevel
+---
+
+```csharp
+using LaunchDarkly.OpenFeature.ServerProvider;
+using LaunchDarkly.Sdk.Server;
+using OpenFeature.Model;
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
@@ -1,0 +1,24 @@
+---
+id: dotnet-server-sdk/sdk-docs/openfeature/initialize-the-provider
+sdk: dotnet-server-sdk
+kind: reference
+lang: csharp
+file: dotnet-server-sdk/sdk-docs/openfeature/initialize-the-provider.cs
+description: ".NET (server-side) OpenFeature provider in section \"Initialize the provider\""
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/openfeature-csharp-init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
+---
+
+```csharp
+var config = Configuration.Builder("YOUR_SDK_KEY")
+    .StartWaitTime(TimeSpan.FromSeconds(10))
+    .Build();
+
+var provider = new Provider(config);
+
+await OpenFeature.Api.Instance.SetProviderAsync(provider);
+
+var client = OpenFeature.Api.Instance.GetClient();
+```

--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-shell.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-shell.snippet.md
@@ -1,0 +1,16 @@
+---
+id: dotnet-server-sdk/sdk-docs/openfeature/install-the-provider-shell
+sdk: dotnet-server-sdk
+kind: reference
+lang: shell
+file: dotnet-server-sdk/sdk-docs/openfeature/install-the-provider-shell.sh
+description: ".NET (server-side) OpenFeature provider in section \"Install the provider\""
+validation:
+  runtime: shell-install
+---
+
+```bash
+dotnet add package LaunchDarkly.ServerSdk
+dotnet add package LaunchDarkly.OpenFeature.ServerProvider
+dotnet add package OpenFeature
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-context-runner.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-context-runner.snippet.md
@@ -1,0 +1,48 @@
+---
+id: java-server-sdk/scaffolds/openfeature-jvm-context-runner
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: |
+  Runs an OpenFeature "construct a context" fragment, which declares its
+  own `context` local. The scaffold registers a real LaunchDarkly
+  provider and binds `client`, but leaves `context` for the fragment to
+  declare; afterward it evaluates a flag with the fragment's `context`
+  and prints the success line. Separate from `openfeature-jvm-runner`
+  because Java forbids re-declaring a local that the scaffold already
+  bound. Requires LaunchDarkly credentials.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment; declares `context` and runs with `client` in scope.
+validation:
+  runtime: jvm
+  entrypoint: src/main/java/com/launchdarkly/tutorial/Main.java
+---
+
+```java
+package com.launchdarkly.tutorial;
+
+import java.util.HashMap;
+import java.util.Map;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.ImmutableContext;
+import dev.openfeature.sdk.Value;
+import com.launchdarkly.openfeature.serverprovider.Provider;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        Provider provider = new Provider(System.getenv("LAUNCHDARKLY_SDK_KEY"));
+        OpenFeatureAPI.getInstance().setProvider(provider);
+        Client client = OpenFeatureAPI.getInstance().getClient();
+
+{{ body }}
+
+        client.getBooleanValue(System.getenv("LAUNCHDARKLY_FLAG_KEY"), false, context);
+        System.out.println("feature flag evaluates to true");
+    }
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-init-runner-main.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-init-runner-main.snippet.md
@@ -1,0 +1,37 @@
+---
+id: java-server-sdk/scaffolds/openfeature-jvm-init-runner-main
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/runner/Runner.java
+description: |
+  Runner half of the Java OpenFeature init scaffold pair. Lives under a
+  sub-package so both this and the wrappee's `Main` can be public
+  top-level classes. The wrappee's `Main.main` registers the provider on
+  the global `OpenFeatureAPI` singleton; this runner then reads the
+  client back off the singleton, evaluates a flag, and prints the
+  success line the harness greps for. Listed as a companion of
+  `openfeature-jvm-init-runner` and used as the maven mainClass.
+---
+
+```java
+package com.launchdarkly.tutorial.runner;
+
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.ImmutableContext;
+
+public class Runner {
+    public static void main(String[] args) throws Exception {
+        // Registers the LaunchDarkly provider on the OpenFeatureAPI singleton.
+        com.launchdarkly.tutorial.Main.main(args);
+
+        Client client = OpenFeatureAPI.getInstance().getClient();
+        EvaluationContext context = new ImmutableContext("example-user-key");
+        client.getBooleanValue(System.getenv("LAUNCHDARKLY_FLAG_KEY"), false, context);
+
+        System.out.println("feature flag evaluates to true");
+    }
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-init-runner.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-init-runner.snippet.md
@@ -1,0 +1,38 @@
+---
+id: java-server-sdk/scaffolds/openfeature-jvm-init-runner
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: |
+  Compiles and runs an OpenFeature "initialize the provider" fragment
+  end-to-end against a real LaunchDarkly environment. The fragment is a
+  full `public class Main` whose `main` registers a LaunchDarkly provider
+  with the global `OpenFeatureAPI` singleton; this scaffold supplies the
+  `import` statements the page's "import the namespaces" fragment
+  documents so the body compiles. The runner companion is the maven
+  entrypoint: it invokes the body's `Main.main`, then reads the now-
+  registered client back off the `OpenFeatureAPI` singleton, evaluates a
+  flag, and prints the success line. The fragment's `YOUR_SDK_KEY`
+  literal is replaced with the real key via `validation.placeholders`.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; a full `public class Main` that registers the provider.
+validation:
+  runtime: jvm
+  entrypoint: src/main/java/com/launchdarkly/tutorial/runner/Runner.java
+  companions:
+    - java-server-sdk/scaffolds/openfeature-jvm-init-runner-main
+---
+
+```java
+package com.launchdarkly.tutorial;
+
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Client;
+import com.launchdarkly.sdk.server.LDClient;
+import com.launchdarkly.openfeature.serverprovider.Provider;
+
+{{ body }}
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-runner.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-runner.snippet.md
@@ -1,0 +1,48 @@
+---
+id: java-server-sdk/scaffolds/openfeature-jvm-runner
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: |
+  Runs an OpenFeature provider doc fragment that assumes a registered
+  provider and a bound `provider`, `client`, and `context` already
+  exist — the "evaluate a context" and "access the LaunchDarkly client"
+  fragments. The scaffold registers a real LaunchDarkly provider, binds
+  those names, runs the fragment, then evaluates a flag and prints the
+  success line. Java has no local-variable shadowing, so fragments that
+  declare their own `context` use the `openfeature-jvm-context-runner`
+  variant instead. Requires LaunchDarkly credentials.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment, run with `provider`, `client`, and `context` in scope.
+validation:
+  runtime: jvm
+  entrypoint: src/main/java/com/launchdarkly/tutorial/Main.java
+---
+
+```java
+package com.launchdarkly.tutorial;
+
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.ImmutableContext;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import com.launchdarkly.openfeature.serverprovider.Provider;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        Provider provider = new Provider(System.getenv("LAUNCHDARKLY_SDK_KEY"));
+        OpenFeatureAPI.getInstance().setProvider(provider);
+        Client client = OpenFeatureAPI.getInstance().getClient();
+        EvaluationContext context = new ImmutableContext("example-user-key");
+
+{{ body }}
+
+        client.getBooleanValue(System.getenv("LAUNCHDARKLY_FLAG_KEY"), false, context);
+        System.out.println("feature flag evaluates to true");
+    }
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-toplevel.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/scaffolds/openfeature-jvm-toplevel.snippet.md
@@ -1,0 +1,36 @@
+---
+id: java-server-sdk/scaffolds/openfeature-jvm-toplevel
+sdk: java-server-sdk
+kind: scaffold
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: |
+  Resolves an OpenFeature provider doc fragment that is a set of
+  top-level `import` statements. The jvm harness lifts the body's
+  `import …;` lines out to file scope at the IMPORT_LIFT_MARKER, so
+  javac resolves each imported name against the OpenFeature SDK and the
+  LaunchDarkly provider baked into the validator image. An import that
+  names a class the packages don't ship fails compilation. The body
+  does not connect to LaunchDarkly, so this needs no credentials beyond
+  what the harness already requires.
+inputs:
+  body:
+    type: string
+    description: The wrappee's import statements; lifted to file scope by the harness.
+validation:
+  runtime: jvm
+  entrypoint: src/main/java/com/launchdarkly/tutorial/Main.java
+---
+
+```java
+package com.launchdarkly.tutorial;
+
+// IMPORT_LIFT_MARKER
+
+public class Main {
+    public static void main(String[] args) {
+{{ body }}
+        System.out.println("feature flag evaluates to true");
+    }
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/access-the-launchdarkly-client.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/access-the-launchdarkly-client.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/access-the-launchdarkly-client
+sdk: java-server-sdk
+kind: reference
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: "Java OpenFeature provider in section \"Access the LaunchDarkly client\""
+validation:
+  scaffold: java-server-sdk/scaffolds/openfeature-jvm-runner
+---
+
+```java
+LDClientInterface ldClient = provider.getLdClient();
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
@@ -1,0 +1,16 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/construct-a-context-organization
+sdk: java-server-sdk
+kind: reference
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: "Java OpenFeature provider in section \"Construct a context\" (organization)"
+validation:
+  scaffold: java-server-sdk/scaffolds/openfeature-jvm-context-runner
+---
+
+```java
+EvaluationContext context = new ImmutableContext("org-key", new HashMap<String, Value>(){{
+    put("kind", new Value("organization"));
+}});
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/construct-a-context-user
+sdk: java-server-sdk
+kind: reference
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: "Java OpenFeature provider in section \"Construct a context\" (user)"
+validation:
+  scaffold: java-server-sdk/scaffolds/openfeature-jvm-context-runner
+---
+
+```java
+EvaluationContext context = new ImmutableContext("example-user-key");
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/evaluate-a-context
+sdk: java-server-sdk
+kind: reference
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: "Java OpenFeature provider in section \"Evaluate a context\""
+validation:
+  scaffold: java-server-sdk/scaffolds/openfeature-jvm-runner
+---
+
+```java
+boolean value = client.getBooleanValue("example-flag-key", false, context);
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
@@ -1,0 +1,17 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/import-the-namespaces
+sdk: java-server-sdk
+kind: reference
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: "Java OpenFeature provider in section \"Install the provider and dependencies\" (imports)"
+validation:
+  scaffold: java-server-sdk/scaffolds/openfeature-jvm-toplevel
+---
+
+```java
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.Client;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import com.launchdarkly.openfeature.serverprovider.Provider;
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
@@ -1,0 +1,22 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/initialize-the-provider
+sdk: java-server-sdk
+kind: reference
+lang: java
+file: src/main/java/com/launchdarkly/tutorial/Main.java
+description: "Java OpenFeature provider in section \"Initialize the provider\""
+validation:
+  scaffold: java-server-sdk/scaffolds/openfeature-jvm-init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
+---
+
+```java
+public class Main {
+    public static void main(String[] args) {
+        OpenFeatureAPI.getInstance().setProvider(new Provider("YOUR_SDK_KEY"));
+
+        Client client = OpenFeatureAPI.getInstance().getClient();
+    }
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/install-dependencies-gradle.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/install-dependencies-gradle.snippet.md
@@ -1,0 +1,15 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/install-dependencies-gradle
+sdk: java-server-sdk
+kind: reference
+lang: groovy
+file: java-server-sdk/sdk-docs/openfeature/install-dependencies-gradle.gradle
+description: "Gradle in section \"Install the provider and dependencies\" (SDK + OpenFeature)"
+validation:
+  runtime: shell-install
+---
+
+```groovy
+implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '[7.1.0, 8.0.0)'
+implementation 'dev.openfeature:sdk:[1.7.0,2.0.0)'
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-gradle.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-gradle.snippet.md
@@ -1,0 +1,14 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/install-the-provider-gradle
+sdk: java-server-sdk
+kind: reference
+lang: groovy
+file: java-server-sdk/sdk-docs/openfeature/install-the-provider-gradle.gradle
+description: "Gradle in section \"Install the provider and dependencies\" (provider)"
+validation:
+  runtime: shell-install
+---
+
+```groovy
+implementation group: 'com.launchdarkly', name: 'launchdarkly-openfeature-serverprovider', version: '1.0.0'
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-xml.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-xml.snippet.md
@@ -1,0 +1,18 @@
+---
+id: java-server-sdk/sdk-docs/openfeature/install-the-provider-xml
+sdk: java-server-sdk
+kind: reference
+lang: xml
+file: java-server-sdk/sdk-docs/openfeature/install-the-provider-xml.xml
+description: "XML in section \"Install the provider and dependencies\" (Maven dependency)"
+validation:
+  runtime: xml
+---
+
+```xml
+<dependency>
+  <groupId>com.launchdarkly</groupId>
+  <artifactId>launchdarkly-openfeature-serverprovider</artifactId>
+  <version>1.0.0</version>
+</dependency>
+```

--- a/snippets/sdks/node-server-sdk/snippets/scaffolds/openfeature-node-init-runner.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/scaffolds/openfeature-node-init-runner.snippet.md
@@ -1,0 +1,41 @@
+---
+id: node-server-sdk/scaffolds/openfeature-node-init-runner
+sdk: node-server-sdk
+kind: scaffold
+lang: javascript
+file: index.mjs
+description: |
+  Runs an OpenFeature "initialize the provider" fragment end-to-end
+  against a real LaunchDarkly environment. The fragment is expected to
+  register a LaunchDarkly provider with OpenFeature and bind a client
+  (`const client = OpenFeature.getClient()`); the scaffold supplies the
+  `import` statements the fragment assumes are already present, then
+  uses the bound `client` to evaluate a flag and print the success line
+  the harness greps for. The fragment's `YOUR_SDK_KEY` literal is
+  replaced with the real key via the snippet's `validation.placeholders`
+  before this runs.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; registers the provider and binds `client`.
+validation:
+  runtime: node
+  entrypoint: index.mjs
+  requirements: |
+    @openfeature/server-sdk
+    @launchdarkly/node-server-sdk
+    @launchdarkly/openfeature-node-server
+---
+
+```javascript
+import { OpenFeature } from '@openfeature/server-sdk';
+import { LaunchDarklyProvider } from '@launchdarkly/openfeature-node-server';
+
+{{ body }}
+
+const _value = await client.getBooleanValue(process.env.LAUNCHDARKLY_FLAG_KEY, false, {
+  targetingKey: 'example-user-key',
+});
+
+console.log('feature flag evaluates to true');
+```

--- a/snippets/sdks/node-server-sdk/snippets/scaffolds/openfeature-node-runner.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/scaffolds/openfeature-node-runner.snippet.md
@@ -1,0 +1,48 @@
+---
+id: node-server-sdk/scaffolds/openfeature-node-runner
+sdk: node-server-sdk
+kind: scaffold
+lang: javascript
+file: index.mjs
+description: |
+  Runs an OpenFeature provider doc fragment that assumes a registered
+  provider and a bound `client`, `provider`, and `context` already
+  exist — the "construct a context", "evaluate a context", "track
+  metrics", and "access the LaunchDarkly client" fragments. The
+  scaffold registers a real LaunchDarkly provider, binds those names,
+  then runs the fragment inside its own block so a fragment that
+  re-declares `context` (the construct-a-context examples) shadows the
+  outer binding rather than colliding with it. After the fragment runs,
+  the scaffold evaluates a flag with the outer context and prints the
+  success line the harness greps for. Requires LaunchDarkly credentials
+  because the provider connects.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment, run with `provider`, `client`, and `context` in scope.
+validation:
+  runtime: node
+  entrypoint: index.mjs
+  requirements: |
+    @openfeature/server-sdk
+    @launchdarkly/node-server-sdk
+    @launchdarkly/openfeature-node-server
+---
+
+```javascript
+import { OpenFeature } from '@openfeature/server-sdk';
+import { LaunchDarklyProvider } from '@launchdarkly/openfeature-node-server';
+
+const provider = new LaunchDarklyProvider(process.env.LAUNCHDARKLY_SDK_KEY);
+await OpenFeature.setProviderAndWait(provider);
+const client = OpenFeature.getClient();
+const context = { targetingKey: 'example-user-key' };
+
+{
+{{ body }}
+}
+
+const _value = await client.getBooleanValue(process.env.LAUNCHDARKLY_FLAG_KEY, false, context);
+
+console.log('feature flag evaluates to true');
+```

--- a/snippets/sdks/node-server-sdk/snippets/scaffolds/openfeature-node-toplevel.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/scaffolds/openfeature-node-toplevel.snippet.md
@@ -1,0 +1,35 @@
+---
+id: node-server-sdk/scaffolds/openfeature-node-toplevel
+sdk: node-server-sdk
+kind: scaffold
+lang: javascript
+file: index.mjs
+description: |
+  Resolves an OpenFeature provider doc fragment that is a set of
+  top-level `import` statements. Unlike the parse-only
+  `node-syntax-only-toplevel` scaffold, this one actually executes the
+  module, so the imported package names must resolve against the
+  OpenFeature SDK, the LaunchDarkly Node.js SDK, and the LaunchDarkly
+  provider that the harness installs from `requirements`. A typo in a
+  package or export name fails the import; this catches drift that a
+  pure parse check would miss. The body imports do not connect to
+  LaunchDarkly — only instantiating the provider does — so this runs
+  without LaunchDarkly credentials.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's import statements, staged verbatim and executed.
+validation:
+  runtime: node
+  entrypoint: index.mjs
+  requirements: |
+    @openfeature/server-sdk
+    @launchdarkly/node-server-sdk
+    @launchdarkly/openfeature-node-server
+---
+
+```javascript
+{{ body }}
+
+console.log('feature flag evaluates to true');
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/access-the-launchdarkly-client.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/access-the-launchdarkly-client.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/access-the-launchdarkly-client
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+file: node-server-sdk/sdk-docs/openfeature/access-the-launchdarkly-client.mjs
+description: "Node.js OpenFeature provider in section \"Access the LaunchDarkly client\""
+validation:
+  scaffold: node-server-sdk/scaffolds/openfeature-node-runner
+---
+
+```js
+const ldClient = provider.getClient();
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
@@ -1,0 +1,17 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/construct-a-context-organization
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+file: node-server-sdk/sdk-docs/openfeature/construct-a-context-organization.mjs
+description: "Node.js OpenFeature provider in section \"Construct a context\" (organization)"
+validation:
+  scaffold: node-server-sdk/scaffolds/openfeature-node-runner
+---
+
+```js
+const context = {
+  kind: "organization",
+  targetingKey: "example-user-key" // Could also use "key" instead of "targetingKey".
+};
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/construct-a-context-user
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+file: node-server-sdk/sdk-docs/openfeature/construct-a-context-user.mjs
+description: "Node.js OpenFeature provider in section \"Construct a context\" (user)"
+validation:
+  scaffold: node-server-sdk/scaffolds/openfeature-node-runner
+---
+
+```js
+const context = {
+  targetingKey: "example-user-key", // Could also use "key" instead of "targetingKey".
+};
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/evaluate-a-context
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+file: node-server-sdk/sdk-docs/openfeature/evaluate-a-context.mjs
+description: "Node.js OpenFeature provider in section \"Evaluate a context\""
+validation:
+  scaffold: node-server-sdk/scaffolds/openfeature-node-runner
+---
+
+```js
+const flagValue = await client.getBooleanValue("example-flag-key", false, context);
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
@@ -1,0 +1,15 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/import-the-namespaces
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+file: node-server-sdk/sdk-docs/openfeature/import-the-namespaces.mjs
+description: "Node.js OpenFeature provider in section \"Install the provider\" (imports)"
+validation:
+  scaffold: node-server-sdk/scaffolds/openfeature-node-toplevel
+---
+
+```js
+import { OpenFeature } from '@openfeature/server-sdk';
+import { LaunchDarklyProvider } from '@launchdarkly/openfeature-node-server';
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
@@ -1,0 +1,18 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/initialize-the-provider
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+file: node-server-sdk/sdk-docs/openfeature/initialize-the-provider.mjs
+description: "Node.js OpenFeature provider in section \"Initialize the provider\""
+validation:
+  scaffold: node-server-sdk/scaffolds/openfeature-node-init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
+---
+
+```js
+await OpenFeature.setProviderAndWait(new LaunchDarklyProvider("YOUR_SDK_KEY"));
+
+const client = OpenFeature.getClient();
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-shell.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-shell.snippet.md
@@ -1,0 +1,16 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/install-the-provider-shell
+sdk: node-server-sdk
+kind: reference
+lang: shell
+file: node-server-sdk/sdk-docs/openfeature/install-the-provider-shell.sh
+description: "Node.js OpenFeature provider in section \"Install the provider\""
+validation:
+  runtime: shell-install
+---
+
+```bash
+npm install @openfeature/server-sdk
+npm install @launchdarkly/node-server-sdk
+npm install @launchdarkly/openfeature-node-server
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/track-metrics.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-docs/openfeature/track-metrics.snippet.md
@@ -1,0 +1,14 @@
+---
+id: node-server-sdk/sdk-docs/openfeature/track-metrics
+sdk: node-server-sdk
+kind: reference
+lang: javascript
+file: node-server-sdk/sdk-docs/openfeature/track-metrics.mjs
+description: "Node.js OpenFeature provider in section \"Track metrics\""
+validation:
+  scaffold: node-server-sdk/scaffolds/openfeature-node-runner
+---
+
+```js
+client.track('example-event-key', context, { "optionalCustomData": "optionalCustomValue"});
+```

--- a/snippets/sdks/openfeature-port-notes.md
+++ b/snippets/sdks/openfeature-port-notes.md
@@ -1,0 +1,49 @@
+# OpenFeature section port notes (SDK-2627)
+
+Source: `ld-docs-private/fern/topics/sdk/openfeature/` — `node-server.mdx`,
+`java.mdx`, `dotnet-server.mdx`, `php.mdx` (`index.mdx` carries no code).
+
+Every code block is bound to a **real provider validator**: the runners
+install the OpenFeature SDK + the LaunchDarkly base SDK + the LaunchDarkly
+OpenFeature provider and exercise each fragment against a live LaunchDarkly
+environment (node/php install at stage time; java/dotnet have the provider
+packages added to the pre-baked dependency superset in their validator
+Dockerfiles).
+
+## Scaffold shape (per language)
+
+- `*-toplevel` — resolves the import/using fragment against the real
+  packages (executes / compiles; not parse-only).
+- `*-init-runner` — runs the "initialize the provider" fragment's own
+  provider registration, then evaluates a flag. Java uses a Main + Runner
+  companion pair (the Runner reads the client back off the global
+  `OpenFeatureAPI` singleton after the body registers the provider).
+- `*-runner` — pre-registers a connected provider + client + context, runs
+  fragments that consume them (evaluate / track / access).
+- `*-context-runner` (java, dotnet) — the "construct a context" fragments
+  declare their own `context`; Java and C# forbid shadowing a local the
+  scaffold already bound, so these get a variant that leaves `context` to
+  the fragment and evaluates with it afterward. Node and PHP reuse the
+  single runner (JS block-shadowing / PHP reassignment make a separate
+  variant unnecessary).
+
+## Snippet content fixes (real bugs the validators caught)
+
+- **java** import fragment omitted `dev.openfeature.sdk.Client`, which the
+  init fragment uses.
+- **java** "access the LaunchDarkly client" declared `LDClient`, but
+  `Provider.getLdClient()` returns `LDClientInterface`.
+- **java** organization-context fragment had a misplaced generic
+  (`new HashMap(<String, Value>)` --> `new HashMap<String, Value>()`).
+- **dotnet** import fragment omitted `using OpenFeature.Model;`
+  (`EvaluationContext`).
+- **dotnet** "evaluate a context" used the pre-v2 `GetBooleanValue`; the
+  OpenFeature .NET v2 API (which the page targets) is `GetBooleanValueAsync`.
+- **dotnet** "access the LaunchDarkly client" was missing its statement
+  semicolon.
+
+## CI
+
+No matrix edit: the `node-server-sdk`, `php-server-sdk`, `java-server-sdk`,
+and `dotnet-server-sdk` rows each validate the whole SDK with a server key,
+so the new `sdk-docs/openfeature/` snippets are picked up automatically.

--- a/snippets/sdks/php-server-sdk/snippets/scaffolds/openfeature-php-init-runner.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/scaffolds/openfeature-php-init-runner.snippet.md
@@ -1,0 +1,39 @@
+---
+id: php-server-sdk/scaffolds/openfeature-php-init-runner
+sdk: php-server-sdk
+kind: scaffold
+lang: php
+file: main.php
+description: |
+  Runs an OpenFeature "initialize the provider" fragment end-to-end
+  against a real LaunchDarkly environment. The fragment is expected to
+  register a LaunchDarkly provider with OpenFeature and bind a `$client`;
+  the scaffold supplies the `use` imports the fragment assumes, then
+  uses `$client` to evaluate a flag and print the success line. The
+  fragment's `YOUR_SDK_KEY` literal is replaced with the real key via
+  the snippet's `validation.placeholders` before this runs.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; registers the provider and binds `$client`.
+validation:
+  runtime: php
+  entrypoint: main.php
+  requirements: |
+    launchdarkly/openfeature-server
+---
+
+```php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\implementation\flags\EvaluationContext;
+
+{{ body }}
+
+$context = new EvaluationContext("example-user-key");
+$flagValue = $client->getBooleanValue(getenv('LAUNCHDARKLY_FLAG_KEY'), false, $context);
+
+echo "feature flag evaluates to true\n";
+```

--- a/snippets/sdks/php-server-sdk/snippets/scaffolds/openfeature-php-runner.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/scaffolds/openfeature-php-runner.snippet.md
@@ -1,0 +1,45 @@
+---
+id: php-server-sdk/scaffolds/openfeature-php-runner
+sdk: php-server-sdk
+kind: scaffold
+lang: php
+file: main.php
+description: |
+  Runs an OpenFeature provider doc fragment that assumes a registered
+  provider and a bound `$client` and `$context` already exist — the
+  "construct a context" and "evaluate a context" fragments. The scaffold
+  registers a real LaunchDarkly provider, binds `$provider`, `$client`,
+  and a default `$context`, then runs the fragment (which may reassign
+  `$context`) and evaluates a flag, printing the success line. Requires
+  LaunchDarkly credentials because the provider connects.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment, run with `$provider`, `$client`, and `$context` in scope.
+validation:
+  runtime: php
+  entrypoint: main.php
+  requirements: |
+    launchdarkly/openfeature-server
+---
+
+```php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\implementation\flags\Attributes;
+use OpenFeature\implementation\flags\EvaluationContext;
+
+$provider = new LaunchDarkly\OpenFeature\Provider(getenv('LAUNCHDARKLY_SDK_KEY'), []);
+$api = OpenFeatureAPI::getInstance();
+$api->setProvider($provider);
+$client = $api->getClient("hello-client", 1);
+$context = new EvaluationContext("example-user-key");
+
+{{ body }}
+
+$flagValue = $client->getBooleanValue(getenv('LAUNCHDARKLY_FLAG_KEY'), false, $context);
+
+echo "feature flag evaluates to true\n";
+```

--- a/snippets/sdks/php-server-sdk/snippets/scaffolds/openfeature-php-toplevel.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/scaffolds/openfeature-php-toplevel.snippet.md
@@ -1,0 +1,44 @@
+---
+id: php-server-sdk/scaffolds/openfeature-php-toplevel
+sdk: php-server-sdk
+kind: scaffold
+lang: php
+file: main.php
+description: |
+  Resolves an OpenFeature provider doc fragment that is a set of `use`
+  imports. A bare `use` statement in PHP is only an alias and does not
+  trigger autoloading, so the scaffold follows the imports with
+  `class_exists`/`interface_exists` checks against the autoloader to
+  confirm each imported name actually resolves to a class shipped by
+  the installed OpenFeature packages. A typo in a namespace fails the
+  check.
+inputs:
+  body:
+    type: string
+    description: The wrappee's `use` statements, staged verbatim at file scope.
+validation:
+  runtime: php
+  entrypoint: main.php
+  requirements: |
+    launchdarkly/openfeature-server
+---
+
+```php
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+{{ body }}
+
+foreach ([
+    'OpenFeature\OpenFeatureAPI',
+    'OpenFeature\implementation\flags\Attributes',
+    'OpenFeature\implementation\flags\EvaluationContext',
+] as $fqcn) {
+    if (!class_exists($fqcn) && !interface_exists($fqcn)) {
+        fwrite(STDERR, "unresolved import: $fqcn\n");
+        exit(1);
+    }
+}
+
+echo "feature flag evaluates to true\n";
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-organization.snippet.md
@@ -1,0 +1,15 @@
+---
+id: php-server-sdk/sdk-docs/openfeature/construct-a-context-organization
+sdk: php-server-sdk
+kind: reference
+lang: php
+file: php-server-sdk/sdk-docs/openfeature/construct-a-context-organization.php
+description: "PHP OpenFeature provider in section \"Construct a context\" (organization)"
+validation:
+  scaffold: php-server-sdk/scaffolds/openfeature-php-runner
+---
+
+```php
+$attributes = new Attributes(["kind" => "organization"]);
+$context = new EvaluationContext("example-user-key", $attributes);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/construct-a-context-user.snippet.md
@@ -1,0 +1,14 @@
+---
+id: php-server-sdk/sdk-docs/openfeature/construct-a-context-user
+sdk: php-server-sdk
+kind: reference
+lang: php
+file: php-server-sdk/sdk-docs/openfeature/construct-a-context-user.php
+description: "PHP OpenFeature provider in section \"Construct a context\" (user)"
+validation:
+  scaffold: php-server-sdk/scaffolds/openfeature-php-runner
+---
+
+```php
+$context = new EvaluationContext("example-user-key");
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/evaluate-a-context.snippet.md
@@ -1,0 +1,14 @@
+---
+id: php-server-sdk/sdk-docs/openfeature/evaluate-a-context
+sdk: php-server-sdk
+kind: reference
+lang: php
+file: php-server-sdk/sdk-docs/openfeature/evaluate-a-context.php
+description: "PHP OpenFeature provider in section \"Evaluate a context\""
+validation:
+  scaffold: php-server-sdk/scaffolds/openfeature-php-runner
+---
+
+```php
+$flagValue = $client->getBooleanValue("example-flag-key", false, $context);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/import-the-namespaces.snippet.md
@@ -1,0 +1,16 @@
+---
+id: php-server-sdk/sdk-docs/openfeature/import-the-namespaces
+sdk: php-server-sdk
+kind: reference
+lang: php
+file: php-server-sdk/sdk-docs/openfeature/import-the-namespaces.php
+description: "PHP OpenFeature provider in section \"Install the provider\" (imports)"
+validation:
+  scaffold: php-server-sdk/scaffolds/openfeature-php-toplevel
+---
+
+```php
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\implementation\flags\Attributes;
+use OpenFeature\implementation\flags\EvaluationContext;
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/initialize-the-provider.snippet.md
@@ -1,0 +1,21 @@
+---
+id: php-server-sdk/sdk-docs/openfeature/initialize-the-provider
+sdk: php-server-sdk
+kind: reference
+lang: php
+file: php-server-sdk/sdk-docs/openfeature/initialize-the-provider.php
+description: "PHP OpenFeature provider in section \"Initialize the provider\""
+validation:
+  scaffold: php-server-sdk/scaffolds/openfeature-php-init-runner
+  placeholders:
+    YOUR_SDK_KEY: LAUNCHDARKLY_SDK_KEY
+---
+
+```php
+$config = [];
+$provider = new LaunchDarkly\OpenFeature\Provider("YOUR_SDK_KEY", $config);
+$api = OpenFeatureAPI::getInstance();
+$api->setProvider($provider);
+
+$client = $api->getClient("hello-client", 1);
+```

--- a/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-shell.snippet.md
+++ b/snippets/sdks/php-server-sdk/snippets/sdk-docs/openfeature/install-the-provider-shell.snippet.md
@@ -1,0 +1,14 @@
+---
+id: php-server-sdk/sdk-docs/openfeature/install-the-provider-shell
+sdk: php-server-sdk
+kind: reference
+lang: shell
+file: php-server-sdk/sdk-docs/openfeature/install-the-provider-shell.sh
+description: "PHP OpenFeature provider in section \"Install the provider\""
+validation:
+  runtime: shell-install
+---
+
+```bash
+composer require launchdarkly/openfeature-server
+```

--- a/snippets/validators/languages/dotnet-server/Dockerfile
+++ b/snippets/validators/languages/dotnet-server/Dockerfile
@@ -37,6 +37,8 @@ RUN printf '%s\n' \
     && dotnet add package LaunchDarkly.ServerSdk.Telemetry \
     && dotnet add package LaunchDarkly.ServerSdk.Consul \
     && dotnet add package LaunchDarkly.ServerSdk.DynamoDB \
+    && dotnet add package OpenFeature \
+    && dotnet add package LaunchDarkly.OpenFeature.ServerProvider \
     && dotnet build -c Debug \
     && cp HelloDotNet.csproj /opt/baseline.csproj
 

--- a/snippets/validators/languages/jvm/Dockerfile
+++ b/snippets/validators/languages/jvm/Dockerfile
@@ -33,6 +33,8 @@ RUN printf '%s\n' \
     '    <dependency><groupId>com.launchdarkly</groupId><artifactId>launchdarkly-java-server-sdk-redis-store</artifactId><version>3.1.1</version></dependency>' \
     '    <dependency><groupId>com.launchdarkly</groupId><artifactId>launchdarkly-java-server-sdk-dynamodb-store</artifactId><version>5.0.0</version></dependency>' \
     '    <dependency><groupId>com.launchdarkly</groupId><artifactId>launchdarkly-java-server-sdk-consul-store</artifactId><version>5.0.0</version></dependency>' \
+    '    <dependency><groupId>dev.openfeature</groupId><artifactId>sdk</artifactId><version>1.7.0</version></dependency>' \
+    '    <dependency><groupId>com.launchdarkly</groupId><artifactId>launchdarkly-openfeature-serverprovider</artifactId><version>1.0.0</version></dependency>' \
     '  </dependencies>' \
     '  <build><plugins>' \
     '    <plugin><groupId>org.codehaus.mojo</groupId><artifactId>exec-maven-plugin</artifactId><version>3.1.1</version></plugin>' \


### PR DESCRIPTION
Ports the OpenFeature provider pages — `node-server`, `java`, `dotnet-server`, and `php` under `ld-docs-private/fern/topics/sdk/openfeature/` — into canonical snippets. (`index.mdx` carries no code.)

Every code block is bound to a **real provider validator**: the runners install the OpenFeature SDK + the LaunchDarkly base SDK + the LaunchDarkly OpenFeature provider and exercise each fragment against a live LaunchDarkly environment, rather than parse-checking. node/php install the provider packages at stage time; java and dotnet have them added to the pre-baked dependency superset in their validator Docker images.

## Scaffolds (per language)

- **toplevel** — resolves the import/`using` fragment against the real packages (executes / compiles).
- **init-runner** — runs the init fragment's own provider registration, then evaluates a flag. Java uses a `Main` + `Runner` companion pair (the Runner reads the client back off the global `OpenFeatureAPI` singleton).
- **runner** — pre-registers a connected provider + client + context, runs the evaluate / track / access fragments.
- **context-runner** (java, dotnet) — the "construct a context" fragments declare their own `context`; Java and C# forbid shadowing a local the scaffold already bound, so these get a variant that leaves `context` to the fragment. Node and PHP reuse the single runner.

## Snippet content fixes (real bugs the validators caught)

- **java**: import fragment omitted `dev.openfeature.sdk.Client` (used by the init fragment); "access" declared `LDClient` but `Provider.getLdClient()` returns `LDClientInterface`; organization-context had a misplaced generic (`new HashMap(<String, Value>)`).
- **dotnet**: import fragment omitted `using OpenFeature.Model;`; "evaluate" used the pre-v2 `GetBooleanValue` (the page targets OpenFeature .NET v2, which is `GetBooleanValueAsync`); "access" was missing its statement semicolon.

Each fix is called out inline below.

## CI

No matrix edit — the `node-server-sdk`, `php-server-sdk`, `java-server-sdk`, and `dotnet-server-sdk` rows each validate the whole SDK with a server key, so the new `sdk-docs/openfeature/` snippets are picked up automatically. All 30 snippets validate green locally against the LD sandbox.

Phase B (the ld-docs `SDK_SNIPPET:RENDER` markers) follows once this merges and a snippets release is cut.

Part of the docs-porting effort (SDK-2434).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation snippets and CI validation harnesses using the existing sandbox credential pattern; no production app or auth logic is modified.
> 
> **Overview**
> Ports **OpenFeature provider** documentation for **Node, Java, .NET server, and PHP** into canonical `sdk-docs/openfeature/` snippets, each wired to **runtime validators** that install OpenFeature + LaunchDarkly provider packages and assert a **live sandbox flag evaluation** (not parse-only checks).
> 
> Adds per-language **scaffolds** (`*-toplevel`, `*-init-runner`, `*-runner`, and Java/C# `*-context-runner` where locals can't be shadowed) plus install/shell snippets. **JVM and dotnet-server validator images** now pre-bake OpenFeature dependencies; Node/PHP pull provider packages at validate time.
> 
> **Snippet fixes** surfaced by the harness include Java missing `Client` import and `LDClientInterface` typing, a broken `HashMap` generic, and .NET missing `OpenFeature.Model`, wrong sync API vs `GetBooleanValueAsync`, and a missing semicolon. The **snippets-validate** workflow comment for `dotnet-server-sdk` is updated to document shell-install plus OpenFeature runners; existing matrix rows pick up the new snippets automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c2fa084039de9c4748048c452b814fdb78ad5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->