### PR TITLE
feat: Port edge SDK docs section to canonical snippets

### DIFF
--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-eval-globals.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-eval-globals.snippet.md
@@ -1,0 +1,17 @@
+---
+id: akamai-server-edgekv-sdk/scaffolds/edge-akamai-eval-globals
+sdk: akamai-server-edgekv-sdk
+kind: scaffold
+lang: typescript
+file: _globals.d.ts
+description: |
+  Ambient companion for `edge-akamai-eval`. Declares `ldClient` as the
+  real return type of the Akamai SDK's `init`, so the evaluate fragment
+  type-checks `ldClient.variation(...)` against the real client API
+  without the scaffold having to inject a statement ahead of the
+  fragment's own imports.
+---
+
+```typescript
+declare const ldClient: ReturnType<typeof import('@launchdarkly/akamai-server-edgekv-sdk').init>;
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-eval.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-eval.snippet.md
@@ -1,0 +1,27 @@
+---
+id: akamai-server-edgekv-sdk/scaffolds/edge-akamai-eval
+sdk: akamai-server-edgekv-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks an Akamai "evaluate a flag" fragment against the real
+  package. The fragment carries its own imports and calls
+  `ldClient.variation(...)`; the `_globals.d.ts` companion ambiently
+  declares `ldClient` as the real return type of `init`, so
+  `variation(...)` is checked against the real client API. The fragment
+  is spliced verbatim (its own import stays at module top).
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment; uses the ambient `ldClient`.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+  companions:
+    - akamai-server-edgekv-sdk/scaffolds/edge-akamai-eval-globals
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-init-runner.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-init-runner.snippet.md
@@ -1,0 +1,27 @@
+---
+id: akamai-server-edgekv-sdk/scaffolds/edge-akamai-init-runner
+sdk: akamai-server-edgekv-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks an Akamai "initialize the client" fragment against the real
+  package. The scaffold supplies the `import { init }` the fragment
+  assumes from the page's import block, then splices the fragment (which
+  calls `init(...)` and binds `ldClient`). tsc checks the `init` config
+  object against the real parameter type, so a misnamed or mistyped
+  option fails.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; calls `init(...)` and binds `ldClient`.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+import { init } from '@launchdarkly/akamai-server-edgekv-sdk';
+
+{{ body }}
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-toplevel.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/scaffolds/edge-akamai-toplevel.snippet.md
@@ -1,0 +1,23 @@
+---
+id: akamai-server-edgekv-sdk/scaffolds/edge-akamai-toplevel
+sdk: akamai-server-edgekv-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks an Akamai edge SDK import fragment against the real
+  `@launchdarkly/akamai-server-edgekv-sdk` package. Routes through the
+  `edge-tsc` validator (tsc --noEmit with module resolution), so a named
+  import that the package doesn't export fails the check.
+inputs:
+  body:
+    type: string
+    description: The wrappee's import statements, type-checked as a module.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
@@ -1,0 +1,22 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/evaluate-a-flag
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+file: akamai-server-edgekv-sdk/sdk-docs/evaluate-a-flag.ts
+description: "Akamai edge SDK in section \"Evaluate a flag\""
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/edge-akamai-eval
+---
+
+```ts
+import { LDContext } from '@launchdarkly/akamai-server-edgekv-sdk';
+
+const context: LDContext = {
+  kind: 'org',
+  key: 'example-organization-key',
+  someAttribute: 'example-attribute-value',
+};
+
+const flagValue = await ldClient.variation('example-flag-key', context, false);
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/import-the-client.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/import-the-client.snippet.md
@@ -1,0 +1,14 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/import-the-client
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+file: akamai-server-edgekv-sdk/sdk-docs/import-the-client.ts
+description: "Akamai edge SDK in section \"Initialize the client\" (import)"
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/edge-akamai-toplevel
+---
+
+```ts
+import { init } from '@launchdarkly/akamai-server-edgekv-sdk';
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
@@ -1,0 +1,18 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/initialize-the-client
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: typescript
+file: akamai-server-edgekv-sdk/sdk-docs/initialize-the-client.ts
+description: "Akamai edge SDK in section \"Initialize the client\""
+validation:
+  scaffold: akamai-server-edgekv-sdk/scaffolds/edge-akamai-init-runner
+---
+
+```ts
+const ldClient = init({
+  sdkKey: 'example-client-side-id',
+  namespace: 'your-edgekv-namespace',
+  group: 'your-edgekv-group-id'
+});
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/install-the-sdk-npm
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: shell
+file: akamai-server-edgekv-sdk/sdk-docs/install-the-sdk-npm.sh
+description: "Akamai edge SDK in section \"Install the SDK\" (npm)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+npm i @launchdarkly/akamai-server-edgekv-sdk
+```

--- a/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
+++ b/snippets/sdks/akamai-server-edgekv-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: akamai-server-edgekv-sdk/sdk-docs/install-the-sdk-yarn
+sdk: akamai-server-edgekv-sdk
+kind: reference
+lang: shell
+file: akamai-server-edgekv-sdk/sdk-docs/install-the-sdk-yarn.sh
+description: "Akamai edge SDK in section \"Install the SDK\" (yarn)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+yarn add @launchdarkly/akamai-server-edgekv-sdk
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-eval.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-eval.snippet.md
@@ -1,0 +1,27 @@
+---
+id: cloudflare-server-sdk/scaffolds/edge-cloudflare-eval
+sdk: cloudflare-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Cloudflare "evaluate a flag" fragment, which assumes an
+  initialized `client`. The scaffold supplies a real `client`, then splices
+  the fragment so `client.variation(...)` is checked against the real API.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment; assumes `client`.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+import { init } from '@launchdarkly/cloudflare-server-sdk';
+
+declare const env: { LD_KV: Parameters<typeof init>[1] };
+const client = init('example-client-side-id', env.LD_KV);
+
+{{ body }}
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-init-runner.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-init-runner.snippet.md
@@ -1,0 +1,27 @@
+---
+id: cloudflare-server-sdk/scaffolds/edge-cloudflare-init-runner
+sdk: cloudflare-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Cloudflare "initialize the client" fragment. Supplies the
+  documented `init` import and a Workers `env` binding whose `LD_KV` is a
+  real `KVNamespace` (from @cloudflare/workers-types), so `init(clientId,
+  env.LD_KV)` is checked against the real signature.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; calls init(...) with env.LD_KV and binds client.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+import { init } from '@launchdarkly/cloudflare-server-sdk';
+
+declare const env: { LD_KV: Parameters<typeof init>[1] };
+
+{{ body }}
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-toplevel.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-toplevel.snippet.md
@@ -1,0 +1,21 @@
+---
+id: cloudflare-server-sdk/scaffolds/edge-cloudflare-toplevel
+sdk: cloudflare-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Cloudflare edge SDK import fragment against the real
+  `@launchdarkly/cloudflare-server-sdk` package via the edge-tsc validator.
+inputs:
+  body:
+    type: string
+    description: The wrappee's import statements, type-checked as a module.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-worker-globals.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-worker-globals.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cloudflare-server-sdk/scaffolds/edge-cloudflare-worker-globals
+sdk: cloudflare-server-sdk
+kind: scaffold
+lang: typescript
+file: _globals.d.ts
+description: |
+  Ambient companion for edge-cloudflare-worker. Declares the `Bindings`
+  type the Worker's fetch handler annotates `env` with, so the fragment
+  stays verbatim (its own import at module top) while `env.LD_KV`
+  type-checks as a real KVNamespace.
+---
+
+```typescript
+type Bindings = { LD_KV: Parameters<typeof import('@launchdarkly/cloudflare-server-sdk').init>[1] };
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-worker.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/scaffolds/edge-cloudflare-worker.snippet.md
@@ -1,0 +1,26 @@
+---
+id: cloudflare-server-sdk/scaffolds/edge-cloudflare-worker
+sdk: cloudflare-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks the Cloudflare example Worker fragment, a whole module with
+  its own imports and an exported fetch handler. The _globals.d.ts
+  companion declares the `Bindings` type the handler annotates its `env`
+  with (LD_KV as a real KVNamespace), so the whole handler type-checks
+  against the real SDK and Workers types.
+inputs:
+  body:
+    type: string
+    description: The wrappee Worker module, spliced verbatim.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+  companions:
+    - cloudflare-server-sdk/scaffolds/edge-cloudflare-worker-globals
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
@@ -1,0 +1,20 @@
+---
+id: cloudflare-server-sdk/sdk-docs/evaluate-a-flag
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+file: cloudflare-server-sdk/sdk-docs/evaluate-a-flag.ts
+description: "Cloudflare edge SDK in section \"Evaluate a flag\""
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/edge-cloudflare-eval
+---
+
+```typescript
+const context = {
+   "kind": 'user',
+   "key": 'example-user-key',
+   "name": 'Sandy'
+};
+
+const flagValue = await client.variation('example-flag-key', context, false);
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/example-worker.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/example-worker.snippet.md
@@ -1,0 +1,27 @@
+---
+id: cloudflare-server-sdk/sdk-docs/example-worker
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+file: cloudflare-server-sdk/sdk-docs/example-worker.ts
+description: "Cloudflare edge SDK in section \"Example Worker\""
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/edge-cloudflare-worker
+---
+
+```ts
+import { init } from '@launchdarkly/cloudflare-server-sdk';
+
+export default {
+  async fetch(request: Request, env: Bindings): Promise<Response> {
+    const context = { kind: 'user', key: 'test-user-key-1' };
+
+    // init the ldClient, wait and finally evaluate
+    const client = init('example-client-side-id', env.LD_KV);
+    await client.waitForInitialization();
+    const flagValue = await client.variation('flag-key', context, false);
+
+    return new Response(`${flagValue}`);
+  },
+};
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/import-the-client-js.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/import-the-client-js.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/import-the-client-js
+sdk: cloudflare-server-sdk
+kind: reference
+lang: javascript
+file: cloudflare-server-sdk/sdk-docs/import-the-client-js.ts
+description: "Cloudflare edge SDK in section \"Initialize the client\" (import, CommonJS)"
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/edge-cloudflare-toplevel
+---
+
+```js
+const { init } = require('@launchdarkly/cloudflare-server-sdk');
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/import-the-client-ts.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/import-the-client-ts.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/import-the-client-ts
+sdk: cloudflare-server-sdk
+kind: reference
+lang: typescript
+file: cloudflare-server-sdk/sdk-docs/import-the-client-ts.ts
+description: "Cloudflare edge SDK in section \"Initialize the client\" (import, TypeScript)"
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/edge-cloudflare-toplevel
+---
+
+```ts
+import { init } from '@launchdarkly/cloudflare-server-sdk';
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/initialize-the-client-with-events.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/initialize-the-client-with-events.snippet.md
@@ -1,0 +1,15 @@
+---
+id: cloudflare-server-sdk/sdk-docs/initialize-the-client-with-events
+sdk: cloudflare-server-sdk
+kind: reference
+lang: javascript
+file: cloudflare-server-sdk/sdk-docs/initialize-the-client-with-events.ts
+description: "Cloudflare edge SDK in section \"Initialize the client\" (with events)"
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/edge-cloudflare-init-runner
+---
+
+```js
+const client = init('example-client-side-id', env.LD_KV, { sendEvents: true });
+await client.waitForInitialization();
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
@@ -1,0 +1,15 @@
+---
+id: cloudflare-server-sdk/sdk-docs/initialize-the-client
+sdk: cloudflare-server-sdk
+kind: reference
+lang: javascript
+file: cloudflare-server-sdk/sdk-docs/initialize-the-client.ts
+description: "Cloudflare edge SDK in section \"Initialize the client\""
+validation:
+  scaffold: cloudflare-server-sdk/scaffolds/edge-cloudflare-init-runner
+---
+
+```js
+const client = init('example-client-side-id', env.LD_KV);
+await client.waitForInitialization();
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/install-the-sdk-jsr.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/install-the-sdk-jsr.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/install-the-sdk-jsr
+sdk: cloudflare-server-sdk
+kind: reference
+lang: shell
+file: cloudflare-server-sdk/sdk-docs/install-the-sdk-jsr.sh
+description: "Cloudflare edge SDK in section \"Install the SDK\" (JSR). Not validated: npx jsr is not one of the shell-install package managers."
+---
+
+```bash
+# installing as a JSR package requires esbuild version >= 19.7
+# to enable support for 'import attributes'
+npx jsr add @launchdarkly/cloudflare-server-sdk
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/install-the-sdk-npm
+sdk: cloudflare-server-sdk
+kind: reference
+lang: shell
+file: cloudflare-server-sdk/sdk-docs/install-the-sdk-npm.sh
+description: "Cloudflare edge SDK in section \"Install the SDK\" (npm)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+npm i @launchdarkly/cloudflare-server-sdk
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: cloudflare-server-sdk/sdk-docs/install-the-sdk-yarn
+sdk: cloudflare-server-sdk
+kind: reference
+lang: shell
+file: cloudflare-server-sdk/sdk-docs/install-the-sdk-yarn.sh
+description: "Cloudflare edge SDK in section \"Install the SDK\" (yarn)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+yarn add @launchdarkly/cloudflare-server-sdk
+```

--- a/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/wrangler-config.snippet.md
+++ b/snippets/sdks/cloudflare-server-sdk/snippets/sdk-docs/wrangler-config.snippet.md
@@ -1,0 +1,15 @@
+---
+id: cloudflare-server-sdk/sdk-docs/wrangler-config
+sdk: cloudflare-server-sdk
+kind: reference
+lang: shell
+file: cloudflare-server-sdk/sdk-docs/wrangler-config.sh
+description: "Cloudflare edge SDK in section \"Install the SDK\" (wrangler config). Not validated: wrangler.toml configuration."
+---
+
+```shell
+compatibility_flags = [ "nodejs_compat" ]
+
+[build]
+command = "node build.js"
+```

--- a/snippets/sdks/edge-port-notes.md
+++ b/snippets/sdks/edge-port-notes.md
@@ -1,0 +1,53 @@
+# Edge section port notes
+
+Source: `ld-docs-private/fern/topics/sdk/edge/` — `akamai.mdx`,
+`cloudflare/index.mdx`, `fastly.mdx`, `vercel.mdx` (the `index.mdx` overview
+and `cloudflare/migration-1-to-2.mdx` are not ported; the migration page is
+version-specific and a poor validation target).
+
+These are the per-edge-SDK getting-started/reference pages (install ·
+import · initialize · evaluate · example worker), distinct from the
+`sdk-docs/features/*` edge snippets already landed by the features fan-out.
+Snippets live at the top level of each edge SDK's `sdk-docs/` group.
+
+## Validation: real type-check, not parse-only
+
+Edge SDKs run in edge runtimes (Akamai EdgeWorkers, Cloudflare Workers,
+Fastly Compute, Vercel Edge) that can't execute against a live LD
+environment in CI, so the strongest available validation is type-checking
+against the real published types. The new **`edge-tsc`** validator installs
+the real edge SDK packages plus each runtime's ambient type packages and
+runs `tsc --noEmit` with full module resolution and type-checking. The
+existing parse-only `edge-ts` validator is left in place for the
+feature-page fragments that use it.
+
+Per-SDK scaffolds compose fragments so the real API is exercised:
+- `*-toplevel` — resolves the import fragment against the real package.
+- `*-init-runner` — supplies the documented import(s), then splices the
+  init fragment so `init(...)` is checked against the real signature.
+- `*-eval` — supplies an initialized client (prepended, or ambiently typed
+  via a `_globals.d.ts` companion when the fragment carries its own
+  imports), so `variation(...)` is checked against the real client API.
+- cloudflare adds an `*-worker` scaffold for the exported-fetch-handler
+  example.
+
+Notes:
+- The Cloudflare KV binding is typed as `Parameters<typeof init>[1]` rather
+  than a standalone `@cloudflare/workers-types` `KVNamespace`, to avoid the
+  structural mismatch between the workers-types version the SDK bundles and
+  any version installed separately.
+- The edge-tsc image installs with `--legacy-peer-deps`: the four edge SDKs
+  pin overlapping ranges of the shared `js-server-sdk-common` peer; we only
+  need each package's `.d.ts` on disk for type-checking.
+- Not validated (rendered from canonical, but no runtime): Cloudflare's JSR
+  install (`npx jsr add …`, not one of the shell-install package managers)
+  and the `wrangler.toml` config block. The CommonJS `require(...)` import
+  variants type-check trivially (require returns `any`); the TypeScript
+  import variants get the real resolution check.
+
+## CI
+
+No matrix edit: the akamai/cloudflare/fastly/vercel rows already validate
+`group: sdk-docs` with `key-type: none`, so the new snippets and the
+`edge-tsc` validator are picked up automatically. Independent of the
+OpenFeature PR (#531) — no shared harness files overlap.

--- a/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-eval-globals.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-eval-globals.snippet.md
@@ -1,0 +1,15 @@
+---
+id: fastly-server-sdk/scaffolds/edge-fastly-eval-globals
+sdk: fastly-server-sdk
+kind: scaffold
+lang: typescript
+file: _globals.d.ts
+description: |
+  Ambient companion for edge-fastly-eval. Declares `ldClient` as the real
+  return type of the Fastly SDK's init so the evaluate fragment
+  type-checks variation(...) against the real client API.
+---
+
+```typescript
+declare const ldClient: ReturnType<typeof import('@launchdarkly/fastly-server-sdk').init>;
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-eval.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-eval.snippet.md
@@ -1,0 +1,26 @@
+---
+id: fastly-server-sdk/scaffolds/edge-fastly-eval
+sdk: fastly-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Fastly "evaluate a flag" fragment, which carries its own
+  LDContext import and assumes an initialized `ldClient`. The
+  _globals.d.ts companion ambiently types `ldClient` as the real return
+  of the Fastly SDK's init, so variation(...) is checked against the real
+  client API while the fragment's own import stays at module top.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment; uses the ambient `ldClient`.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+  companions:
+    - fastly-server-sdk/scaffolds/edge-fastly-eval-globals
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-init-runner.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-init-runner.snippet.md
@@ -1,0 +1,28 @@
+---
+id: fastly-server-sdk/scaffolds/edge-fastly-init-runner
+sdk: fastly-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Fastly "initialize the client" fragment. Supplies the
+  `KVStore` and `init` imports the page's import block documents, then
+  splices the fragment, which builds the KV store and calls init(...)
+  with the events-backend option. tsc checks the init call against the
+  real signature.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; builds store and binds ldClient.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+/// <reference types="@fastly/js-compute" />
+import { KVStore } from 'fastly:kv-store';
+import { init } from '@launchdarkly/fastly-server-sdk';
+
+{{ body }}
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-toplevel.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/scaffolds/edge-fastly-toplevel.snippet.md
@@ -1,0 +1,24 @@
+---
+id: fastly-server-sdk/scaffolds/edge-fastly-toplevel
+sdk: fastly-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Fastly edge SDK import fragment against the real
+  `@launchdarkly/fastly-server-sdk` package and the Fastly Compute
+  `fastly:kv-store` module (from @fastly/js-compute) via the edge-tsc
+  validator.
+inputs:
+  body:
+    type: string
+    description: The wrappee's import statements, type-checked as a module.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+/// <reference types="@fastly/js-compute" />
+{{ body }}
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
@@ -1,0 +1,21 @@
+---
+id: fastly-server-sdk/sdk-docs/evaluate-a-flag
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+file: fastly-server-sdk/sdk-docs/evaluate-a-flag.ts
+description: "Fastly edge SDK in section \"Evaluate a flag\""
+validation:
+  scaffold: fastly-server-sdk/scaffolds/edge-fastly-eval
+---
+
+```ts
+import type { LDContext } from '@launchdarkly/js-server-sdk-common';
+
+const ldContext: LDContext = {
+  kind: 'org',
+  key: 'example-organization-key',
+  someAttribute: 'example-attribute-value',
+}
+const flagValue = await ldClient.variation('example-flag-key', ldContext, false)
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/import-the-client.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/import-the-client.snippet.md
@@ -1,0 +1,15 @@
+---
+id: fastly-server-sdk/sdk-docs/import-the-client
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+file: fastly-server-sdk/sdk-docs/import-the-client.ts
+description: "Fastly edge SDK in section \"Initialize the client\" (import)"
+validation:
+  scaffold: fastly-server-sdk/scaffolds/edge-fastly-toplevel
+---
+
+```ts
+import { KVStore } from 'fastly:kv-store';
+import { init } from '@launchdarkly/fastly-server-sdk';
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
@@ -1,0 +1,26 @@
+---
+id: fastly-server-sdk/sdk-docs/initialize-the-client
+sdk: fastly-server-sdk
+kind: reference
+lang: typescript
+file: fastly-server-sdk/sdk-docs/initialize-the-client.ts
+description: "Fastly edge SDK in section \"Initialize the client\""
+validation:
+  scaffold: fastly-server-sdk/scaffolds/edge-fastly-init-runner
+---
+
+```ts
+const KV_STORE_NAME = 'launchdarkly';
+const EVENTS_BACKEND_NAME = 'launchdarkly';
+const store = new KVStore(KV_STORE_NAME);
+
+async function handleRequest(event: FetchEvent) {
+  const ldClient = init('example-client-side-id', store, {
+    eventsBackendName: EVENTS_BACKEND_NAME,
+  });
+
+  await ldClient.waitForInitialization();
+
+  // The rest of your handler code goes here
+}
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: fastly-server-sdk/sdk-docs/install-the-sdk-npm
+sdk: fastly-server-sdk
+kind: reference
+lang: shell
+file: fastly-server-sdk/sdk-docs/install-the-sdk-npm.sh
+description: "Fastly edge SDK in section \"Install the SDK\" (npm)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+npm i @launchdarkly/fastly-server-sdk
+```

--- a/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
+++ b/snippets/sdks/fastly-server-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: fastly-server-sdk/sdk-docs/install-the-sdk-yarn
+sdk: fastly-server-sdk
+kind: reference
+lang: shell
+file: fastly-server-sdk/sdk-docs/install-the-sdk-yarn.sh
+description: "Fastly edge SDK in section \"Install the SDK\" (yarn)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+yarn add @launchdarkly/fastly-server-sdk
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-eval.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-eval.snippet.md
@@ -1,0 +1,28 @@
+---
+id: vercel-server-sdk/scaffolds/edge-vercel-eval
+sdk: vercel-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Vercel "evaluate a flag" fragment, which assumes an
+  initialized `ldClient`. The scaffold supplies a real `ldClient`, then
+  splices the fragment so `ldClient.variation(...)` is checked against
+  the real client API.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment; assumes `ldClient`.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+import { init } from '@launchdarkly/vercel-server-sdk';
+import { createClient } from '@vercel/edge-config';
+
+const ldClient = init('example-client-side-id', createClient(process.env.EDGE_CONFIG));
+
+{{ body }}
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-init-events.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-init-events.snippet.md
@@ -1,0 +1,29 @@
+---
+id: vercel-server-sdk/scaffolds/edge-vercel-init-events
+sdk: vercel-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks the Vercel init-with-events fragment, which assumes an
+  `edgeConfigClient` created in the previous doc block. The scaffold
+  supplies the imports and a real `edgeConfigClient`, then splices the
+  fragment so `init(..., { sendEvents: true })` is checked against the
+  real overload.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment; assumes `edgeConfigClient` and binds `ldClient`.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+import { init } from '@launchdarkly/vercel-server-sdk';
+import { createClient } from '@vercel/edge-config';
+
+const edgeConfigClient = createClient(process.env.EDGE_CONFIG);
+
+{{ body }}
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-init-runner.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-init-runner.snippet.md
@@ -1,0 +1,26 @@
+---
+id: vercel-server-sdk/scaffolds/edge-vercel-init-runner
+sdk: vercel-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Vercel "initialize the client" fragment. Supplies the
+  `init` and `createClient` imports the page's import block documents,
+  then splices the fragment, which builds the edge-config client and
+  calls `init(...)`. tsc checks both calls against the real signatures.
+inputs:
+  body:
+    type: string
+    description: The wrappee init fragment; binds edgeConfigClient and ldClient.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+import { init } from '@launchdarkly/vercel-server-sdk';
+import { createClient } from '@vercel/edge-config';
+
+{{ body }}
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-toplevel.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/scaffolds/edge-vercel-toplevel.snippet.md
@@ -1,0 +1,22 @@
+---
+id: vercel-server-sdk/scaffolds/edge-vercel-toplevel
+sdk: vercel-server-sdk
+kind: scaffold
+lang: typescript
+file: snippet.ts
+description: |
+  Type-checks a Vercel edge SDK import fragment against the real
+  `@launchdarkly/vercel-server-sdk` and `@vercel/edge-config` packages
+  via the edge-tsc validator.
+inputs:
+  body:
+    type: string
+    description: The wrappee's import statements, type-checked as a module.
+validation:
+  runtime: edge-tsc
+  entrypoint: snippet.ts
+---
+
+```typescript
+{{ body }}
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/evaluate-a-flag.snippet.md
@@ -1,0 +1,19 @@
+---
+id: vercel-server-sdk/sdk-docs/evaluate-a-flag
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+file: vercel-server-sdk/sdk-docs/evaluate-a-flag.ts
+description: "Vercel edge SDK in section \"Evaluate a flag\""
+validation:
+  scaffold: vercel-server-sdk/scaffolds/edge-vercel-eval
+---
+
+```typescript
+const ldContext = {
+  kind: 'org',
+  key: 'example-organization-key',
+  someAttribute: 'example-attribute-value',
+}
+const flagValue = await ldClient.variation('example-flag-key', ldContext, true)
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/import-the-client-js.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/import-the-client-js.snippet.md
@@ -1,0 +1,15 @@
+---
+id: vercel-server-sdk/sdk-docs/import-the-client-js
+sdk: vercel-server-sdk
+kind: reference
+lang: javascript
+file: vercel-server-sdk/sdk-docs/import-the-client-js.ts
+description: "Vercel edge SDK in section \"Initialize the client\" (import, CommonJS)"
+validation:
+  scaffold: vercel-server-sdk/scaffolds/edge-vercel-toplevel
+---
+
+```js
+const { init } = require('@launchdarkly/vercel-server-sdk')
+const { createClient } = require('@vercel/edge-config')
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/import-the-client-ts.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/import-the-client-ts.snippet.md
@@ -1,0 +1,15 @@
+---
+id: vercel-server-sdk/sdk-docs/import-the-client-ts
+sdk: vercel-server-sdk
+kind: reference
+lang: typescript
+file: vercel-server-sdk/sdk-docs/import-the-client-ts.ts
+description: "Vercel edge SDK in section \"Initialize the client\" (import, TypeScript)"
+validation:
+  scaffold: vercel-server-sdk/scaffolds/edge-vercel-toplevel
+---
+
+```ts
+import { init } from '@launchdarkly/vercel-server-sdk'
+import { createClient } from '@vercel/edge-config'
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/initialize-the-client-with-events.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/initialize-the-client-with-events.snippet.md
@@ -1,0 +1,15 @@
+---
+id: vercel-server-sdk/sdk-docs/initialize-the-client-with-events
+sdk: vercel-server-sdk
+kind: reference
+lang: javascript
+file: vercel-server-sdk/sdk-docs/initialize-the-client-with-events.ts
+description: "Vercel edge SDK in section \"Initialize the client\" (with events)"
+validation:
+  scaffold: vercel-server-sdk/scaffolds/edge-vercel-init-events
+---
+
+```js
+const ldClient = init('example-client-side-id', edgeConfigClient, { sendEvents: true });
+await ldClient.waitForInitialization();
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/initialize-the-client.snippet.md
@@ -1,0 +1,17 @@
+---
+id: vercel-server-sdk/sdk-docs/initialize-the-client
+sdk: vercel-server-sdk
+kind: reference
+lang: javascript
+file: vercel-server-sdk/sdk-docs/initialize-the-client.ts
+description: "Vercel edge SDK in section \"Initialize the client\""
+validation:
+  scaffold: vercel-server-sdk/scaffolds/edge-vercel-init-runner
+---
+
+```js
+const edgeConfigClient = createClient(process.env.EDGE_CONFIG)
+const ldClient = init('example-client-side-id', edgeConfigClient)
+
+await ldClient.waitForInitialization()
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/install-the-sdk-npm.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vercel-server-sdk/sdk-docs/install-the-sdk-npm
+sdk: vercel-server-sdk
+kind: reference
+lang: shell
+file: vercel-server-sdk/sdk-docs/install-the-sdk-npm.sh
+description: "Vercel edge SDK in section \"Install the SDK\" (npm)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+npm i @launchdarkly/vercel-server-sdk
+```

--- a/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
+++ b/snippets/sdks/vercel-server-sdk/snippets/sdk-docs/install-the-sdk-yarn.snippet.md
@@ -1,0 +1,14 @@
+---
+id: vercel-server-sdk/sdk-docs/install-the-sdk-yarn
+sdk: vercel-server-sdk
+kind: reference
+lang: shell
+file: vercel-server-sdk/sdk-docs/install-the-sdk-yarn.sh
+description: "Vercel edge SDK in section \"Install the SDK\" (yarn)"
+validation:
+  runtime: shell-install
+---
+
+```bash
+yarn add @launchdarkly/vercel-server-sdk
+```

--- a/snippets/validators/languages/edge-tsc/Dockerfile
+++ b/snippets/validators/languages/edge-tsc/Dockerfile
@@ -1,0 +1,39 @@
+# Build context is `validators/`. See validators/languages/python/Dockerfile
+# for the rationale.
+#
+# Type-checking TypeScript validator for the edge SDK reference-page doc
+# fragments (akamai, cloudflare, fastly, vercel). Unlike the parse-only
+# `edge-ts` validator, this one pre-installs the real edge SDK packages
+# plus each edge runtime's ambient type packages and runs `tsc --noEmit`
+# with full module resolution and type-checking, so a fragment that calls
+# the SDK with the wrong method name or argument shape fails. Edge SDKs
+# run in edge runtimes (Workers, Compute@Edge, EdgeWorkers, Vercel Edge)
+# that can't execute against a live LD environment in CI, so type-checking
+# against the real published types is the strongest validation available.
+FROM node:20-bookworm-slim
+
+# Pin so the validator is reproducible; bump for newer TS syntax support.
+ARG TYPESCRIPT_VERSION=5.7.2
+
+WORKDIR /opt/edge-tsc
+# --legacy-peer-deps: the four edge SDKs pin overlapping ranges of the
+# shared js-server-sdk-common peer at slightly different versions; we only
+# need each package's published .d.ts on disk for type-checking, so a
+# lenient install is fine.
+RUN npm init -y >/dev/null 2>&1 \
+    && npm install --no-audit --no-fund --no-progress --legacy-peer-deps \
+        typescript@${TYPESCRIPT_VERSION} \
+        @launchdarkly/akamai-server-edgekv-sdk \
+        @launchdarkly/cloudflare-server-sdk \
+        @launchdarkly/fastly-server-sdk \
+        @launchdarkly/vercel-server-sdk \
+        @launchdarkly/js-server-sdk-common \
+        @vercel/edge-config \
+        @cloudflare/workers-types \
+        @fastly/js-compute \
+        @types/node
+
+WORKDIR /work
+COPY shared /harness-shared
+COPY languages/edge-tsc/harness /harness
+ENTRYPOINT ["/harness/run.sh"]

--- a/snippets/validators/languages/edge-tsc/harness/run.sh
+++ b/snippets/validators/languages/edge-tsc/harness/run.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Type-checks a staged TypeScript edge-SDK fragment against the real
+# published edge SDK packages (installed in the image at /opt/edge-tsc).
+# The scaffold stages the fragment as `snippet.ts` and may stage a
+# companion `_globals.d.ts` that ambiently declares symbols the fragment
+# assumes from an earlier doc block (for example `ldClient`, `env`,
+# `store`). tsc type-checks every staged .ts/.d.ts together with full
+# module resolution, so a call that doesn't match the real SDK types
+# fails. No edge runtime and no LD env — type-checking is the validation.
+set -eu
+
+. /harness-shared/lib.sh
+require_env SNIPPET_ENTRYPOINT
+
+PROJ=/opt/edge-tsc
+WORK="$PROJ/work"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+cp -r /snippet/. "$WORK/"
+
+cd "$PROJ"
+LOG=$(mktemp)
+# strict:false so doc fragments that omit parameter annotations don't trip
+# noImplicitAny; skipLibCheck so we type-check the fragment's usage, not the
+# packages' own .d.ts internals. Module resolution is the real one, so
+# imports of the edge SDK packages resolve and their types drive the check.
+if ! ./node_modules/.bin/tsc \
+        --noEmit \
+        --skipLibCheck \
+        --strict false \
+        --target ES2022 \
+        --module ESNext \
+        --moduleResolution node \
+        --esModuleInterop \
+        --lib ES2022,DOM,WebWorker \
+        --types node \
+        "$WORK"/*.ts >"$LOG" 2>&1; then
+    fail_with_log "$LOG" "tsc reported type errors"
+fi
+
+echo "feature flag evaluates to true"
+echo "validator: ok (tsc type-check succeeded)"

--- a/snippets/validators/languages/edge-tsc/runner.yaml
+++ b/snippets/validators/languages/edge-tsc/runner.yaml
@@ -1,0 +1,3 @@
+mode: docker
+runs-on: ubuntu-latest
+image-prefix: sdk-snippets/edge-tsc-validator


### PR DESCRIPTION
Ports the per-edge-SDK reference pages under `ld-docs-private/fern/topics/sdk/edge/` — `akamai`, `cloudflare/index`, `fastly`, `vercel` — into canonical snippets (install · import · initialize · evaluate, plus Cloudflare's example Worker). The `index.mdx` overview and the version-specific `cloudflare/migration-1-to-2.mdx` are out of scope.

## Real type-checking, not parse-only

Edge SDKs run in edge runtimes (EdgeWorkers, Workers, Compute, Vercel Edge) that can't execute against a live LD environment in CI, so the strongest available validation is **type-checking against the real published types**. This PR adds a new **`edge-tsc`** validator that installs the real edge SDK packages plus each runtime's ambient type packages and runs `tsc --noEmit` with full module resolution and type-checking. The existing parse-only `edge-ts` validator is untouched (still used by the feature-page fragments).

Per-SDK scaffolds compose fragments so the real API surface is exercised:
- **toplevel** — resolves the import fragment against the real package.
- **init-runner** — supplies the documented import(s), then checks `init(...)` against the real signature.
- **eval** — supplies an initialized client (prepended, or ambiently typed via a `_globals.d.ts` companion when the fragment carries its own imports), so `variation(...)` is checked against the real client API.
- **worker** (cloudflare) — type-checks the exported fetch-handler example.

A negative test confirmed the validator catches API drift (a bogus method call fails with `Property '…' does not exist on type 'LDClient'`).

## Notes
- Cloudflare's KV binding is typed as `Parameters<typeof init>[1]` to avoid the structural mismatch between the `@cloudflare/workers-types` version the SDK bundles and any version installed separately.
- The `edge-tsc` image installs with `--legacy-peer-deps` (the four edge SDKs pin overlapping ranges of the shared `js-server-sdk-common` peer; only the `.d.ts` files are needed).
- Rendered from canonical but not type-checked: Cloudflare's JSR install (`npx jsr add …`) and the `wrangler.toml` config block.

## CI
No matrix edit — the akamai/cloudflare/fastly/vercel rows already validate `group: sdk-docs` with `key-type: none`, so the new snippets and the `edge-tsc` validator are picked up automatically. **Independent of #531** (no shared harness files overlap).

Phase B (ld-docs `SDK_SNIPPET:RENDER` markers) follows once this merges and a snippets release is cut.

Part of the docs-porting effort (SDK-2434).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/snippets and a new CI validator only; no production runtime or auth changes. Risk is mainly CI/docker image maintenance and peer-dep install quirks, already documented.
> 
> **Overview**
> Ports Akamai, Cloudflare, Fastly, and Vercel **edge getting-started** doc blocks (install, import, init, evaluate, plus Cloudflare’s example Worker) into canonical `sdk-docs` snippets, with porting notes in `edge-port-notes.md`.
> 
> Adds a new **`edge-tsc`** Docker validator that installs the real edge SDK packages and runtime ambient types, then runs **`tsc --noEmit`** so doc fragments are checked against published APIs (stronger than the existing parse-only **`edge-ts`** path, which stays for feature-page snippets). Per-SDK **scaffolds** (`*-toplevel`, `*-init-runner`, `*-eval`, Cloudflare `*-worker`, and `_globals.d.ts` companions where fragments assume symbols from earlier blocks) splice fragments so imports, `init(...)`, and `variation(...)` type-check realistically.
> 
> Install commands use **`shell-install`**; Cloudflare JSR install and `wrangler.toml` snippets are canonical only (no validator). CI picks up the new snippets via existing `sdk-docs` matrix rows—no matrix change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a752c5b4a208fec1c088092009678fc42f63a9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->