### PR TITLE
ci: add apt-get update before installing sqlite3-tools in crawl workflow

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -18,7 +18,9 @@ jobs:
         with:
             go-version: 1.22
       - name: Install sqldiff
-        run: sudo apt-get install -y sqlite3-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sqlite3-tools
       - name: Crawl repos
         id: crawl
         env:


### PR DESCRIPTION
## Summary

The "Crawl Repos" CI has been failing daily since July 2 because the GitHub Actions runner's pre-installed apt package index is stale. Ubuntu superseded `sqlite3-tools` version `3.45.1-1ubuntu2.5` in its mirrors, so the install step gets a 404.

Fix: run `sudo apt-get update` before `sudo apt-get install` so the package index is refreshed and the current version is resolved.


Link to Devin session: https://app.devin.ai/sessions/535fb19657ee4782a2d520d690eabe05
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the apt install step; no application or runtime behavior is affected.
> 
> **Overview**
> The **Crawl Repos** workflow’s **Install sqldiff** step now runs `sudo apt-get update` before installing `sqlite3-tools`, so apt resolves the current package version instead of failing with a 404 on a stale index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3826354a87f4f3fba17b61b3273633b903c9def0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->