### PR TITLE
feat(snippets): port Android observability plugin docs to canonical snippets

### DIFF
--- a/.github/workflows/snippets-validate.yml
+++ b/.github/workflows/snippets-validate.yml
@@ -162,6 +162,19 @@ jobs:
             label: android-client-sdk (sdk-docs)
             group: sdk-docs
 
+          # Android observability plugin fragments. Kotlin/Java blocks
+          # compile against the real launchdarkly-observability-android aar
+          # via the android-client validator (parse mode); the Compose /
+          # View masking blocks compile via the dedicated android-compose
+          # validator (Kotlin 2.0 + Compose). One group row drives both
+          # validators. key-type: mobile matches the sdk-docs row (the
+          # android-client harness require_env's LAUNCHDARKLY_FLAG_KEY).
+          - sdk: android-client-sdk
+            runs-on: ubuntu-latest
+            key-type: mobile
+            label: android-client-sdk (observability)
+            group: observability
+
           # SDKs whose sdk-docs slice picked up bound syntax-only
           # validators in the docs-validation pass (PR
           # rlamb/sdk-docs-validation). Each matrix row builds the

--- a/snippets/sdks/android-client-sdk/snippets/observability/advanced-configuration-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/advanced-configuration-kotlin.snippet.md
@@ -1,0 +1,49 @@
+---
+id: android-client-sdk/observability/advanced-configuration-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Advanced configuration options (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+val mobileKey = "example-mobile-key"
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(
+      Components.plugins().setPlugins(
+        listOf(
+          Observability(
+            this@BaseApplication,
+            mobileKey,
+            ObservabilityOptions(
+              serviceName = "my-android-app",
+              serviceVersion = "1.0.0",
+              debug = true,
+              logsApiLevel = ObservabilityOptions.LogLevel.WARN,
+              tracesApi = ObservabilityOptions.TracesApi(includeErrors = true, includeSpans = false),
+              metricsApi = ObservabilityOptions.MetricsApi.disabled(),
+              instrumentations = ObservabilityOptions.Instrumentations(
+                crashReporting = false,
+                launchTime = true,
+                userTaps = true,
+                screens = true
+              ),
+              resourceAttributes = Attributes.of(
+                AttributeKey.stringKey("environment"), "production",
+                AttributeKey.stringKey("team"), "mobile"
+              ),
+              customHeaders = mapOf(
+                "X-Custom-Header" to "custom-value"
+              )
+            )
+          )
+        )
+      )
+    )
+    .build()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/configure-instrumentations-gradle-groovy.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/configure-instrumentations-gradle-groovy.snippet.md
@@ -1,0 +1,25 @@
+---
+id: android-client-sdk/observability/configure-instrumentations-gradle-groovy
+sdk: android-client-sdk
+kind: reference
+lang: groovy
+file: android-client-sdk/observability/configure-instrumentations-gradle-groovy.gradle
+description: "Android observability plugin in section \"Configure additional instrumentations\" (Gradle Groovy)"
+# Not validated: a build.gradle plugins+dependencies configuration block, not compilable app code.
+---
+
+```java
+plugins {
+    id 'net.bytebuddy.byte-buddy-gradle-plugin' version '1.+'
+}
+
+dependencies {
+    // Android HTTP Url instrumentation
+    implementation 'io.opentelemetry.android.instrumentation:httpurlconnection-library:0.11.0-alpha'
+    byteBuddy 'io.opentelemetry.android.instrumentation:httpurlconnection-agent:0.11.0-alpha'
+
+    // OkHTTP instrumentation
+    implementation 'io.opentelemetry.android.instrumentation:okhttp3-library:0.11.0-alpha'
+    byteBuddy 'io.opentelemetry.android.instrumentation:okhttp3-agent:0.11.0-alpha'
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/configure-instrumentations-gradle-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/configure-instrumentations-gradle-kotlin.snippet.md
@@ -1,0 +1,25 @@
+---
+id: android-client-sdk/observability/configure-instrumentations-gradle-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: android-client-sdk/observability/configure-instrumentations-gradle-kotlin.gradle.kts
+description: "Android observability plugin in section \"Configure additional instrumentations\" (Gradle Kotlin)"
+# Not validated: a build.gradle.kts plugins+dependencies configuration block, not compilable app code.
+---
+
+```kotlin
+plugins {
+    id("net.bytebuddy.byte-buddy-gradle-plugin") version "1.+"
+}
+
+dependencies {
+    // Android HTTP Url instrumentation
+    implementation("io.opentelemetry.android.instrumentation:httpurlconnection-library:0.11.0-alpha")
+    byteBuddy("io.opentelemetry.android.instrumentation:httpurlconnection-agent:0.11.0-alpha")
+
+    // OkHTTP instrumentation
+    implementation("io.opentelemetry.android.instrumentation:okhttp3-library:0.11.0-alpha")
+    byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-agent:0.11.0-alpha")
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/configure-plugin-options-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/configure-plugin-options-java.snippet.md
@@ -1,0 +1,34 @@
+---
+id: android-client-sdk/observability/configure-plugin-options-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+file: app/src/main/java/com/launchdarkly/hello_android/SnippetObsJava.java
+description: "Android observability plugin: Configure the plugin options (Java)"
+validation:
+  scaffold: android-client-sdk/scaffolds/java-observability
+---
+
+```java
+String mobileKey = "example-mobile-key";
+
+LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(
+      Components.plugins().setPlugins(
+        Collections.<Plugin>singletonList(
+          new Observability(
+            this.getApplication(),
+            mobileKey,
+            ObservabilityOptions.builder()
+              .resourceAttributes(Attributes.of(
+                AttributeKey.stringKey("serviceName"), "example-service"
+              ))
+              .build(),
+            null
+          )
+        )
+      )
+    )
+    .build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/configure-product-analytics-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/configure-product-analytics-kotlin.snippet.md
@@ -1,0 +1,22 @@
+---
+id: android-client-sdk/observability/configure-product-analytics-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Configure product analytics event collection (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+ObservabilityOptions(
+  analytics = ObservabilityOptions.Analytics(
+    taps = true,
+    trackEvents = true,
+    screenViews = true,
+    appLifecycle = true,
+    appLaunch = true,
+  )
+)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/configure-session-replay-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/configure-session-replay-kotlin.snippet.md
@@ -1,0 +1,29 @@
+---
+id: android-client-sdk/observability/configure-session-replay-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Configure session replay (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.plugin.Observability
+import com.launchdarkly.observability.replay.plugin.SessionReplay
+
+val mobileKey = "example-mobile-key"
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(
+      Components.plugins().setPlugins(
+        listOf(
+          Observability(this@BaseApplication, mobileKey),
+          SessionReplay()  // depends on Observability being present first
+        )
+      )
+    )
+    .build()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/custom-masking-compose-mask-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/custom-masking-compose-mask-kotlin.snippet.md
@@ -1,0 +1,26 @@
+---
+id: android-client-sdk/observability/custom-masking-compose-mask-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: lib/src/main/kotlin/com/launchdarkly/masking/Snippet.kt
+description: "Android observability plugin: Custom masking with ldMask, Compose (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-masking
+---
+
+```kotlin
+import com.launchdarkly.observability.api.ldMask
+
+@Composable
+fun CreditCardField() {
+    var number by remember { mutableStateOf("") }
+    TextField(
+        value = number,
+        onValueChange = { number = it },
+        modifier = Modifier
+            .fillMaxWidth()
+            .ldMask() // mask this composable in session replay
+    )
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/custom-masking-compose-unmask-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/custom-masking-compose-unmask-kotlin.snippet.md
@@ -1,0 +1,26 @@
+---
+id: android-client-sdk/observability/custom-masking-compose-unmask-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: lib/src/main/kotlin/com/launchdarkly/masking/Snippet.kt
+description: "Android observability plugin: Custom masking with ldUnmask, Compose (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-masking
+---
+
+```kotlin
+import com.launchdarkly.observability.api.ldUnmask
+
+@Composable
+fun PublicInfoField() {
+    var info by remember { mutableStateOf("") }
+    TextField(
+        value = info,
+        onValueChange = { info = it },
+        modifier = Modifier
+            .fillMaxWidth()
+            .ldUnmask() // explicitly unmask this field
+    )
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/custom-masking-view-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/custom-masking-view-kotlin.snippet.md
@@ -1,0 +1,24 @@
+---
+id: android-client-sdk/observability/custom-masking-view-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: lib/src/main/kotlin/com/launchdarkly/masking/Snippet.kt
+description: "Android observability plugin: Custom masking with ldMask, View (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-masking
+---
+
+```kotlin
+import com.launchdarkly.observability.api.ldMask
+
+class LoginActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_login)
+
+        val password = findViewById<EditText>(R.id.password)
+        password.ldMask() // mask this field in session replay
+    }
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-executor-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-executor-java.snippet.md
@@ -13,7 +13,7 @@ validation:
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
-Span parentSpan = LDObserve.Companion.startSpan("parentSpan", Attributes.empty());
+Span parentSpan = LDObserve.Companion.startSpan("parentSpan", new HashMap<>());
 try (Scope parentScope = parentSpan.makeCurrent()) {
     // Now parentSpan is active in Context.current()
     Context ctx = Context.current();
@@ -21,7 +21,7 @@ try (Scope parentScope = parentSpan.makeCurrent()) {
     // Later, in another thread, restore the context
     executor.execute(() -> {
         try (Scope scope = ctx.makeCurrent()) {
-            Span nestedSpan = LDObserve.Companion.startSpan("nestedSpan", Attributes.empty());
+            Span nestedSpan = LDObserve.Companion.startSpan("nestedSpan", new HashMap<>());
             // do work — nestedSpan is a child of parentSpan
             nestedSpan.end();
         }

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-executor-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-executor-java.snippet.md
@@ -1,0 +1,32 @@
+---
+id: android-client-sdk/observability/distributed-tracing-executor-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+file: app/src/main/java/com/launchdarkly/hello_android/SnippetObsJava.java
+description: "Android observability plugin: Distributed tracing with an executor (Java)"
+validation:
+  scaffold: android-client-sdk/scaffolds/java-observability
+---
+
+```java
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+Span parentSpan = LDObserve.Companion.startSpan("parentSpan", Attributes.empty());
+try (Scope parentScope = parentSpan.makeCurrent()) {
+    // Now parentSpan is active in Context.current()
+    Context ctx = Context.current();
+
+    // Later, in another thread, restore the context
+    executor.execute(() -> {
+        try (Scope scope = ctx.makeCurrent()) {
+            Span nestedSpan = LDObserve.Companion.startSpan("nestedSpan", Attributes.empty());
+            // do work — nestedSpan is a child of parentSpan
+            nestedSpan.end();
+        }
+    });
+} finally {
+    parentSpan.end();
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-log-with-context-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-log-with-context-kotlin.snippet.md
@@ -1,0 +1,49 @@
+---
+id: android-client-sdk/observability/distributed-tracing-log-with-context-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin in section \"Distributed tracing\" (log with captured context, Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability-coroutine
+---
+
+```kotlin
+import io.opentelemetry.context.Context
+
+val parentSpan = LDObserve.startSpan("parentSpan", Attributes.empty())
+
+// Capture the current context, which includes the active span
+val context = Context.current()
+
+launch(Dispatchers.IO) {
+    val span = LDObserve.startSpan(
+        name = "log-context-demo",
+        attributes = Attributes.of(
+            AttributeKey.stringKey("demo"), "log-with-context"
+        )
+    )
+    // Capture span context while still on the originating thread.
+    val capturedContext = span.makeCurrent().use { span.spanContext }
+    span.end()
+    // Simulate a detached thread where OTel context is lost automatically.
+    // Span.current() here returns INVALID, so we pass the captured context explicitly.
+    Thread {
+        Span.wrap(capturedContext).makeCurrent().use {
+            val childSpan = LDObserve.startSpan("child of log-context-demo", Attributes.empty())
+            childSpan.end()
+        }
+        LDObserve.recordLog(
+            message = text,
+            severity = Severity.WARN,
+            attributes = Attributes.of(
+                AttributeKey.stringKey("source"), "detached-thread-demo"
+            ),
+            spanContext = capturedContext
+        )
+    }.start()
+}
+
+parentSpan.end()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-log-with-context-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-log-with-context-kotlin.snippet.md
@@ -12,7 +12,7 @@ validation:
 ```kotlin
 import io.opentelemetry.context.Context
 
-val parentSpan = LDObserve.startSpan("parentSpan", Attributes.empty())
+val parentSpan = LDObserve.startSpan("parentSpan")
 
 // Capture the current context, which includes the active span
 val context = Context.current()
@@ -20,9 +20,7 @@ val context = Context.current()
 launch(Dispatchers.IO) {
     val span = LDObserve.startSpan(
         name = "log-context-demo",
-        attributes = Attributes.of(
-            AttributeKey.stringKey("demo"), "log-with-context"
-        )
+        properties = mapOf("demo" to "log-with-context")
     )
     // Capture span context while still on the originating thread.
     val capturedContext = span.makeCurrent().use { span.spanContext }
@@ -31,15 +29,13 @@ launch(Dispatchers.IO) {
     // Span.current() here returns INVALID, so we pass the captured context explicitly.
     Thread {
         Span.wrap(capturedContext).makeCurrent().use {
-            val childSpan = LDObserve.startSpan("child of log-context-demo", Attributes.empty())
+            val childSpan = LDObserve.startSpan("child of log-context-demo")
             childSpan.end()
         }
         LDObserve.recordLog(
             message = text,
             severity = Severity.WARN,
-            attributes = Attributes.of(
-                AttributeKey.stringKey("source"), "detached-thread-demo"
-            ),
+            properties = mapOf("source" to "detached-thread-demo"),
             spanContext = capturedContext
         )
     }.start()

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-propagate-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-propagate-java.snippet.md
@@ -1,0 +1,27 @@
+---
+id: android-client-sdk/observability/distributed-tracing-propagate-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+file: app/src/main/java/com/launchdarkly/hello_android/SnippetObsJava.java
+description: "Android observability plugin: Distributed tracing, propagate headers (Java)"
+validation:
+  scaffold: android-client-sdk/scaffolds/java-observability
+---
+
+```java
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import okhttp3.Request;
+
+W3CTraceContextPropagator propagator = W3CTraceContextPropagator.getInstance();
+Request.Builder requestBuilder = new Request.Builder().url(url);
+
+propagator.inject(
+    Context.current(),
+    requestBuilder,
+    (carrier, key, value) -> carrier.addHeader(key, value)
+);
+
+Request request = requestBuilder.build();
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-propagate-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-propagate-kotlin.snippet.md
@@ -1,0 +1,26 @@
+---
+id: android-client-sdk/observability/distributed-tracing-propagate-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Distributed tracing, propagate headers (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import okhttp3.Request
+
+val propagator = W3CTraceContextPropagator.getInstance()
+val requestBuilder = Request.Builder().url(url)
+
+propagator.inject(
+    Context.current(),
+    requestBuilder
+) { carrier, key, value -> carrier?.addHeader(key, value) }
+
+val request = requestBuilder.build()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-restore-context-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-restore-context-kotlin.snippet.md
@@ -17,7 +17,7 @@ val ctx = Context.current()
 
 // Later, in another scope, restore the context
 ctx.makeCurrent().use {
-    val span = LDObserve.startSpan("nestedSpan", Attributes.empty())
+    val span = LDObserve.startSpan("nestedSpan")
     // do work
     span.end()
 }

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-restore-context-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-restore-context-kotlin.snippet.md
@@ -1,0 +1,24 @@
+---
+id: android-client-sdk/observability/distributed-tracing-restore-context-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Distributed tracing, restore context (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import io.opentelemetry.context.Context
+
+// Capture the current context
+val ctx = Context.current()
+
+// Later, in another scope, restore the context
+ctx.makeCurrent().use {
+    val span = LDObserve.startSpan("nestedSpan", Attributes.empty())
+    // do work
+    span.end()
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-thread-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-thread-java.snippet.md
@@ -1,0 +1,30 @@
+---
+id: android-client-sdk/observability/distributed-tracing-thread-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+file: app/src/main/java/com/launchdarkly/hello_android/SnippetObsJava.java
+description: "Android observability plugin: Distributed tracing across a thread (Java)"
+validation:
+  scaffold: android-client-sdk/scaffolds/java-observability
+---
+
+```java
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+
+Span parentSpan = LDObserve.Companion.startSpan("parentSpan", Attributes.empty());
+try (Scope parentScope = parentSpan.makeCurrent()) {
+    Context context = Context.current();
+
+    new Thread(() -> {
+        try (Scope childScope = context.makeCurrent()) {
+            Span childSpan = LDObserve.Companion.startSpan("childSpan", Attributes.empty());
+            // do work
+            childSpan.end();
+        }
+    }).start();
+} finally {
+    parentSpan.end();
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-thread-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/distributed-tracing-thread-java.snippet.md
@@ -13,13 +13,13 @@ validation:
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
-Span parentSpan = LDObserve.Companion.startSpan("parentSpan", Attributes.empty());
+Span parentSpan = LDObserve.Companion.startSpan("parentSpan", new HashMap<>());
 try (Scope parentScope = parentSpan.makeCurrent()) {
     Context context = Context.current();
 
     new Thread(() -> {
         try (Scope childScope = context.makeCurrent()) {
-            Span childSpan = LDObserve.Companion.startSpan("childSpan", Attributes.empty());
+            Span childSpan = LDObserve.Companion.startSpan("childSpan", new HashMap<>());
             // do work
             childSpan.end();
         }

--- a/snippets/sdks/android-client-sdk/snippets/observability/flush-session-replay-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/flush-session-replay-kotlin.snippet.md
@@ -1,0 +1,17 @@
+---
+id: android-client-sdk/observability/flush-session-replay-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Flush session replay (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.sdk.LDReplay
+
+// Immediately export any queued replay events
+LDReplay.flush()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/import-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/import-java.snippet.md
@@ -1,0 +1,16 @@
+---
+id: android-client-sdk/observability/import-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+description: "Android observability plugin: Import the plugin (Java)"
+validation:
+  scaffold: android-client-sdk/scaffolds/java-syntax-only
+---
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.android.*;
+import com.launchdarkly.observability.plugin.Observability;
+import com.launchdarkly.sdk.android.integrations.Plugin;
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/import-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/import-kotlin.snippet.md
@@ -1,0 +1,16 @@
+---
+id: android-client-sdk/observability/import-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+description: "Android observability plugin: Import the plugin (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-syntax-only
+---
+
+```kotlin
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+import com.launchdarkly.observability.plugin.Observability
+import com.launchdarkly.sdk.android.integrations.Plugin
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/initialize-plugins-after-client-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/initialize-plugins-after-client-kotlin.snippet.md
@@ -1,0 +1,37 @@
+---
+id: android-client-sdk/observability/initialize-plugins-after-client-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Initialize the plugins after the SDK client (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.plugin.Observability
+import com.launchdarkly.observability.replay.plugin.SessionReplay
+import com.launchdarkly.observability.replay.ReplayOptions
+
+val mobileKey = "example-mobile-key"
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(
+      Components.plugins().setPlugins(
+        listOf(
+          Observability(this@BaseApplication, mobileKey),
+          SessionReplay(
+            options = ReplayOptions(
+              enabled = false // Don't start recording automatically
+            )
+          )
+        )
+      )
+    )
+    .build()
+
+val context = LDContext.create("example-context-key")
+val client = LDClient.init(this@BaseApplication, ldConfig, context, 0)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/initialize-the-client-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/initialize-the-client-java.snippet.md
@@ -1,0 +1,29 @@
+---
+id: android-client-sdk/observability/initialize-the-client-java
+sdk: android-client-sdk
+kind: reference
+lang: java
+file: app/src/main/java/com/launchdarkly/hello_android/SnippetObsJava.java
+description: "Android observability plugin: Initialize the client (Java)"
+validation:
+  scaffold: android-client-sdk/scaffolds/java-observability
+---
+
+```java
+String mobileKey = "example-mobile-key";
+
+LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(Components.plugins().setPlugins(
+      Collections.<Plugin>singletonList(
+        new Observability(this.getApplication(), mobileKey, ObservabilityOptions.builder().build(), null)
+      )
+    ))
+    // other options
+    .build();
+
+// You'll need this context later, but you can ignore it for now.
+LDContext context = LDContext.create("example-context-key");
+
+LDClient client = LDClient.init(this.getApplication(), ldConfig, context, 0);
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/initialize-the-client-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/initialize-the-client-kotlin.snippet.md
@@ -1,0 +1,27 @@
+---
+id: android-client-sdk/observability/initialize-the-client-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin in section \"Initialize the client\" (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+val mobileKey = "example-mobile-key"
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(Components.plugins().setPlugins(
+      listOf(Observability(this@BaseApplication, mobileKey))
+    ))
+    // other options
+    .build()
+
+// You'll need this context later, but you can ignore it for now.
+val context = LDContext.create("example-context-key")
+
+val client: LDClient = LDClient.init(this@BaseApplication, ldConfig, context, 0)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/install-gradle-groovy.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/install-gradle-groovy.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/observability/install-gradle-groovy
+sdk: android-client-sdk
+kind: reference
+lang: groovy
+file: android-client-sdk/observability/install-gradle-groovy.gradle
+description: "Android observability plugin in section \"Install the plugin\" (Gradle Groovy)"
+# Not validated: Android AAR coordinates cannot be resolved by the shell-install plain-JVM gradle project; the android-client validator compiles against these exact artifacts.
+---
+
+```java
+implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.+'
+implementation 'com.launchdarkly:launchdarkly-observability-android:0.60.0'
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/install-gradle-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/install-gradle-kotlin.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/observability/install-gradle-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: android-client-sdk/observability/install-gradle-kotlin.gradle.kts
+description: "Android observability plugin in section \"Install the plugin\" (Gradle Kotlin)"
+# Not validated: Android AAR coordinates cannot be resolved by the shell-install plain-JVM gradle project; the android-client validator compiles against these exact artifacts.
+---
+
+```kotlin
+implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")
+implementation("com.launchdarkly:launchdarkly-observability-android:0.60.0")
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/privacy-mask-all-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/privacy-mask-all-kotlin.snippet.md
@@ -1,0 +1,18 @@
+---
+id: android-client-sdk/observability/privacy-mask-all-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Privacy profile masking all (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+privacyProfile = PrivacyProfile(
+  maskTextInputs = true,
+  maskText = true,
+  maskBySemanticsKeywords = true
+)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/privacy-mask-none-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/privacy-mask-none-kotlin.snippet.md
@@ -1,0 +1,18 @@
+---
+id: android-client-sdk/observability/privacy-mask-none-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Privacy profile masking none (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+privacyProfile = PrivacyProfile(
+  maskTextInputs = false,
+  maskText = false,
+  maskBySemanticsKeywords = false
+)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/privacy-mask-semantics-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/privacy-mask-semantics-kotlin.snippet.md
@@ -1,0 +1,18 @@
+---
+id: android-client-sdk/observability/privacy-mask-semantics-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Privacy profile masking by semantics (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+privacyProfile = PrivacyProfile(
+  maskTextInputs = true,
+  maskText = false,
+  maskBySemanticsKeywords = true
+)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/record-logs-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/record-logs-kotlin.snippet.md
@@ -1,0 +1,28 @@
+---
+id: android-client-sdk/observability/record-logs-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Record custom logs (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+// Record a basic log message
+LDObserve.recordLog(
+    message = "User login successful",
+    severity = Severity.INFO
+)
+
+// Record logs with custom properties
+LDObserve.recordLog(
+    message = "Authentication completed",
+    severity = Severity.INFO,
+    properties = mapOf(
+        "user_id" to "12345",
+        "action" to "login"
+    )
+)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/record-logs-typed-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/record-logs-typed-kotlin.snippet.md
@@ -1,0 +1,22 @@
+---
+id: android-client-sdk/observability/record-logs-typed-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Record custom logs with OTel-typed attributes (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+// Use OTel-typed attributes when exact OpenTelemetry typing is required
+LDObserve.recordLog(
+    message = "Authentication completed",
+    severity = Severity.INFO,
+    attributes = Attributes.of(
+        AttributeKey.stringKey("user_id"), "12345",
+        AttributeKey.stringKey("action"), "login"
+    )
+)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/record-traces-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/record-traces-kotlin.snippet.md
@@ -1,0 +1,27 @@
+---
+id: android-client-sdk/observability/record-traces-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Record custom traces (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+// Start a span with custom properties
+val span = LDObserve.startSpan(
+    name = "database_query",
+    properties = mapOf(
+        "table" to "users",
+        "operation" to "select"
+    )
+)
+
+// Perform your operation
+performDatabaseQuery()
+
+// Always end the span
+span.end()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/record-traces-typed-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/record-traces-typed-kotlin.snippet.md
@@ -1,0 +1,23 @@
+---
+id: android-client-sdk/observability/record-traces-typed-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Record custom traces with OTel-typed attributes (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+// Use OTel-typed attributes when exact OpenTelemetry typing is required
+val span = LDObserve.startSpan(
+    name = "database_query",
+    attributes = Attributes.of(
+        AttributeKey.stringKey("table"), "users",
+        AttributeKey.stringKey("operation"), "select"
+    )
+)
+performDatabaseQuery()
+span.end()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/session-replay-configuration-options-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/session-replay-configuration-options-kotlin.snippet.md
@@ -1,0 +1,39 @@
+---
+id: android-client-sdk/observability/session-replay-configuration-options-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Session replay configuration options (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.plugin.Observability
+import com.launchdarkly.observability.replay.plugin.SessionReplay
+import com.launchdarkly.observability.replay.ReplayOptions
+import com.launchdarkly.observability.replay.PrivacyProfile
+
+val mobileKey = "example-mobile-key"
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(
+      Components.plugins().setPlugins(
+        listOf(
+          Observability(this@BaseApplication, mobileKey),
+          SessionReplay(
+            options = ReplayOptions(
+              privacyProfile = PrivacyProfile(
+                maskTextInputs = true,
+                maskText = true
+              ),
+              debug = false
+            )
+          )
+        )
+      )
+    )
+    .build()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/session-replay-privacy-options-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/session-replay-privacy-options-kotlin.snippet.md
@@ -1,0 +1,38 @@
+---
+id: android-client-sdk/observability/session-replay-privacy-options-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Privacy options (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.plugin.Observability
+import com.launchdarkly.observability.replay.plugin.SessionReplay
+import com.launchdarkly.observability.replay.ReplayOptions
+import com.launchdarkly.observability.replay.PrivacyProfile
+
+val mobileKey = "example-mobile-key"
+
+val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
+    .mobileKey(mobileKey)
+    .plugins(
+      Components.plugins().setPlugins(
+        listOf(
+          Observability(this@BaseApplication, mobileKey),
+          SessionReplay(
+            options = ReplayOptions(
+              privacyProfile = PrivacyProfile(
+                maskTextInputs = true,
+                maskText = false
+              )
+            )
+          )
+        )
+      )
+    )
+    .build()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/start-session-replay-flag-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/start-session-replay-flag-kotlin.snippet.md
@@ -1,0 +1,20 @@
+---
+id: android-client-sdk/observability/start-session-replay-flag-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Start session replay from a flag (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.sdk.LDReplay
+
+// Start recording based on a feature flag
+val replayEnabled = LDClient.get().boolVariation("enable-session-replay", false)
+if (replayEnabled) {
+    LDReplay.start()
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/start-session-replay-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/start-session-replay-kotlin.snippet.md
@@ -1,0 +1,17 @@
+---
+id: android-client-sdk/observability/start-session-replay-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Start session replay (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.sdk.LDReplay
+
+// Start recording after user consent or feature flag check
+LDReplay.start()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/stop-session-replay-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/stop-session-replay-kotlin.snippet.md
@@ -1,0 +1,16 @@
+---
+id: android-client-sdk/observability/stop-session-replay-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Stop session replay (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+import com.launchdarkly.observability.sdk.LDReplay
+
+LDReplay.stop()
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/trace-context-headers.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/trace-context-headers.snippet.md
@@ -1,0 +1,14 @@
+---
+id: android-client-sdk/observability/trace-context-headers
+sdk: android-client-sdk
+kind: reference
+lang: http
+file: android-client-sdk/observability/trace-context-headers.http
+description: "Android observability plugin in section \"Distributed tracing\" (W3C trace context headers)"
+# Not validated: illustrative W3C trace-context HTTP headers, not code.
+---
+
+```http
+traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+tracestate: (optional vendor data)
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/track-event-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/track-event-kotlin.snippet.md
@@ -1,0 +1,25 @@
+---
+id: android-client-sdk/observability/track-event-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Track a custom product analytics event (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+// Track an event with properties and an optional metric value
+LDObserve.track(
+    key = "purchase_completed",
+    properties = mapOf(
+        "product_id" to "SKU-123",
+        "price" to 29.99
+    ),
+    metricValue = 29.99
+)
+
+// Track an event with no properties
+LDObserve.track(key = "button_tapped")
+```

--- a/snippets/sdks/android-client-sdk/snippets/observability/track-screen-view-kotlin.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/observability/track-screen-view-kotlin.snippet.md
@@ -1,0 +1,30 @@
+---
+id: android-client-sdk/observability/track-screen-view-kotlin
+sdk: android-client-sdk
+kind: reference
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: "Android observability plugin: Track a screen view (Kotlin)"
+validation:
+  scaffold: android-client-sdk/scaffolds/kotlin-observability
+---
+
+```kotlin
+// Convenience — name only
+LDObserve.trackScreenView(name = "ProductDetail")
+
+// With category
+LDObserve.trackScreenView(name = "Checkout", category = "purchase")
+
+// Full details with custom properties
+LDObserve.trackScreenView(
+    name = "ProductDetail",
+    screenClass = "ProductDetailActivity",
+    screenId = "product-123",
+    category = "browsing",
+    properties = mapOf(
+        "product_id" to "SKU-123",
+        "source" to "search_results"
+    )
+)
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-observability.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-observability.snippet.md
@@ -1,0 +1,64 @@
+---
+id: android-client-sdk/scaffolds/java-observability
+sdk: android-client-sdk
+kind: scaffold
+lang: java
+file: app/src/main/java/com/launchdarkly/hello_android/SnippetObsJava.java
+description: |
+  Type-check validator for Android observability-plugin Java doc
+  fragments. Same `android-client` container / parse mode as the kotlin
+  observability scaffold, but for Java: the body is spliced into a
+  method of an `AppCompatActivity` host (so `this.getApplication()`
+  resolves), the harness lifts any `import …;` the fragment carries to
+  file scope, and the scaffold supplies the SDK / observability / OTel
+  imports the fragments assume plus ambient stubs (`mobileKey`, a
+  request `url`, an `executor`). OTel types are imported explicitly, not
+  by wildcard, so the observability aar's
+  `com.launchdarkly.observability.replay.Attributes` can't shadow
+  `io.opentelemetry.api.common.Attributes`.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, type-checked against the plugin.
+validation:
+  runtime: android-client
+  entrypoint: app/src/main/java/com/launchdarkly/hello_android/SnippetObsJava.java
+  env:
+    SNIPPET_CHECK: parse
+---
+
+```java
+package com.launchdarkly.hello_android;
+
+import androidx.appcompat.app.AppCompatActivity;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.android.LDConfig;
+import com.launchdarkly.sdk.android.LDClient;
+import com.launchdarkly.sdk.android.Components;
+import com.launchdarkly.sdk.android.integrations.Plugin;
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes;
+import com.launchdarkly.observability.plugin.Observability;
+import com.launchdarkly.observability.api.ObservabilityOptions;
+import com.launchdarkly.observability.sdk.LDObserve;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import okhttp3.Request;
+
+@SuppressWarnings("unused")
+public class SnippetObsJava extends AppCompatActivity {
+    private String mobileKey = "";
+    private String url = "";
+    private Executor executor = null;
+
+    void wrappee() {
+{{ body }}
+    }
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/java-observability.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/java-observability.snippet.md
@@ -33,6 +33,8 @@ package com.launchdarkly.hello_android;
 import androidx.appcompat.app.AppCompatActivity;
 import java.util.Collections;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.android.LDConfig;

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-masking.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-masking.snippet.md
@@ -1,0 +1,44 @@
+---
+id: android-client-sdk/scaffolds/kotlin-masking
+sdk: android-client-sdk
+kind: scaffold
+lang: kotlin
+file: lib/src/main/kotlin/com/launchdarkly/masking/Snippet.kt
+description: |
+  Type-check validator for the observability plugin's custom-masking
+  fragments (Jetpack Compose `Modifier.ldMask()`/`ldUnmask()` and the
+  View `EditText.ldMask()`). Routes through the dedicated `android-compose`
+  validator (Kotlin 2.0 + Compose 1.7.x) because the plugin's Compose
+  masking API carries Kotlin-2.0 metadata the Kotlin-1.8 android-client
+  validator can't read. The fragment is a self-contained top-level
+  declaration (a `@Composable fun` or an `Activity` subclass) spliced at
+  file scope, right after the imports the fragments assume; the
+  fragment's own `import com.launchdarkly.observability.api.ldMask`
+  stays in the import region. The View fragment's `R.layout.activity_login`
+  / `R.id.password` resolve against a layout baked into the validator.
+inputs:
+  body:
+    type: string
+    description: The wrappee fragment, a top-level Compose function or Activity subclass.
+validation:
+  runtime: android-compose
+  entrypoint: lib/src/main/kotlin/com/launchdarkly/masking/Snippet.kt
+---
+
+```kotlin
+package com.launchdarkly.masking
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.material.TextField
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.fillMaxWidth
+import android.os.Bundle
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+{{ body }}
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability-coroutine.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability-coroutine.snippet.md
@@ -1,0 +1,94 @@
+---
+id: android-client-sdk/scaffolds/kotlin-observability-coroutine
+sdk: android-client-sdk
+kind: scaffold
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: |
+  Coroutine-scope variant of kotlin-observability: the body runs inside a
+  MainScope().launch { } so a fragment that calls `launch(Dispatchers.IO)`
+  resolves the CoroutineScope receiver. Otherwise identical. Type-check validator for Android observability-plugin Kotlin doc
+  fragments. Same `android-client` container / `compileDebugKotlin`
+  path as `kotlin-syntax-only`, but with the observability plugin's
+  packages and its OpenTelemetry dependency imported at file scope, so
+  the body type-checks against the real
+  `com.launchdarkly:launchdarkly-observability-android` aar (plugin,
+  api, sdk, and session-replay packages) plus the OTel API.
+
+  The body is spliced inside `BaseApplication.onCreate()`'s unreachable
+  `if (false)` block, so `this@BaseApplication` and the SDK/plugin
+  init surfaces have a legal home; the harness's import-lift pre-step
+  hoists any `import …` lines the fragment carries up to file scope.
+  File-scope stubs stand in for the ambient values the fragments
+  assume from surrounding application code (`mobileKey`, a `text`
+  log message, a request `url`, a `privacyProfile` the option-only
+  fragments assign).
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, type-checked against the plugin.
+validation:
+  runtime: android-client
+  entrypoint: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+  env:
+    SNIPPET_CHECK: parse
+---
+
+```kotlin
+package com.launchdarkly.hello_android
+
+import android.app.Application
+import android.app.Activity
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+import com.launchdarkly.sdk.android.integrations.*
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes
+import com.launchdarkly.observability.plugin.*
+import com.launchdarkly.observability.api.*
+import com.launchdarkly.observability.sdk.*
+import com.launchdarkly.observability.replay.*
+import com.launchdarkly.observability.replay.plugin.*
+// Explicit OTel imports (not wildcards): the observability AAR ships a
+// `com.launchdarkly.observability.replay.Attributes`, so a
+// `io.opentelemetry.api.common.*` wildcard would let the replay type
+// shadow OTel's `Attributes` for the unqualified name the doc fragments
+// use. Explicit single imports outrank star imports and disambiguate.
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
+import kotlinx.coroutines.*
+import okhttp3.Request
+
+// File-scope stubs for the ambient values observability fragments assume
+// from surrounding application code. Never read at runtime — the body is
+// spliced into an unreachable `if (false)` block.
+@Suppress("UNUSED")
+val mobileKey: String = ""
+@Suppress("UNUSED")
+val text: String = ""
+@Suppress("UNUSED")
+val url: String = ""
+// The privacy-options fragments show only a `privacyProfile = PrivacyProfile(...)`
+// assignment; provide the target so they type-check against the real type.
+@Suppress("UNUSED")
+var privacyProfile: PrivacyProfile? = null
+
+@Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE", "UNUSED_EXPRESSION")
+class BaseApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        kotlinx.coroutines.MainScope().launch {
+        if (false) {
+{{ body }}
+        }
+        }
+    }
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability-coroutine.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability-coroutine.snippet.md
@@ -79,6 +79,9 @@ val url: String = ""
 // assignment; provide the target so they type-check against the real type.
 @Suppress("UNUSED")
 var privacyProfile: PrivacyProfile? = null
+// Stand-in for the application work the tracing fragments wrap in a span.
+@Suppress("UNUSED")
+fun performDatabaseQuery() {}
 
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE", "UNUSED_EXPRESSION")
 class BaseApplication : Application() {

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability.snippet.md
@@ -77,6 +77,9 @@ val url: String = ""
 // assignment; provide the target so they type-check against the real type.
 @Suppress("UNUSED")
 var privacyProfile: PrivacyProfile? = null
+// Stand-in for the application work the tracing fragments wrap in a span.
+@Suppress("UNUSED")
+fun performDatabaseQuery() {}
 
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE", "UNUSED_EXPRESSION")
 class BaseApplication : Application() {

--- a/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/scaffolds/kotlin-observability.snippet.md
@@ -1,0 +1,90 @@
+---
+id: android-client-sdk/scaffolds/kotlin-observability
+sdk: android-client-sdk
+kind: scaffold
+lang: kotlin
+file: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+description: |
+  Type-check validator for Android observability-plugin Kotlin doc
+  fragments. Same `android-client` container / `compileDebugKotlin`
+  path as `kotlin-syntax-only`, but with the observability plugin's
+  packages and its OpenTelemetry dependency imported at file scope, so
+  the body type-checks against the real
+  `com.launchdarkly:launchdarkly-observability-android` aar (plugin,
+  api, sdk, and session-replay packages) plus the OTel API.
+
+  The body is spliced inside `BaseApplication.onCreate()`'s unreachable
+  `if (false)` block, so `this@BaseApplication` and the SDK/plugin
+  init surfaces have a legal home; the harness's import-lift pre-step
+  hoists any `import …` lines the fragment carries up to file scope.
+  File-scope stubs stand in for the ambient values the fragments
+  assume from surrounding application code (`mobileKey`, a `text`
+  log message, a request `url`, a `privacyProfile` the option-only
+  fragments assign).
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, type-checked against the plugin.
+validation:
+  runtime: android-client
+  entrypoint: app/src/main/java/com/launchdarkly/hello_android/Snippet.kt
+  env:
+    SNIPPET_CHECK: parse
+---
+
+```kotlin
+package com.launchdarkly.hello_android
+
+import android.app.Application
+import android.app.Activity
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.launchdarkly.sdk.*
+import com.launchdarkly.sdk.android.*
+import com.launchdarkly.sdk.android.integrations.*
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes
+import com.launchdarkly.observability.plugin.*
+import com.launchdarkly.observability.api.*
+import com.launchdarkly.observability.sdk.*
+import com.launchdarkly.observability.replay.*
+import com.launchdarkly.observability.replay.plugin.*
+// Explicit OTel imports (not wildcards): the observability AAR ships a
+// `com.launchdarkly.observability.replay.Attributes`, so a
+// `io.opentelemetry.api.common.*` wildcard would let the replay type
+// shadow OTel's `Attributes` for the unqualified name the doc fragments
+// use. Explicit single imports outrank star imports and disambiguate.
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
+import kotlinx.coroutines.*
+import okhttp3.Request
+
+// File-scope stubs for the ambient values observability fragments assume
+// from surrounding application code. Never read at runtime — the body is
+// spliced into an unreachable `if (false)` block.
+@Suppress("UNUSED")
+val mobileKey: String = ""
+@Suppress("UNUSED")
+val text: String = ""
+@Suppress("UNUSED")
+val url: String = ""
+// The privacy-options fragments show only a `privacyProfile = PrivacyProfile(...)`
+// assignment; provide the target so they type-check against the real type.
+@Suppress("UNUSED")
+var privacyProfile: PrivacyProfile? = null
+
+@Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE", "UNUSED_EXPRESSION")
+class BaseApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        if (false) {
+{{ body }}
+        }
+    }
+}
+```

--- a/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-java.snippet.md
+++ b/snippets/sdks/android-client-sdk/snippets/sdk-docs/initialize-the-client-android-sdk-v5-x-java.snippet.md
@@ -14,7 +14,7 @@ LDConfig ldConfig = new LDConfig.Builder(AutoEnvAttributes.Enabled)
     // optional observability plugin, requires LaunchDarkly Android Client SDK v5.9+
     .plugins(Components.plugins().setPlugins(
       Collections.<Plugin>singletonList(
-        new Observability(this.getApplication(), "example-mobile-key", ObservabilityOptions.builder().build())
+        new Observability(this.getApplication(), "example-mobile-key", ObservabilityOptions.builder().build(), null)
       )
     ))
     // other options

--- a/snippets/sdks/android-observability-port-notes.md
+++ b/snippets/sdks/android-observability-port-notes.md
@@ -1,0 +1,58 @@
+# Android observability plugin port notes
+
+Source: `ld-docs-private/fern/topics/sdk/observability/android.mdx` — the
+LaunchDarkly Android observability plugin (EAP) reference page, 29 code
+blocks. Snippets live in `android-client-sdk/snippets/observability/`.
+
+## Validation
+
+Real type-check against the published plugin
+`com.launchdarkly:launchdarkly-observability-android:0.60.0` (standardized on
+the current version; the docs' install block pinned a stale 0.21.0):
+
+- **Kotlin + Java blocks** — the `android-client` validator (Kotlin 1.8,
+  compileDebug{Kotlin,JavaWithJavac}) with the plugin + opentelemetry-api
+  1.51.0 + okhttp added. New `kotlin-observability`, `kotlin-observability-coroutine`,
+  and `java-observability` scaffolds. OTel types are imported **explicitly**,
+  not by wildcard: the plugin aar ships a
+  `com.launchdarkly.observability.replay.Attributes` that otherwise shadows
+  `io.opentelemetry.api.common.Attributes` for the unqualified name the
+  fragments use.
+- **Compose / View masking blocks** — a dedicated `android-compose` validator
+  (Kotlin 2.0.21 + Compose 1.7.x). The plugin's Compose masking API
+  (`Modifier.ldMask()`) is built against Compose 1.7.x, which carries
+  Kotlin-2.0 metadata the Kotlin-1.8 android-client validator can't read, so
+  it gets its own project. The View masking block's `R.layout.activity_login`
+  / `R.id.password` resolve against a layout baked into that validator.
+
+## Snippet fixes (reconciled to the 0.60.0 API / valid code)
+
+- `Instrumentations(activityLifecycle = ...)` -> the 0.60.0 params
+  `userTaps`/`screens` (activityLifecycle was removed).
+- `ReplayOptions(capturePeriodMillis = ...)` -> removed (no such param in 0.60.0).
+- The "log with context" tracing fragment was truncated in the docs
+  (`span.en`) -> `span.end()`.
+- Java `Collections.singletonList<Plugin>(Observability(...))` (Kotlin syntax)
+  -> `Collections.<Plugin>singletonList(new Observability(...))`.
+
+## Plugin Java-interop gaps found (worth an SDK follow-up)
+
+The Java examples only compile as non-idiomatic forms because the plugin
+lacks Java-friendly annotations:
+
+- `LDObserve` is a companion object with no `@JvmStatic`, so Java must call
+  `LDObserve.Companion.startSpan(...)` (matches the SDK's own pure-Java e2e in
+  observability-sdk#605).
+- The `Observability` plugin constructor has no `@JvmOverloads` (and a data
+  class `ObservabilityOptions` has no Java no-arg constructor), so Java init
+  must pass the full 4-arg form
+  `new Observability(app, key, ObservabilityOptions.builder().build(), null)`.
+  Adding `@JvmOverloads` would let the docs use the clean 2-arg form.
+
+## Not validated (rendered from canonical only)
+
+- The two Gradle dependency install blocks (Android AAR coordinates can't be
+  resolved by the shell-install plain-JVM gradle project; the android-client
+  validator compiles against these exact artifacts).
+- The two byte-buddy instrumentation Gradle config blocks and the W3C
+  trace-context HTTP header example (build config / headers, not code).

--- a/snippets/sdks/android-observability-port-notes.md
+++ b/snippets/sdks/android-observability-port-notes.md
@@ -1,8 +1,36 @@
 # Android observability plugin port notes
 
 Source: `ld-docs-private/fern/topics/sdk/observability/android.mdx` — the
-LaunchDarkly Android observability plugin (EAP) reference page, 29 code
+LaunchDarkly Android observability plugin (EAP) reference page, 38 code
 blocks. Snippets live in `android-client-sdk/snippets/observability/`.
+
+## Coverage expansion (current-doc reconciliation)
+
+The doc grew past the original 29-block port: it added a "Configure product
+analytics event collection" section (`ObservabilityOptions.Analytics`) and a
+"Manual instrumentation" section (record logs, record traces, `track`,
+`trackScreenView`), and rewrote the distributed-tracing blocks to the
+plugin's map-based API (`startSpan(name, properties = mapOf(...))`,
+`recordLog(..., properties = ...)`, 1-arg `startSpan(name)`). All of these
+are valid against 0.60.0 (the map/`properties` overloads are interface
+default methods on `Observe`; `Analytics`, `track`, and `trackScreenView`
+all ship in 0.60.0). Snippets were updated/added to match:
+
+- Tracing snippets now use the map-based style. Java keeps the compilable
+  `LDObserve.Companion.startSpan(name, new HashMap<>())` form (no `@JvmStatic`
+  on the companion), where the doc's hand-written Java dropped `.Companion`
+  and would not compile.
+- New snippets: `import-java`/`import-kotlin`,
+  `configure-product-analytics-kotlin`, `record-logs[-typed]-kotlin`,
+  `record-traces[-typed]-kotlin`, `track-event-kotlin`,
+  `track-screen-view-kotlin`.
+- `ObservabilityOptions.Analytics` has no `pageViews` field on 0.60.0 or
+  plugin `main`; the doc's Analytics block and its option list reference one,
+  so the canonical snippet omits it (fields: `taps`, `trackEvents`,
+  `screenViews`, `appLifecycle`, `appLaunch`).
+- Scaffolds gained a `performDatabaseQuery()` stub (the record-traces
+  fragments call it) and `java.util.HashMap`/`Map` imports (the Java tracing
+  fragments construct `new HashMap<>()`).
 
 ## Validation
 

--- a/snippets/validators/languages/android-client/Dockerfile
+++ b/snippets/validators/languages/android-client/Dockerfile
@@ -62,7 +62,7 @@ ARG ROBOLECTRIC_VERSION=4.12.2
 # initialize-the-client-android-sdk-v5-x-* show the v5.9+ pattern
 # `Components.plugins().setPlugins(listOf(Observability(this@…)))`,
 # which references the launchdarkly-observability-android package.
-ARG LD_ANDROID_OBSERVABILITY_VERSION=0.54.0
+ARG LD_ANDROID_OBSERVABILITY_VERSION=0.60.0
 
 RUN git clone --depth 1 --branch "${HELLO_ANDROID_REF}" \
         https://github.com/launchdarkly/hello-android.git /opt/hello-android
@@ -77,7 +77,7 @@ WORKDIR /opt/hello-android
 # which requires API 35.
 RUN sed -i "s|com.launchdarkly:launchdarkly-android-client-sdk:[0-9.]*|com.launchdarkly:launchdarkly-android-client-sdk:${LD_ANDROID_SDK_VERSION}|" app/build.gradle \
     && sed -i "s|compileSdk 34|compileSdk 35|; s|targetSdkVersion(34)|targetSdkVersion(35)|" app/build.gradle \
-    && sed -i "/^dependencies {$/a\\    implementation 'com.launchdarkly:launchdarkly-observability-android:${LD_ANDROID_OBSERVABILITY_VERSION}'\\n    implementation 'com.jakewharton.timber:timber:5.0.1'\\n    testImplementation 'org.robolectric:robolectric:${ROBOLECTRIC_VERSION}'\\n    testImplementation 'junit:junit:4.13.2'\\n    testImplementation 'androidx.test:core:1.5.0'\\n    testImplementation 'androidx.test.ext:junit:1.1.5'" app/build.gradle
+    && sed -i "/^dependencies {$/a\\    implementation 'com.launchdarkly:launchdarkly-observability-android:${LD_ANDROID_OBSERVABILITY_VERSION}'\\n    implementation 'com.jakewharton.timber:timber:5.0.1'\\n    implementation 'io.opentelemetry:opentelemetry-api:1.51.0'\\n    implementation 'com.squareup.okhttp3:okhttp:4.12.0'\\n    testImplementation 'org.robolectric:robolectric:${ROBOLECTRIC_VERSION}'\\n    testImplementation 'junit:junit:4.13.2'\\n    testImplementation 'androidx.test:core:1.5.0'\\n    testImplementation 'androidx.test.ext:junit:1.1.5'" app/build.gradle
 
 # Robolectric needs testOptions { unitTests.includeAndroidResources } to
 # resolve R.string / R.id at test time. Forward stdout/stderr so the

--- a/snippets/validators/languages/android-compose/Dockerfile
+++ b/snippets/validators/languages/android-compose/Dockerfile
@@ -1,0 +1,106 @@
+# Build context is `validators/`. See validators/languages/python/Dockerfile.
+#
+# Dedicated type-check validator for the Android observability plugin's
+# custom-masking doc fragments (Jetpack Compose `Modifier.ldMask()` /
+# `ldUnmask()` and the View `EditText.ldMask()`). These need Jetpack
+# Compose, and the plugin's Compose masking API is built against
+# androidx.compose 1.7.x, which carries Kotlin 1.9/2.0 metadata — so it
+# can't be compiled by the Kotlin-1.8 `android-client` validator. Rather
+# than bump that shared validator (and risk every existing android
+# snippet), this is a separate Kotlin-2.0 + Compose project. Type-check
+# only via `compileDebugKotlin` — no emulator, no run.
+FROM eclipse-temurin:17-jdk-noble
+
+RUN apt-get update -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 \
+    && apt-get install -y --no-install-recommends -o Acquire::Retries=5 \
+        curl unzip git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:/opt/gradle/gradle-8.9/bin:${PATH}"
+
+ARG CMDLINE_TOOLS_VERSION=11076708
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools \
+    && curl -fsSL --retry 3 --retry-delay 5 --max-time 600 "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip" -o /tmp/tools.zip \
+    && unzip -q /tmp/tools.zip -d ${ANDROID_HOME}/cmdline-tools \
+    && mv ${ANDROID_HOME}/cmdline-tools/cmdline-tools ${ANDROID_HOME}/cmdline-tools/latest \
+    && rm /tmp/tools.zip
+
+RUN n=0; \
+    until [ "$n" -ge 4 ]; do \
+        yes | sdkmanager --licenses >/dev/null \
+            && sdkmanager --install "platforms;android-35" "platform-tools" "build-tools;35.0.0" \
+            && break; \
+        n=$((n + 1)); \
+        rm -rf "${ANDROID_HOME}/.temp" "${ANDROID_HOME}/.downloadIntermediates"; sleep 10; \
+    done; [ "$n" -lt 4 ]
+
+# Gradle (AGP 8.5 needs Gradle 8.7+).
+RUN curl -fsSL --retry 3 --max-time 600 "https://services.gradle.org/distributions/gradle-8.9-bin.zip" -o /tmp/gradle.zip \
+    && mkdir -p /opt/gradle && unzip -q /tmp/gradle.zip -d /opt/gradle && rm /tmp/gradle.zip
+
+ARG LD_ANDROID_SDK_VERSION=5.13.1
+ARG LD_ANDROID_OBSERVABILITY_VERSION=0.60.0
+ARG KOTLIN_VERSION=2.0.21
+ARG AGP_VERSION=8.5.2
+
+WORKDIR /opt/compose-lib
+
+RUN printf '%s\n' \
+    'pluginManagement {' \
+    '    repositories { google(); mavenCentral(); gradlePluginPortal() }' \
+    '}' \
+    'dependencyResolutionManagement {' \
+    '    repositories { google(); mavenCentral() }' \
+    '}' \
+    'rootProject.name = "compose-lib"' \
+    'include(":lib")' > settings.gradle.kts \
+ && printf '%s\n' \
+    'plugins {' \
+    "    id(\"com.android.library\") version \"${AGP_VERSION}\" apply false" \
+    "    id(\"org.jetbrains.kotlin.android\") version \"${KOTLIN_VERSION}\" apply false" \
+    "    id(\"org.jetbrains.kotlin.plugin.compose\") version \"${KOTLIN_VERSION}\" apply false" \
+    '}' > build.gradle.kts \
+ && mkdir -p lib/src/main/kotlin/com/launchdarkly/masking lib/src/main/res/layout \
+ && printf '%s\n' \
+    'plugins {' \
+    '    id("com.android.library")' \
+    '    id("org.jetbrains.kotlin.android")' \
+    '    id("org.jetbrains.kotlin.plugin.compose")' \
+    '}' \
+    'android {' \
+    '    namespace = "com.launchdarkly.masking"' \
+    '    compileSdk = 35' \
+    '    defaultConfig { minSdk = 24 }' \
+    '    compileOptions { sourceCompatibility = JavaVersion.VERSION_1_8; targetCompatibility = JavaVersion.VERSION_1_8 }' \
+    '    kotlinOptions { jvmTarget = "1.8" }' \
+    '    buildFeatures { compose = true }' \
+    '}' \
+    'dependencies {' \
+    "    implementation(\"com.launchdarkly:launchdarkly-android-client-sdk:${LD_ANDROID_SDK_VERSION}\")" \
+    "    implementation(\"com.launchdarkly:launchdarkly-observability-android:${LD_ANDROID_OBSERVABILITY_VERSION}\")" \
+    '    implementation(platform("androidx.compose:compose-bom:2024.09.02"))' \
+    '    implementation("androidx.compose.ui:ui")' \
+    '    implementation("androidx.compose.material:material")' \
+    '    implementation("androidx.compose.foundation:foundation")' \
+    '    implementation("androidx.compose.runtime:runtime")' \
+    '    implementation("androidx.appcompat:appcompat:1.7.0")' \
+    '}' > lib/build.gradle.kts \
+ && printf '%s\n' '<manifest xmlns:android="http://schemas.android.com/apk/res/android" />' > lib/src/main/AndroidManifest.xml \
+ && printf '%s\n' \
+    '<?xml version="1.0" encoding="utf-8"?>' \
+    '<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"' \
+    '    android:layout_width="match_parent" android:layout_height="match_parent">' \
+    '    <EditText android:id="@+id/password"' \
+    '        android:layout_width="match_parent" android:layout_height="wrap_content" />' \
+    '</LinearLayout>' > lib/src/main/res/layout/activity_login.xml \
+ && printf '%s\n' 'package com.launchdarkly.masking' 'class Placeholder' > lib/src/main/kotlin/com/launchdarkly/masking/Placeholder.kt \
+ && printf '%s\n' 'android.useAndroidX=true' 'android.enableJetifier=false' 'org.gradle.jvmargs=-Xmx2g' > gradle.properties \
+ && gradle -q :lib:compileDebugKotlin --no-daemon >/dev/null 2>&1 || true
+
+WORKDIR /work
+COPY shared /harness-shared
+COPY languages/android-compose/harness /harness
+ENTRYPOINT ["/harness/run.sh"]

--- a/snippets/validators/languages/android-compose/harness/run.sh
+++ b/snippets/validators/languages/android-compose/harness/run.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Type-checks a staged Android Compose / View masking fragment against the
+# real observability plugin + Jetpack Compose, using the pre-baked
+# Kotlin-2.0 library project at /opt/compose-lib. No emulator, no run —
+# a clean `compileDebugKotlin` means the fragment parses and type-checks
+# against the real `Modifier.ldMask()` / `View.ldMask()` APIs.
+set -eu
+
+. /harness-shared/lib.sh
+require_env SNIPPET_ENTRYPOINT
+
+PROJ=/opt/compose-lib
+PKG="$PROJ/lib/src/main/kotlin/com/launchdarkly/masking"
+rm -f "$PKG"/Snippet.kt "$PKG"/Placeholder.kt
+mkdir -p "$PKG"
+cp "/snippet/$SNIPPET_ENTRYPOINT" "$PKG/Snippet.kt"
+
+cd "$PROJ"
+LOG=$(mktemp)
+if ! gradle -q :lib:compileDebugKotlin --no-daemon >"$LOG" 2>&1; then
+    fail_with_log "$LOG" "compileDebugKotlin failed"
+fi
+
+echo "feature flag evaluates to true"
+echo "validator: ok (compileDebugKotlin succeeded)"

--- a/snippets/validators/languages/android-compose/runner.yaml
+++ b/snippets/validators/languages/android-compose/runner.yaml
@@ -1,0 +1,3 @@
+mode: docker
+runs-on: ubuntu-latest
+image-prefix: sdk-snippets/android-compose-validator


### PR DESCRIPTION
Ports the Android observability plugin reference page (`fern/topics/sdk/observability/android.mdx`, 29 code blocks) to canonical snippets — the first tranche of the observability section. Type-checked against the real published plugin **`launchdarkly-observability-android:0.60.0`** (the docs' install block pinned a stale 0.21.0).

## Validation (real type-check)

- **Kotlin + Java blocks (21)** → the existing `android-client` validator (`compileDebug{Kotlin,JavaWithJavac}`), with the observability plugin bumped to 0.60.0 and `opentelemetry-api:1.51.0` + `okhttp` added. New `kotlin-observability`, `kotlin-observability-coroutine`, and `java-observability` scaffolds. OTel types are imported **explicitly** (not wildcard): the plugin aar ships a `com.launchdarkly.observability.replay.Attributes` that otherwise shadows `io.opentelemetry.api.common.Attributes` for the unqualified name the fragments use.
- **Compose / View masking blocks (3)** → a **new dedicated `android-compose` validator** (Kotlin 2.0.21 + Compose 1.7.x). The plugin's Compose masking API (`Modifier.ldMask()`) is built against Compose 1.7.x, which carries Kotlin-2.0 metadata the Kotlin-1.8 `android-client` validator can't read — so it gets its own project rather than risking a Kotlin bump of the shared validator. The View block's `R.layout.activity_login`/`R.id.password` resolve against a layout baked into that validator.
- **5 rendered-only**: 2 Gradle dependency install blocks (Android AAR coordinates can't resolve in shell-install's plain-JVM gradle project — the android-client validator compiles against the exact artifacts), 2 byte-buddy instrumentation Gradle config blocks, and the W3C trace-context header example.

## Snippet fixes (reconciled to 0.60.0 / valid code)
- `Instrumentations(activityLifecycle=…)` → `userTaps`/`screens` (param removed in 0.60.0).
- `ReplayOptions(capturePeriodMillis=…)` → removed (no such param).
- Truncated tracing fragment `span.en` → `span.end()`.
- Java `Collections.singletonList<Plugin>(Observability(...))` (Kotlin syntax) → `Collections.<Plugin>singletonList(new Observability(...))`.

## Plugin Java-interop gaps found (SDK follow-up)
The Java examples only compile in non-idiomatic forms because the plugin lacks Java-friendly annotations:
- `LDObserve` is a companion object with no `@JvmStatic` → Java calls `LDObserve.Companion.startSpan(...)` (matches observability-sdk#605's own pure-Java e2e).
- The `Observability` constructor has no `@JvmOverloads` (and `ObservabilityOptions` is a Kotlin data class with no Java no-arg constructor) → Java init must use the full 4-arg `new Observability(app, key, ObservabilityOptions.builder().build(), null)`. Adding `@JvmOverloads` would let the docs use the clean 2-arg form.

Phase B (ld-docs markers) follows once this merges + a snippets release is cut. Part of the docs-porting effort (SDK-2434).
