### PR TITLE
docs: fix segment key in file-data example (includes → included)

### DIFF
--- a/snippets/sdks/_shared/snippets/sdk-docs/features/filedata/flag-data-json.snippet.md
+++ b/snippets/sdks/_shared/snippets/sdk-docs/features/filedata/flag-data-json.snippet.md
@@ -17,7 +17,7 @@ description: Example full-format flag data file with flags and segments.
   "segments": {
     "segment-key-1": {
       "key": "segment-key-1",
-      "includes": [ "context-key-1" ]
+      "included": [ "context-key-1" ]
     }
   }
 }


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: segment key in file-data example (includes → included)
END_COMMIT_OVERRIDE

## What

Fixes a functional error in the shared full-format file-data JSON example. The `segments` object used `"includes"` for the list of context keys:

```json
"segments": {
  "segment-key-1": {
    "key": "segment-key-1",
    "includes": [ "context-key-1" ]
  }
}
```

## Why

The SDK segment model deserializes `"included"` / `"excluded"` (and `includedContexts` / `excludedContexts`), never `"includes"`. Confirmed against the Ruby SDK model, which reads:

```ruby
@included = data[:included] || []
@excluded = data[:excluded] || []
```

An unknown `"includes"` key is silently dropped and `included` defaults to an empty array, so a context listed under `includes` is **never actually added to the segment**. The example doesn't work as written.

This snippet lives in `_shared`, so the fix propagates to every SDK's file-data topic (Ruby, Python, Go, Java, Node, etc.).

## Change

`"includes"` → `"included"` in `snippets/sdks/_shared/snippets/sdk-docs/features/filedata/flag-data-json.snippet.md`.

## Downstream

Surfaces in the docs at [Reading flags from files](https://launchdarkly.com/docs/sdk/features/flags-from-files). The `sync-ld-docs-snippets` job in `ld-docs-private` will re-render the block once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction in a shared snippet; no runtime or SDK code changes.
> 
> **Overview**
> Corrects the shared **full-format file-data JSON** example so segment membership uses **`"included"`** instead of **`"includes"`**, matching how SDKs deserialize segment definitions.
> 
> Because this snippet lives under `_shared`, the fix applies across every SDK’s “flags from files” documentation that embeds it. Copy-paste or file-based setups that followed the old key would have had listed context keys ignored (empty `included`), so segments would not behave as the doc implied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba517a9f2ed5df35e963ec4054a8f6edf5aa518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->