### PR TITLE
feat(snippets): add type-aware flagEval variants for six SDKs

### DIFF
--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -371,3 +371,33 @@ in `internal/adapters/rawfiles/rawfiles.go` (`renderBody`).
 **Recommended action**: None. Documented here so future readers don't
 chase a phantom drift if a `.snippet.md` body ends with multiple blank
 lines and the rendered output normalizes to one.
+
+>## Type-aware flagEval variants
+
+**Severity**: informational
+
+**SDKs affected**: the six with a `sdk-info/flagEval` snippet —
+dotnet-client, java-server, js-client, node-server, python-server,
+react-client.
+
+**What we observed**: `flagEval` only ever showed a boolean evaluation,
+so gonfalon hand-maintained string / number / JSON copies in
+`packages/sdk-info/src/typeAwareFlagEvalSnippets.ts`, guarded by a drift
+test. Those belong here.
+
+**What we did**: Added `flagEval-string` / `-number` / `-json` beside
+each `flagEval`. Only the evaluation call and the comparison differ from
+the boolean sibling — imports, context setup, and the flag-key
+placeholder are untouched — and each variant reuses the boolean's
+`validation.scaffold`. The three SDKs with a single generic `variation`
+signal the type through the default value rather than the method name.
+No CI change needed; every affected SDK already has an unfiltered row.
+
+One caveat before trusting a green run: only java (typed `client` stub)
+and react (real end-to-end) actually check the evaluation call. dotnet's
+`client` is `dynamic` and the other three are parse-only, so a
+misspelled method name there would still pass.
+
+**Recommended action**: Add the eighteen new ids to gonfalon's
+`packages/sdk-info/extract.yaml`, then delete
+`typeAwareFlagEvalSnippets.ts` and its drift test.

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,18 @@
+---
+id: dotnet-client-sdk/sdk-info/flagEval-json
+sdk: dotnet-client-sdk
+kind: flag-eval
+lang: csharp
+file: dotnet-client-sdk/flagEval-json.txt
+description: Flag evaluation example for dotnet-client-sdk (JSON flag).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+---
+
+```csharp
+// Evaluate the feature flag.
+var flagValue = client.JsonVariation("featureKey", LdValue.Null);
+
+// Use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,28 @@
+---
+id: dotnet-client-sdk/sdk-info/flagEval-number
+sdk: dotnet-client-sdk
+kind: flag-eval
+lang: csharp
+file: dotnet-client-sdk/flagEval-number.txt
+description: Flag evaluation example for dotnet-client-sdk (number flag).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+---
+
+```csharp
+// Evaluate the feature flag.
+var flagValue = client.DoubleVariation("featureKey", 0);
+
+if (flagValue == 1)
+{
+
+    // TODO: Put your feature here
+
+}
+else
+{
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,28 @@
+---
+id: dotnet-client-sdk/sdk-info/flagEval-string
+sdk: dotnet-client-sdk
+kind: flag-eval
+lang: csharp
+file: dotnet-client-sdk/flagEval-string.txt
+description: Flag evaluation example for dotnet-client-sdk (string flag).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+---
+
+```csharp
+// Evaluate the feature flag.
+var flagValue = client.StringVariation("featureKey", "fallback-value");
+
+if (flagValue == "example-variation-value")
+{
+
+    // TODO: Put your feature here
+
+}
+else
+{
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,23 @@
+---
+id: java-server-sdk/sdk-info/flagEval-json
+sdk: java-server-sdk
+kind: flag-eval
+lang: java
+file: java-server-sdk/flagEval-json.txt
+description: Flag evaluation example for java-server-sdk (JSON flag).
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+---
+
+```java
+// Set up the evaluation context.
+final LDContext context = LDContext.builder("example-context-key")
+    .name("Sandy")
+    .build();
+
+// Evaluate the feature flag for this context.
+LDValue flagValue = client.jsonValueVariation("featureKey", context, LDValue.ofNull());
+
+// Use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,30 @@
+---
+id: java-server-sdk/sdk-info/flagEval-number
+sdk: java-server-sdk
+kind: flag-eval
+lang: java
+file: java-server-sdk/flagEval-number.txt
+description: Flag evaluation example for java-server-sdk (number flag).
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+---
+
+```java
+// Set up the evaluation context.
+final LDContext context = LDContext.builder("example-context-key")
+    .name("Sandy")
+    .build();
+
+// Evaluate the feature flag for this context.
+double flagValue = client.doubleVariation("featureKey", context, 0);
+
+if (flagValue == 1) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,30 @@
+---
+id: java-server-sdk/sdk-info/flagEval-string
+sdk: java-server-sdk
+kind: flag-eval
+lang: java
+file: java-server-sdk/flagEval-string.txt
+description: Flag evaluation example for java-server-sdk (string flag).
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+---
+
+```java
+// Set up the evaluation context.
+final LDContext context = LDContext.builder("example-context-key")
+    .name("Sandy")
+    .build();
+
+// Evaluate the feature flag for this context.
+String flagValue = client.stringVariation("featureKey", context, "fallback-value");
+
+if (flagValue.equals("example-variation-value")) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,19 @@
+---
+id: js-client-sdk/sdk-info/flagEval-json
+sdk: js-client-sdk
+kind: flag-eval
+lang: javascript
+file: js-client-sdk/flagEval-json.txt
+description: Flag evaluation example for js-client-sdk (JSON flag).
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+const flagKey = 'featureKey';
+
+const flagValue = ldclient.variation(flagKey, {});
+
+// Use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,26 @@
+---
+id: js-client-sdk/sdk-info/flagEval-number
+sdk: js-client-sdk
+kind: flag-eval
+lang: javascript
+file: js-client-sdk/flagEval-number.txt
+description: Flag evaluation example for js-client-sdk (number flag).
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+const flagKey = 'featureKey';
+
+const flagValue = ldclient.variation(flagKey, 0);
+
+if (flagValue === 1) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,26 @@
+---
+id: js-client-sdk/sdk-info/flagEval-string
+sdk: js-client-sdk
+kind: flag-eval
+lang: javascript
+file: js-client-sdk/flagEval-string.txt
+description: Flag evaluation example for js-client-sdk (string flag).
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+const flagKey = 'featureKey';
+
+const flagValue = ldclient.variation(flagKey, 'fallback-value');
+
+if (flagValue === 'example-variation-value') {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,26 @@
+---
+id: node-server-sdk/sdk-info/flagEval-json
+sdk: node-server-sdk
+kind: flag-eval
+lang: javascript
+file: node-server-sdk/flagEval-json.txt
+description: Flag evaluation example for node-server-sdk (JSON flag).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+---
+
+```javascript
+// Evaluate a context
+const context = {
+   "kind": 'user',
+   "key": 'user-key-123abc',
+   "name": 'Sandy',
+};
+
+client.on('ready', () => {
+  client.variation('featureKey', context, {}, function(err, flagValue) {
+    // Use the flag value to configure your feature
+    // TODO: Put your feature here
+  });
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,33 @@
+---
+id: node-server-sdk/sdk-info/flagEval-number
+sdk: node-server-sdk
+kind: flag-eval
+lang: javascript
+file: node-server-sdk/flagEval-number.txt
+description: Flag evaluation example for node-server-sdk (number flag).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+---
+
+```javascript
+// Evaluate a context
+const context = {
+   "kind": 'user',
+   "key": 'user-key-123abc',
+   "name": 'Sandy',
+};
+
+client.on('ready', () => {
+  client.variation('featureKey', context, 0, function(err, flagValue) {
+    if (flagValue === 1) {
+
+      // TODO: Put your feature here
+
+    } else {
+
+      // TODO: Put your fallback feature here
+
+    }
+  });
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,33 @@
+---
+id: node-server-sdk/sdk-info/flagEval-string
+sdk: node-server-sdk
+kind: flag-eval
+lang: javascript
+file: node-server-sdk/flagEval-string.txt
+description: Flag evaluation example for node-server-sdk (string flag).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+---
+
+```javascript
+// Evaluate a context
+const context = {
+   "kind": 'user',
+   "key": 'user-key-123abc',
+   "name": 'Sandy',
+};
+
+client.on('ready', () => {
+  client.variation('featureKey', context, 'fallback-value', function(err, flagValue) {
+    if (flagValue === 'example-variation-value') {
+
+      // TODO: Put your feature here
+
+    } else {
+
+      // TODO: Put your fallback feature here
+
+    }
+  });
+});
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,21 @@
+---
+id: python-server-sdk/sdk-info/flagEval-json
+sdk: python-server-sdk
+kind: flag-eval
+lang: python
+file: python-server-sdk/flagEval-json.txt
+description: Flag evaluation example for python-server-sdk (JSON flag).
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+---
+
+```python
+from ldclient import Context
+
+# Create context using Context builder and use your own values here
+context = Context.builder("context-key-123abc").name("Sandy").build()
+flag_value = client.variation("featureKey", context, {})
+
+# Use the flag value to configure your feature
+# TODO: Put your feature here
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,23 @@
+---
+id: python-server-sdk/sdk-info/flagEval-number
+sdk: python-server-sdk
+kind: flag-eval
+lang: python
+file: python-server-sdk/flagEval-number.txt
+description: Flag evaluation example for python-server-sdk (number flag).
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+---
+
+```python
+from ldclient import Context
+
+# Create context using Context builder and use your own values here
+context = Context.builder("context-key-123abc").name("Sandy").build()
+flag_value = client.variation("featureKey", context, 0)
+
+if flag_value == 1:
+    pass  # TODO: Put your feature here
+else:
+    pass  # TODO: Put your fallback behavior here
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,23 @@
+---
+id: python-server-sdk/sdk-info/flagEval-string
+sdk: python-server-sdk
+kind: flag-eval
+lang: python
+file: python-server-sdk/flagEval-string.txt
+description: Flag evaluation example for python-server-sdk (string flag).
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+---
+
+```python
+from ldclient import Context
+
+# Create context using Context builder and use your own values here
+context = Context.builder("context-key-123abc").name("Sandy").build()
+flag_value = client.variation("featureKey", context, "fallback-value")
+
+if flag_value == "example-variation-value":
+    pass  # TODO: Put your feature here
+else:
+    pass  # TODO: Put your fallback behavior here
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,22 @@
+---
+id: react-client-sdk/sdk-info/flagEval-json
+sdk: react-client-sdk
+kind: flag-eval
+lang: javascript
+file: react-client-sdk/flagEval-json.txt
+description: Flag evaluation example for react-client-sdk (JSON flag).
+validation:
+  scaffold: react-client-sdk/scaffolds/flag-eval-runner
+  placeholders:
+    feature-key: LAUNCHDARKLY_FLAG_KEY
+---
+
+```javascript
+import { useJsonVariation } from '@launchdarkly/react-sdk';
+
+// useJsonVariation evaluates a JSON feature flag and returns its value.
+const flagValue = useJsonVariation('feature-key', {});
+
+// In your component, use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,30 @@
+---
+id: react-client-sdk/sdk-info/flagEval-number
+sdk: react-client-sdk
+kind: flag-eval
+lang: javascript
+file: react-client-sdk/flagEval-number.txt
+description: Flag evaluation example for react-client-sdk (number flag).
+validation:
+  scaffold: react-client-sdk/scaffolds/flag-eval-runner
+  placeholders:
+    feature-key: LAUNCHDARKLY_FLAG_KEY
+---
+
+```javascript
+import { useNumberVariation } from '@launchdarkly/react-sdk';
+
+// useNumberVariation evaluates a number feature flag and returns its value.
+const flagValue = useNumberVariation('feature-key', 0);
+
+// In your component, compare the flag value against your variation values
+if (flagValue === 1) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,30 @@
+---
+id: react-client-sdk/sdk-info/flagEval-string
+sdk: react-client-sdk
+kind: flag-eval
+lang: javascript
+file: react-client-sdk/flagEval-string.txt
+description: Flag evaluation example for react-client-sdk (string flag).
+validation:
+  scaffold: react-client-sdk/scaffolds/flag-eval-runner
+  placeholders:
+    feature-key: LAUNCHDARKLY_FLAG_KEY
+---
+
+```javascript
+import { useStringVariation } from '@launchdarkly/react-sdk';
+
+// useStringVariation evaluates a string feature flag and returns its value.
+const flagValue = useStringVariation('feature-key', 'fallback-value');
+
+// In your component, compare the flag value against your variation values
+if (flagValue === 'example-variation-value') {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```


### PR DESCRIPTION
> **Stacked on #550.** That PR carries the validator toolchain fixes (Node 22, Go 1.25) this branch's CI depends on. Review and merge #550 first; this diff is then 19 markdown files and nothing else.

The base flagEval snippet only covers boolean evaluation, so gonfalon maintained parallel string, number, and JSON templates by hand and guarded them with a drift test. Porting the variants here makes this repo the single canonical source for all four flag types, letting the downstream template map and its drift test be deleted once the ids are added to gonfalon's extract.yaml.


I had claude make some additional changes here: https://github.com/launchdarkly/sdk-meta/pull/550 because the validations CI was failing due to upstream version drift in the shared validator images

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are snippet content and CI validator images only; user impact depends on a separate gonfalon extract.yaml update, and most new snippets use parse-only validation except Java and React.
> 
> **Overview**
> Adds **string**, **number**, and **JSON** `sdk-info` flag-eval snippets for dotnet-client, java-server, js-client, node-server, python-server, and react-client (18 new `flagEval-*` ids), mirroring what gonfalon kept in `typeAwareFlagEvalSnippets.ts`. Each variant only changes the evaluation call and comparison; it reuses the existing boolean snippet’s validation scaffold.
> 
> Documents the port in `_sdk-info-port-notes.md`, including a follow-up to register the new ids in gonfalon `extract.yaml` and remove the hand-maintained map.
> 
> **Validator CI** is bumped so installs and Go snippets keep working: shell-install moves to **Node 22** (fastly-server-sdk engine requirement) and **Go 1.25.12**; the Go validator image uses **golang:1.25** and `run.sh` now surfaces **`go mod init` / `go mod tidy`** failures instead of swallowing stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00fd56bf03c1f32315415c185d31fd2f4cb8e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->