### PR TITLE
fix(snippets): bump validator Go and Node toolchains

### DIFF
--- a/snippets/CLAUDE.md
+++ b/snippets/CLAUDE.md
@@ -170,9 +170,9 @@ image-prefix: sdk-snippets/python-validator   # docker mode only
 
 ### Dockerfile pattern
 
-1. `FROM` a runtime-appropriate base (`python:3.11-slim`, `node:20-bookworm-slim`, `node:22-bookworm`, `mcr.microsoft.com/playwright:v1.59.1-noble`, `eclipse-temurin:17-jdk-noble`).
+1. `FROM` a runtime-appropriate base (`python:3.11-slim`, `node:20-bookworm-slim`, `node:22-bookworm-slim`, `node:22-bookworm`, `mcr.microsoft.com/playwright:v1.59.1-noble`, `eclipse-temurin:17-jdk-noble`).
 2. Install OS packages: `apt-get update ... && apt-get install ... && rm -rf /var/lib/apt/lists/*`. `android-client` uses `Acquire::Retries=5` and curl `--retry 3` for flaky noble mirrors.
-3. Layer additional toolchains as needed. `shell-install` adds Go via the upstream tarball, pip via `python3-pip`, and `corepack prepare pnpm@9 --activate` + a `yarn@1` pin compatible with Node 20.
+3. Layer additional toolchains as needed. `shell-install` builds on `node:22-bookworm-slim` and adds Go via the upstream tarball, pip via `python3-pip`, and `corepack prepare pnpm@9 --activate` + a `yarn@1` pin. The 22 line is deliberate: it still bundles corepack (Node 25 drops it), and Node 20 is below the `engines.node` floor that `@napi-rs/lzma` — pulled in transitively by the Fastly SDK — enforces on yarn installs. pnpm 9 is now a hold for continuity rather than a ceiling; Node 22 would also satisfy pnpm 11's `node:sqlite` requirement.
 4. Pre-bake a project dir with the SDK and dev deps pre-installed so per-validate cycles stay fast. Examples:
    - `js-client` writes `package.json` / `tsdown.config.ts` / `tsconfig.json` / placeholder `src/app.ts` + `index.html` under `/opt/hello-js`, then `npm install` and a pre-warm `npm run build`.
    - `react-native-client` writes `package.json` / `babel.config.js` / `jest.setup.js` / `tsconfig.json` + placeholder `App.tsx` and `src/welcome.tsx` under `/opt/hello-react-native` and runs `npm install`.

--- a/snippets/sdks/_sdk-info-port-notes.md
+++ b/snippets/sdks/_sdk-info-port-notes.md
@@ -371,3 +371,33 @@ in `internal/adapters/rawfiles/rawfiles.go` (`renderBody`).
 **Recommended action**: None. Documented here so future readers don't
 chase a phantom drift if a `.snippet.md` body ends with multiple blank
 lines and the rendered output normalizes to one.
+
+>## Type-aware flagEval variants
+
+**Severity**: informational
+
+**SDKs affected**: the six with a `sdk-info/flagEval` snippet —
+dotnet-client, java-server, js-client, node-server, python-server,
+react-client.
+
+**What we observed**: `flagEval` only ever showed a boolean evaluation,
+so gonfalon hand-maintained string / number / JSON copies in
+`packages/sdk-info/src/typeAwareFlagEvalSnippets.ts`, guarded by a drift
+test. Those belong here.
+
+**What we did**: Added `flagEval-string` / `-number` / `-json` beside
+each `flagEval`. Only the evaluation call and the comparison differ from
+the boolean sibling — imports, context setup, and the flag-key
+placeholder are untouched — and each variant reuses the boolean's
+`validation.scaffold`. The three SDKs with a single generic `variation`
+signal the type through the default value rather than the method name.
+No CI change needed; every affected SDK already has an unfiltered row.
+
+One caveat before trusting a green run: only java (typed `client` stub)
+and react (real end-to-end) actually check the evaluation call. dotnet's
+`client` is `dynamic` and the other three are parse-only, so a
+misspelled method name there would still pass.
+
+**Recommended action**: Add the eighteen new ids to gonfalon's
+`packages/sdk-info/extract.yaml`, then delete
+`typeAwareFlagEvalSnippets.ts` and its drift test.

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,18 @@
+---
+id: dotnet-client-sdk/sdk-info/flagEval-json
+sdk: dotnet-client-sdk
+kind: flag-eval
+lang: csharp
+file: dotnet-client-sdk/flagEval-json.txt
+description: Flag evaluation example for dotnet-client-sdk (JSON flag).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+---
+
+```csharp
+// Evaluate the feature flag.
+var flagValue = client.JsonVariation("featureKey", LdValue.Null);
+
+// Use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,28 @@
+---
+id: dotnet-client-sdk/sdk-info/flagEval-number
+sdk: dotnet-client-sdk
+kind: flag-eval
+lang: csharp
+file: dotnet-client-sdk/flagEval-number.txt
+description: Flag evaluation example for dotnet-client-sdk (number flag).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+---
+
+```csharp
+// Evaluate the feature flag.
+var flagValue = client.DoubleVariation("featureKey", 0);
+
+if (flagValue == 1)
+{
+
+    // TODO: Put your feature here
+
+}
+else
+{
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/dotnet-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,28 @@
+---
+id: dotnet-client-sdk/sdk-info/flagEval-string
+sdk: dotnet-client-sdk
+kind: flag-eval
+lang: csharp
+file: dotnet-client-sdk/flagEval-string.txt
+description: Flag evaluation example for dotnet-client-sdk (string flag).
+validation:
+  scaffold: dotnet-client-sdk/scaffolds/csharp-client-syntax-only
+---
+
+```csharp
+// Evaluate the feature flag.
+var flagValue = client.StringVariation("featureKey", "fallback-value");
+
+if (flagValue == "example-variation-value")
+{
+
+    // TODO: Put your feature here
+
+}
+else
+{
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,23 @@
+---
+id: java-server-sdk/sdk-info/flagEval-json
+sdk: java-server-sdk
+kind: flag-eval
+lang: java
+file: java-server-sdk/flagEval-json.txt
+description: Flag evaluation example for java-server-sdk (JSON flag).
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+---
+
+```java
+// Set up the evaluation context.
+final LDContext context = LDContext.builder("example-context-key")
+    .name("Sandy")
+    .build();
+
+// Evaluate the feature flag for this context.
+LDValue flagValue = client.jsonValueVariation("featureKey", context, LDValue.ofNull());
+
+// Use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,30 @@
+---
+id: java-server-sdk/sdk-info/flagEval-number
+sdk: java-server-sdk
+kind: flag-eval
+lang: java
+file: java-server-sdk/flagEval-number.txt
+description: Flag evaluation example for java-server-sdk (number flag).
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+---
+
+```java
+// Set up the evaluation context.
+final LDContext context = LDContext.builder("example-context-key")
+    .name("Sandy")
+    .build();
+
+// Evaluate the feature flag for this context.
+double flagValue = client.doubleVariation("featureKey", context, 0);
+
+if (flagValue == 1) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,30 @@
+---
+id: java-server-sdk/sdk-info/flagEval-string
+sdk: java-server-sdk
+kind: flag-eval
+lang: java
+file: java-server-sdk/flagEval-string.txt
+description: Flag evaluation example for java-server-sdk (string flag).
+validation:
+  scaffold: java-server-sdk/scaffolds/java-syntax-only
+---
+
+```java
+// Set up the evaluation context.
+final LDContext context = LDContext.builder("example-context-key")
+    .name("Sandy")
+    .build();
+
+// Evaluate the feature flag for this context.
+String flagValue = client.stringVariation("featureKey", context, "fallback-value");
+
+if (flagValue.equals("example-variation-value")) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,19 @@
+---
+id: js-client-sdk/sdk-info/flagEval-json
+sdk: js-client-sdk
+kind: flag-eval
+lang: javascript
+file: js-client-sdk/flagEval-json.txt
+description: Flag evaluation example for js-client-sdk (JSON flag).
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+const flagKey = 'featureKey';
+
+const flagValue = ldclient.variation(flagKey, {});
+
+// Use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,26 @@
+---
+id: js-client-sdk/sdk-info/flagEval-number
+sdk: js-client-sdk
+kind: flag-eval
+lang: javascript
+file: js-client-sdk/flagEval-number.txt
+description: Flag evaluation example for js-client-sdk (number flag).
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+const flagKey = 'featureKey';
+
+const flagValue = ldclient.variation(flagKey, 0);
+
+if (flagValue === 1) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,26 @@
+---
+id: js-client-sdk/sdk-info/flagEval-string
+sdk: js-client-sdk
+kind: flag-eval
+lang: javascript
+file: js-client-sdk/flagEval-string.txt
+description: Flag evaluation example for js-client-sdk (string flag).
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+const flagKey = 'featureKey';
+
+const flagValue = ldclient.variation(flagKey, 'fallback-value');
+
+if (flagValue === 'example-variation-value') {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,26 @@
+---
+id: node-server-sdk/sdk-info/flagEval-json
+sdk: node-server-sdk
+kind: flag-eval
+lang: javascript
+file: node-server-sdk/flagEval-json.txt
+description: Flag evaluation example for node-server-sdk (JSON flag).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+---
+
+```javascript
+// Evaluate a context
+const context = {
+   "kind": 'user',
+   "key": 'user-key-123abc',
+   "name": 'Sandy',
+};
+
+client.on('ready', () => {
+  client.variation('featureKey', context, {}, function(err, flagValue) {
+    // Use the flag value to configure your feature
+    // TODO: Put your feature here
+  });
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,33 @@
+---
+id: node-server-sdk/sdk-info/flagEval-number
+sdk: node-server-sdk
+kind: flag-eval
+lang: javascript
+file: node-server-sdk/flagEval-number.txt
+description: Flag evaluation example for node-server-sdk (number flag).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+---
+
+```javascript
+// Evaluate a context
+const context = {
+   "kind": 'user',
+   "key": 'user-key-123abc',
+   "name": 'Sandy',
+};
+
+client.on('ready', () => {
+  client.variation('featureKey', context, 0, function(err, flagValue) {
+    if (flagValue === 1) {
+
+      // TODO: Put your feature here
+
+    } else {
+
+      // TODO: Put your fallback feature here
+
+    }
+  });
+});
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,33 @@
+---
+id: node-server-sdk/sdk-info/flagEval-string
+sdk: node-server-sdk
+kind: flag-eval
+lang: javascript
+file: node-server-sdk/flagEval-string.txt
+description: Flag evaluation example for node-server-sdk (string flag).
+validation:
+  scaffold: node-server-sdk/scaffolds/node-syntax-only
+---
+
+```javascript
+// Evaluate a context
+const context = {
+   "kind": 'user',
+   "key": 'user-key-123abc',
+   "name": 'Sandy',
+};
+
+client.on('ready', () => {
+  client.variation('featureKey', context, 'fallback-value', function(err, flagValue) {
+    if (flagValue === 'example-variation-value') {
+
+      // TODO: Put your feature here
+
+    } else {
+
+      // TODO: Put your fallback feature here
+
+    }
+  });
+});
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,21 @@
+---
+id: python-server-sdk/sdk-info/flagEval-json
+sdk: python-server-sdk
+kind: flag-eval
+lang: python
+file: python-server-sdk/flagEval-json.txt
+description: Flag evaluation example for python-server-sdk (JSON flag).
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+---
+
+```python
+from ldclient import Context
+
+# Create context using Context builder and use your own values here
+context = Context.builder("context-key-123abc").name("Sandy").build()
+flag_value = client.variation("featureKey", context, {})
+
+# Use the flag value to configure your feature
+# TODO: Put your feature here
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,23 @@
+---
+id: python-server-sdk/sdk-info/flagEval-number
+sdk: python-server-sdk
+kind: flag-eval
+lang: python
+file: python-server-sdk/flagEval-number.txt
+description: Flag evaluation example for python-server-sdk (number flag).
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+---
+
+```python
+from ldclient import Context
+
+# Create context using Context builder and use your own values here
+context = Context.builder("context-key-123abc").name("Sandy").build()
+flag_value = client.variation("featureKey", context, 0)
+
+if flag_value == 1:
+    pass  # TODO: Put your feature here
+else:
+    pass  # TODO: Put your fallback behavior here
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,23 @@
+---
+id: python-server-sdk/sdk-info/flagEval-string
+sdk: python-server-sdk
+kind: flag-eval
+lang: python
+file: python-server-sdk/flagEval-string.txt
+description: Flag evaluation example for python-server-sdk (string flag).
+validation:
+  scaffold: python-server-sdk/scaffolds/python-syntax-only
+---
+
+```python
+from ldclient import Context
+
+# Create context using Context builder and use your own values here
+context = Context.builder("context-key-123abc").name("Sandy").build()
+flag_value = client.variation("featureKey", context, "fallback-value")
+
+if flag_value == "example-variation-value":
+    pass  # TODO: Put your feature here
+else:
+    pass  # TODO: Put your fallback behavior here
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-json.snippet.md
@@ -1,0 +1,22 @@
+---
+id: react-client-sdk/sdk-info/flagEval-json
+sdk: react-client-sdk
+kind: flag-eval
+lang: javascript
+file: react-client-sdk/flagEval-json.txt
+description: Flag evaluation example for react-client-sdk (JSON flag).
+validation:
+  scaffold: react-client-sdk/scaffolds/flag-eval-runner
+  placeholders:
+    feature-key: LAUNCHDARKLY_FLAG_KEY
+---
+
+```javascript
+import { useJsonVariation } from '@launchdarkly/react-sdk';
+
+// useJsonVariation evaluates a JSON feature flag and returns its value.
+const flagValue = useJsonVariation('feature-key', {});
+
+// In your component, use the flag value to configure your feature
+// TODO: Put your feature here
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-number.snippet.md
@@ -1,0 +1,30 @@
+---
+id: react-client-sdk/sdk-info/flagEval-number
+sdk: react-client-sdk
+kind: flag-eval
+lang: javascript
+file: react-client-sdk/flagEval-number.txt
+description: Flag evaluation example for react-client-sdk (number flag).
+validation:
+  scaffold: react-client-sdk/scaffolds/flag-eval-runner
+  placeholders:
+    feature-key: LAUNCHDARKLY_FLAG_KEY
+---
+
+```javascript
+import { useNumberVariation } from '@launchdarkly/react-sdk';
+
+// useNumberVariation evaluates a number feature flag and returns its value.
+const flagValue = useNumberVariation('feature-key', 0);
+
+// In your component, compare the flag value against your variation values
+if (flagValue === 1) {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/flagEval-string.snippet.md
@@ -1,0 +1,30 @@
+---
+id: react-client-sdk/sdk-info/flagEval-string
+sdk: react-client-sdk
+kind: flag-eval
+lang: javascript
+file: react-client-sdk/flagEval-string.txt
+description: Flag evaluation example for react-client-sdk (string flag).
+validation:
+  scaffold: react-client-sdk/scaffolds/flag-eval-runner
+  placeholders:
+    feature-key: LAUNCHDARKLY_FLAG_KEY
+---
+
+```javascript
+import { useStringVariation } from '@launchdarkly/react-sdk';
+
+// useStringVariation evaluates a string feature flag and returns its value.
+const flagValue = useStringVariation('feature-key', 'fallback-value');
+
+// In your component, compare the flag value against your variation values
+if (flagValue === 'example-variation-value') {
+
+    // TODO: Put your feature here
+
+} else {
+
+    // TODO: Put your fallback behavior here
+
+}
+```

--- a/snippets/validators/languages/go/Dockerfile
+++ b/snippets/validators/languages/go/Dockerfile
@@ -1,6 +1,11 @@
 # Build context is `validators/`. See validators/languages/python/Dockerfile
 # for the rationale.
-FROM golang:1.24
+#
+# Track the go-server-sdk's stated minimum: v7.15.5 declares `go >= 1.25.0`.
+# The official golang images set GOTOOLCHAIN=local, so an under-spec base
+# does not silently self-upgrade -- `go mod tidy` fails outright with
+# "toolchain upgrade needed". Bump this when the SDK's minimum moves.
+FROM golang:1.25
 
 WORKDIR /work
 

--- a/snippets/validators/languages/go/harness/run.sh
+++ b/snippets/validators/languages/go/harness/run.sh
@@ -19,8 +19,18 @@ trap 'rm -rf "$WORK"' EXIT
 cp -r /snippet/. "$WORK/"
 cd "$WORK"
 
-go mod init example/hello-go >/dev/null 2>&1
-go mod tidy >/dev/null 2>&1
+# Keep module setup quiet on success, but surface the reason on failure.
+# Discarding stderr here hid every module-resolution error behind a bare
+# `exit status 1` from `set -e` -- no validator line, no snippet output, so
+# a transient proxy failure and a genuinely unresolvable import looked
+# identical from the CI log.
+MODLOG=$(mktemp)
+if ! go mod init example/hello-go >"$MODLOG" 2>&1; then
+    fail_with_log "$MODLOG" "go mod init failed"
+fi
+if ! go mod tidy >"$MODLOG" 2>&1; then
+    fail_with_log "$MODLOG" "go mod tidy failed to resolve the snippet's imports"
+fi
 
 LOG=$(mktemp)
 

--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -39,8 +39,12 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Go. Pinning here so the image is reproducible; bump when the
-# go-server-sdk's stated minimum moves.
-ENV GO_VERSION=1.24.3
+# go-server-sdk's stated minimum moves -- v7.15.5 declares `go >= 1.25.0`.
+# Unlike the `go` validator's official golang base (GOTOOLCHAIN=local), a
+# tarball install leaves GOTOOLCHAIN at its `auto` default, so an under-spec
+# pin here self-upgrades mid-run instead of failing. Keeping the pin at or
+# above the SDK minimum avoids paying for that download on every validate.
+ENV GO_VERSION=1.25.12
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
         -o /tmp/go.tgz \
  && tar -C /usr/local -xzf /tmp/go.tgz \

--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -7,9 +7,13 @@
 # body's leading token and runs the appropriate package manager. Image is
 # intentionally fat (~2 GB) — a CI-only artifact, cached per matrix cell
 # after the first build, so the size pays for itself quickly.
-FROM node:20-bookworm-slim
+# Node 22 (not 20): the fastly-server-sdk pulls `@napi-rs/lzma`, which
+# declares `engines.node: ^22.20 || ^24.12 || >=25`. yarn enforces engines
+# and hard-fails the install on Node 20. Staying on the 22 line keeps
+# corepack bundled (Node 25 drops it) so the pnpm/yarn pins below still work.
+FROM node:22-bookworm-slim
 
-# pnpm + yarn come via corepack (node 20 ships it). Python provides the
+# pnpm + yarn come via corepack (the 22 line ships it). Python provides the
 # pip path. Go provides `go get`. Ruby provides the `gem install` path
 # used by ruby-server-sdk install snippets.
 #
@@ -44,13 +48,12 @@ RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
 ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH
 ENV GOFLAGS=-mod=mod
 
-# Enable corepack-shipped package managers without prompting. Pin pnpm and
-# yarn to versions compatible with the Node 20 base above; without an
-# explicit pin, corepack auto-fetches `latest` on first invocation, and pnpm
-# 11+ requires Node 22.13+ (uses the `node:sqlite` builtin) which crashes
-# the harness with `ERR_UNKNOWN_BUILTIN_MODULE`. pnpm 9 is the last major
-# that supports Node 20; yarn 1 is the classic line that every install
-# snippet uses.
+# Enable corepack-shipped package managers without prompting. Pin both, or
+# corepack auto-fetches `latest` on first invocation and the image stops
+# being reproducible. pnpm 9 is kept for continuity — the Node 22 base would
+# also satisfy pnpm 11's `node:sqlite` requirement, so this pin is now a
+# deliberate hold rather than a floor. yarn 1 is the classic line that every
+# install snippet uses.
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable \
  && corepack prepare pnpm@9 --activate \


### PR DESCRIPTION
Unblocks the `Validate snippets` workflow. Both failures are upstream version drift in the shared validator images, independent of any snippet content — the validators resolve live upstream versions at validate time (`yarn add` hits the npm registry, `go mod tidy` hits the Go module proxy), so they rot on upstream's schedule. Any PR touching `snippets/**` was going red.

Split out of #549 so the fixes land on their own; #549 is now stacked on this branch.

## `shell-install`: Node 20 --> 22

`fastly-server-sdk/sdk-docs/install-the-sdk-yarn` failed:

```
error @napi-rs/lzma@1.5.1: The engine "node" is incompatible with this module.
      Expected version "^22.20 || ^24.12 || >=25". Got "20.20.2"
```

The Fastly SDK picked up a transitive dep requiring Node >= 22.20 and yarn enforces `engines`. Moved to the 22 line specifically rather than 24/25 — Node 25 drops bundled corepack, which the existing `pnpm@9` / `yarn@1` pins rely on.

## `go` validator: Go 1.24 --> 1.25

`go-server-sdk/sdk-info/init` failed:

```
go: toolchain upgrade needed to resolve github.com/launchdarkly/go-server-sdk/v7
go: go-server-sdk/v7@v7.15.5 requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

The SDK raised its floor to Go 1.25. The official `golang` images set `GOTOOLCHAIN=local`, so an under-spec base errors instead of self-upgrading.

`shell-install` pins Go from a tarball, which leaves `GOTOOLCHAIN` at its `auto` default — so its go-get install snippets kept *passing* on 1.24.3 by silently downloading a newer toolchain mid-run. Bumped that pin to 1.25.12 as well, to match the SDK minimum and skip the per-run download. Both Dockerfiles now record which behavior applies where, since that `local` vs `auto` difference is why only one of the two images failed.

## Diagnostics fix

The go harness ran `go mod init` / `go mod tidy` with stderr discarded, so under `set -e` any module-resolution failure exited 1 with **no validator line and no snippet output**. The first CI run was undiagnosable. Both now capture output and route failures through `fail_with_log` — that is what surfaced the `toolchain upgrade needed` message above.

## Verification

Neither Docker change is testable locally (no Docker in the authoring environment), so CI is the only check. The Node 22 bump is already confirmed: on the intermediate run, `fastly-server-sdk` went green and the tally moved 31/2 --> 33/1. The Go bump has not yet had a full green run.

Blast radius: `shell-install` backs install snippets for 17 SDKs. The other Node-20 images (`apex`, `edge-ts`, `edge-tsc`, `node`, `roku-client`) are parse/typecheck-only and never invoke a package manager, so they have no `lzma` exposure and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Validator image bumps affect install validation across many SDK matrix rows (live registry/module resolution); snippet additions are documentation with existing scaffolds and widen CI surface modestly.
> 
> **Overview**
> Unblocks **Validate snippets** by aligning shared validator images with upstream minimums: **`shell-install`** moves from Node 20 to **Node 22** (yarn `engines` on Fastly’s `@napi-rs/lzma` transitive), bumps the bundled **Go pin to 1.25.12**, and documents why Node 22 vs 25 and pnpm 9; the **`go`** validator base image goes **1.24 → 1.25** so `go mod tidy` against go-server-sdk v7.15.5 no longer fails with `toolchain upgrade needed` under `GOTOOLCHAIN=local`.
> 
> The **go harness** now routes **`go mod init` / `go mod tidy`** failures through **`fail_with_log`** instead of discarding stderr, so CI shows module-resolution errors instead of a bare exit 1.
> 
> Separately, adds **18 sdk-info snippets** (`flagEval-string`, `flagEval-number`, `flagEval-json` for six SDKs) so typed flag examples can replace gonfalon’s hand-maintained `typeAwareFlagEvalSnippets.ts`; each variant reuses the existing boolean **`validation.scaffold`**. **`CLAUDE.md`** and **`_sdk-info-port-notes.md`** record the Docker/toolchain rationale and the gonfalon follow-up (`extract.yaml`, delete drift test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e18eff5a51dda8fdaaafd6011d46d080c765dcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->