### PR TITLE
fix(snippets): add node-client-sdk v4 snippets

### DIFF
--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v4-javascript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v4-javascript.snippet.md
@@ -1,0 +1,36 @@
+---
+id: node-client-sdk/sdk-docs/initialize-the-client-node-js-sdk-v4-javascript
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: "Node.js SDK v4.x (JavaScript) in section \"Initialize the client\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+---
+
+```js
+import { createClient } from '@launchdarkly/node-client-sdk';
+
+// You'll need this context later, but you can ignore it for now.
+const context = {
+  kind: 'user',
+  key: 'example-user-key'
+};
+
+// Create client
+const client = createClient('example-client-side-id', context);
+
+// Then start the client
+client.start();
+
+const result = await client.waitForInitialization({ timeout: 5 });
+
+if (result.status === 'complete') {
+  // initialization succeeded, flag values are now available
+} else if (result.status === 'failed') {
+  // initialization failed
+  console.error('Initialization failed:', result.error);
+} else if (result.status === 'timeout') {
+  // initialization did not complete before the timeout
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v4-typescript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-node-js-sdk-v4-typescript.snippet.md
@@ -1,0 +1,36 @@
+---
+id: node-client-sdk/sdk-docs/initialize-the-client-node-js-sdk-v4-typescript
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: "Node.js SDK v4.x (TypeScript) in section \"Initialize the client\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+---
+
+```ts
+import { createClient, LDContext } from '@launchdarkly/node-client-sdk';
+
+// You'll need this context later, but you can ignore it for now.
+const context: LDContext = {
+  kind: 'user',
+  key: 'example-user-key'
+};
+
+// Create client
+const client = createClient('example-client-side-id', context);
+
+// Then start the client
+client.start();
+
+const result = await client.waitForInitialization({ timeout: 5 });
+
+if (result.status === 'complete') {
+  // initialization succeeded, flag values are now available
+} else if (result.status === 'failed') {
+  // initialization failed
+  console.error('Initialization failed:', result.error);
+} else if (result.status === 'timeout') {
+  // initialization did not complete before the timeout
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-v4-javascript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-v4-javascript.snippet.md
@@ -1,0 +1,20 @@
+---
+id: node-client-sdk/sdk-docs/initialize-the-client-v4-javascript
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: "JavaScript, Node.js SDK v4.x in section \"Initialize the client\" (event listeners)"
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+---
+
+```js
+client.on('ready', () => {
+  // The client has finished starting up, whether or not it succeeded
+});
+client.on('initialized', () => {
+  // Initialization succeeded, flag values are now available
+  const flagValue = client.variation('example-flag-key', false);
+  // etc.
+});
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-v4-typescript.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/initialize-the-client-v4-typescript.snippet.md
@@ -1,0 +1,25 @@
+---
+id: node-client-sdk/sdk-docs/initialize-the-client-v4-typescript
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: "TypeScript, Node.js SDK v4.x in section \"Initialize the client\" (event listeners)"
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+---
+
+```ts
+client.on('ready', () => {
+  // The client has finished starting up, whether or not it succeeded
+});
+client.on('initialized', () => {
+  // Initialization succeeded, flag values are now available
+  const boolFlagValue = client.variation('example-flag-key', false) as boolean;
+  const numberFlagValue = client.variation('example-flag-key', 2) as number;
+  const stringFlagValue = client.variation('example-flag-key', 'default') as string;
+  // etc.
+});
+client.on('error', (context, err) => {
+  // An error occurred, which may include an initialization failure
+});
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-javascript-v4.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-javascript-v4.snippet.md
@@ -1,0 +1,13 @@
+---
+id: node-client-sdk/sdk-docs/install-the-sdk-javascript-v4
+sdk: node-client-sdk
+kind: reference
+lang: javascript
+description: "JavaScript, Node.js SDK v4.x in section \"Install the SDK\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+---
+
+```js
+import { createClient } from '@launchdarkly/node-client-sdk';
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-typescript-v4.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-docs/install-the-sdk-typescript-v4.snippet.md
@@ -1,0 +1,13 @@
+---
+id: node-client-sdk/sdk-docs/install-the-sdk-typescript-v4
+sdk: node-client-sdk
+kind: reference
+lang: typescript
+description: "TypeScript, Node.js SDK v4.x in section \"Install the SDK\""
+validation:
+  scaffold: node-client-sdk/scaffolds/node-client-syntax-only
+---
+
+```ts
+import { createClient } from '@launchdarkly/node-client-sdk';
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only snippet additions with no runtime or application code changes.
> 
> **Overview**
> Adds **six new validated doc snippets** for the Node.js client SDK **v4.x**, mirroring the existing v3 install/initialize split for JavaScript and TypeScript.
> 
> The **install** snippets show importing `createClient` from `@launchdarkly/node-client-sdk`. The **initialize** snippets document the v4 flow: `createClient` with context, **`client.start()`**, then **`waitForInitialization({ timeout: 5 })`** with `complete` / `failed` / `timeout` handling. Separate **event-listener** snippets cover `ready`, `initialized`, and (TypeScript) `error`, including typed `variation` examples.
> 
> All fragments use the existing `node-client-syntax-only` validation scaffold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3510a975502e355872d5104e33bd4241298e27c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->