### PR TITLE
fix: update node-client-sdk metadata metadata

### DIFF
--- a/backfill/launchdarkly_node-client-sdk.json
+++ b/backfill/launchdarkly_node-client-sdk.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "sdks": {
+    "node-client-sdk": {
+      "releases": {
+        "tag-prefix": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single new JSON backfill config with no application code, auth, or data-path changes.
> 
> **Overview**
> Adds **`backfill/launchdarkly_node-client-sdk.json`** so metadata crawl/backfill can ingest releases from `launchdarkly/node-client-sdk` with an explicit empty **`tag-prefix`** under `releases` (version 1 SDK metadata shape).
> 
> This follows the same backfill pattern used for other LaunchDarkly SDK repos and only affects how historical or unprefixed release tags are read for that SDK—not runtime snippet or API behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce7e51c51a36363417e9222a7a7fb0e9ad1d23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->