### PR TITLE
feat(snippets): Add C++ server-side DynamoDB and Big Segments snippets

### DIFF
--- a/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only-dynamodb.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only-dynamodb.snippet.md
@@ -1,0 +1,82 @@
+---
+id: cpp-server-sdk/scaffolds/cpp-syntax-only-dynamodb
+sdk: cpp-server-sdk
+kind: scaffold
+lang: cpp
+file: main.cpp
+description: |
+  Parse-only validator for C++ server SDK doc fragments that reference
+  the DynamoDB integration -- both the Lazy Load persistent store
+  (`DynamoDBDataSource`) and the Big Segments store
+  (`DynamoDBBigSegmentStore`).
+
+  Same shape as `cpp-syntax-only-redis`, with one difference in how the
+  build is wired. The DynamoDB source library links the AWS C++ SDK,
+  which is fetched from source and is too heavy to build in CI. But its
+  public headers are AWS-clean (they pull in no AWS headers), and the
+  wrappee below is a never-instantiated template, so no DynamoDB or AWS
+  symbols are ever ODR-used. The cpp-server Dockerfile therefore puts
+  the DynamoDB source library's `include/` directory on the compile
+  path without enabling `LD_BUILD_DYNAMODB_SUPPORT` -- the fragment's
+  API calls type-check against the real headers with no AWS SDK build
+  and no link. No `CPP_*` env flag is set: these fragments compile in
+  the default project alongside the other `cpp-syntax-only` snippets.
+inputs:
+  body:
+    type: string
+    description: The wrappee snippet's rendered body, inserted into the parse-only harness.
+validation:
+  runtime: cpp-server
+  entrypoint: main.cpp
+---
+
+```cpp
+#include <chrono>
+#include <cstdio>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+// Native C++ headers.
+#include <launchdarkly/server_side/client.hpp>
+#include <launchdarkly/server_side/config/config_builder.hpp>
+#include <launchdarkly/context_builder.hpp>
+#include <launchdarkly/value.hpp>
+// C-binding headers — doc fragments mix C-binding and native styles.
+#include <launchdarkly/server_side/bindings/c/sdk.h>
+#include <launchdarkly/server_side/bindings/c/config/builder.h>
+#include <launchdarkly/bindings/c/context.h>
+#include <launchdarkly/bindings/c/context_builder.h>
+// DynamoDB source + Big Segments store headers (native + C binding),
+// plus the core Big Segments builder the store is handed to. Bodies
+// that #include these themselves hit the include guard and stay
+// verbatim.
+#include <launchdarkly/server_side/integrations/dynamodb/dynamodb_source.hpp>
+#include <launchdarkly/server_side/bindings/c/integrations/dynamodb/dynamodb_source.h>
+#include <launchdarkly/server_side/integrations/dynamodb/dynamodb_big_segment_store.hpp>
+#include <launchdarkly/server_side/bindings/c/integrations/dynamodb/dynamodb_big_segment_store.h>
+#include <launchdarkly/server_side/config/builders/big_segments_builder.hpp>
+#include <launchdarkly/server_side/bindings/c/config/big_segments_builder/big_segments_builder.h>
+
+// Wrappee is a never-instantiated template — body is parsed but
+// most type-checks are deferred to instantiation (which never
+// happens). The body lives in a nested block so it can re-declare
+// names the scaffold stubs. As in cpp-syntax-only-redis, no
+// namespaces are lifted here: the native DynamoDB fragment carries
+// its own `using namespace launchdarkly::server_side;`. Init-shaped
+// fragments pass an `sdk_key` the docs assume already exists.
+template <int = 0>
+void _wrappee() {
+    char const* sdk_key = "";
+    (void)sdk_key;
+    {
+{{ body }}
+    }
+}
+
+int main() {
+    std::cout << "feature flag evaluates to true" << std::endl;
+    return 0;
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only-redis.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/scaffolds/cpp-syntax-only-redis.snippet.md
@@ -6,15 +6,18 @@ lang: cpp
 file: main.cpp
 description: |
   Parse-only validator for C++ server SDK doc fragments that reference
-  the Redis integration (`launchdarkly::server_redis_source`).
+  the Redis integration (`launchdarkly::server_redis_source`) -- both
+  the Lazy Load persistent store (`RedisDataSource`) and the Big
+  Segments store (`RedisBigSegmentStore`).
 
   Same shape as `cpp-syntax-only`, with two additions:
 
-  - The Redis source headers (native + C binding) are pre-included at
-    file scope. Doc fragments carry their own `#include` of
-    `redis_source.hpp` inside the wrappee body; the header's include
-    guard makes that inner include a no-op, so the body stays verbatim
-    while the declarations land at file scope where they belong.
+  - The Redis integration headers (native + C binding) are pre-included
+    at file scope: the Lazy Load source, the Big Segments store, and the
+    core Big Segments builder. Doc fragments carry their own `#include`
+    inside the wrappee body; the headers' include guards make those
+    inner includes a no-op, so the body stays verbatim while the
+    declarations land at file scope where they belong.
   - `validation.env` sets `CPP_REDIS=1`, which tells the cpp-server
     harness to configure cpp-sdks with `-DLD_BUILD_REDIS_SUPPORT=ON`
     and link `launchdarkly::server_redis_source`.
@@ -50,6 +53,13 @@ validation:
 // native header themselves hit the include guard and stay verbatim.
 #include <launchdarkly/server_side/integrations/redis/redis_source.hpp>
 #include <launchdarkly/server_side/bindings/c/integrations/redis/redis_source.h>
+// Redis Big Segments store headers (native + C binding) plus the core
+// Big Segments builder the store is handed to. Same include-guard
+// reasoning as the source headers above.
+#include <launchdarkly/server_side/integrations/redis/redis_big_segment_store.hpp>
+#include <launchdarkly/server_side/bindings/c/integrations/redis/redis_big_segment_store.h>
+#include <launchdarkly/server_side/config/builders/big_segments_builder.hpp>
+#include <launchdarkly/server_side/bindings/c/config/big_segments_builder/big_segments_builder.h>
 
 // Wrappee is a never-instantiated template — body is parsed but
 // most type-checks are deferred to instantiation (which never

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-dynamodb-v3-c.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-dynamodb-v3-c.snippet.md
@@ -1,0 +1,46 @@
+---
+id: cpp-server-sdk/sdk-docs/features/bigsegments/big-segments-dynamodb-v3-c
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Big Segments DynamoDB store configuration example for C++ (server-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-dynamodb
+
+---
+
+```c
+// Stack allocate the result struct, which will hold the store pointer or
+// an error message.
+struct LDServerBigSegmentsDynamoDBResult result;
+
+// Create the DynamoDB Big Segments store, passing in the table name, key
+// prefix, client options (NULL for the default AWS region and
+// credentials), and a pointer to the result.
+if (!LDServerBigSegmentsDynamoDBStore_New("my-table", "my-key-prefix", NULL,
+                                          &result)) {
+    // DynamoDB config is invalid, cannot proceed.
+    // Error message is stored in result.error_message.
+}
+
+// Create a Big Segments builder from the store pointer.
+LDServerBigSegmentsBuilder bs_builder =
+    LDServerBigSegmentsBuilder_New((LDServerBigSegmentStorePtr)result.store);
+
+LDServerBigSegmentsBuilder_ContextCacheSize(bs_builder, 2000);
+LDServerBigSegmentsBuilder_ContextCacheTimeMs(bs_builder, 30000);
+
+// Create a standard server-side SDK configuration builder.
+LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+
+// Tell the SDK config builder to use the Big Segments store that was just
+// configured.
+LDServerConfigBuilder_BigSegments(cfg_builder, bs_builder);
+
+LDServerConfig config;
+LDStatus status = LDServerConfigBuilder_Build(cfg_builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    // an error occurred, config is not valid
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-dynamodb-v3.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-dynamodb-v3.snippet.md
@@ -1,0 +1,36 @@
+---
+id: cpp-server-sdk/sdk-docs/features/bigsegments/big-segments-dynamodb-v3
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Big Segments DynamoDB store configuration example for C++ (server-side) SDK v3.0 (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-dynamodb
+
+---
+
+```cpp
+// Make sure to include the DynamoDB Big Segments store's header.
+#include <launchdarkly/server_side/integrations/dynamodb/dynamodb_big_segment_store.hpp>
+
+using namespace launchdarkly::server_side;
+
+ConfigBuilder config_builder(sdk_key);
+
+auto dynamodb_store = integrations::DynamoDBBigSegmentStore::Create("my-table", "my-key-prefix");
+
+if (!dynamodb_store) {
+    /* dynamodb config is invalid, cannot proceed */
+}
+
+config_builder.BigSegments(
+    config::builders::BigSegmentsBuilder(std::move(*dynamodb_store))
+        .ContextCacheSize(2000)
+        .ContextCacheTime(std::chrono::seconds(30))
+);
+
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-redis-v3-c.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-redis-v3-c.snippet.md
@@ -1,0 +1,45 @@
+---
+id: cpp-server-sdk/sdk-docs/features/bigsegments/big-segments-redis-v3-c
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: Big Segments Redis store configuration example for C++ (server-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-redis
+
+---
+
+```c
+// Stack allocate the result struct, which will hold the store pointer or
+// an error message.
+struct LDServerBigSegmentsRedisResult result;
+
+// Create the Redis Big Segments store, passing in arguments for the URI,
+// prefix, and pointer to the result.
+if (!LDServerBigSegmentsRedisStore_New("redis://localhost:6379", "my-key-prefix",
+                                       &result)) {
+    // Redis config is invalid, cannot proceed.
+    // Error message is stored in result.error_message.
+}
+
+// Create a Big Segments builder from the store pointer.
+LDServerBigSegmentsBuilder bs_builder =
+    LDServerBigSegmentsBuilder_New((LDServerBigSegmentStorePtr)result.store);
+
+LDServerBigSegmentsBuilder_ContextCacheSize(bs_builder, 2000);
+LDServerBigSegmentsBuilder_ContextCacheTimeMs(bs_builder, 30000);
+
+// Create a standard server-side SDK configuration builder.
+LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+
+// Tell the SDK config builder to use the Big Segments store that was just
+// configured.
+LDServerConfigBuilder_BigSegments(cfg_builder, bs_builder);
+
+LDServerConfig config;
+LDStatus status = LDServerConfigBuilder_Build(cfg_builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    // an error occurred, config is not valid
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-redis-v3.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/bigsegments/big-segments-redis-v3.snippet.md
@@ -1,0 +1,36 @@
+---
+id: cpp-server-sdk/sdk-docs/features/bigsegments/big-segments-redis-v3
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: Big Segments Redis store configuration example for C++ (server-side) SDK v3.0 (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-redis
+
+---
+
+```cpp
+// Make sure to include the Redis Big Segments store's header.
+#include <launchdarkly/server_side/integrations/redis/redis_big_segment_store.hpp>
+
+using namespace launchdarkly::server_side;
+
+ConfigBuilder config_builder(sdk_key);
+
+auto redis_store = integrations::RedisBigSegmentStore::Create("redis://localhost:6379", "my-key-prefix");
+
+if (!redis_store) {
+    /* redis config is invalid, cannot proceed */
+}
+
+config_builder.BigSegments(
+    config::builders::BigSegmentsBuilder(std::move(*redis_store))
+        .ContextCacheSize(2000)
+        .ContextCacheTime(std::chrono::seconds(30))
+);
+
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/storing-data/dynamodb/dynamodb-v3-c.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/storing-data/dynamodb/dynamodb-v3-c.snippet.md
@@ -1,0 +1,46 @@
+---
+id: cpp-server-sdk/sdk-docs/features/storing-data/dynamodb/dynamodb-v3-c
+sdk: cpp-server-sdk
+kind: reference
+lang: c
+description: DynamoDB source configuration example for C++ (server-side) SDK v3.0 (C binding).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-dynamodb
+
+---
+
+```c
+// Stack allocate the result struct, which will hold the result pointer or
+// an error message.
+struct LDServerLazyLoadDynamoDBResult result;
+
+// Create the DynamoDB source, passing in the table name, key prefix,
+// client options (NULL for the default AWS region and credentials), and
+// a pointer to the result.
+if (!LDServerLazyLoadDynamoDBSource_New("my-table", "my-key-prefix", NULL,
+                                        &result)) {
+    // DynamoDB config is invalid, cannot proceed.
+    // Error message is stored in result.error_message.
+}
+
+// Create a builder for the Lazy Load data system.
+LDServerLazyLoadBuilder lazy_builder = LDServerLazyLoadBuilder_New();
+
+// Pass the DynamoDB source pointer into it.
+LDServerLazyLoadBuilder_SourcePtr(lazy_builder,
+                                  (LDServerLazyLoadSourcePtr)result.source);
+
+// Create a standard server-side SDK configuration builder.
+LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("YOUR_SDK_KEY");
+
+// Tell the SDK config builder to use the Lazy Load system that was just
+// configured.
+LDServerConfigBuilder_DataSystem_LazyLoad(cfg_builder, lazy_builder);
+
+LDServerConfig config;
+LDStatus status = LDServerConfigBuilder_Build(cfg_builder, &config);
+
+if (!LDStatus_Ok(status)) {
+    // an error occurred, config is not valid
+}
+```

--- a/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/storing-data/dynamodb/dynamodb-v3.snippet.md
+++ b/snippets/sdks/cpp-server-sdk/snippets/sdk-docs/features/storing-data/dynamodb/dynamodb-v3.snippet.md
@@ -1,0 +1,36 @@
+---
+id: cpp-server-sdk/sdk-docs/features/storing-data/dynamodb/dynamodb-v3
+sdk: cpp-server-sdk
+kind: reference
+lang: cpp
+description: DynamoDB source configuration example for C++ (server-side) SDK v3.0 (native).
+validation:
+  scaffold: cpp-server-sdk/scaffolds/cpp-syntax-only-dynamodb
+
+---
+
+```cpp
+// Make sure to include the DynamoDB source's header.
+#include <launchdarkly/server_side/integrations/dynamodb/dynamodb_source.hpp>
+
+using namespace launchdarkly::server_side;
+
+using LazyLoad = config::builders::LazyLoadBuilder;
+
+ConfigBuilder config_builder(sdk_key);
+
+auto dynamodb_source = integrations::DynamoDBDataSource::Create("my-table", "my-key-prefix");
+
+if (!dynamodb_source) {
+    /* dynamodb config is invalid, cannot proceed */
+}
+
+config_builder.DataSystem().Method(
+    LazyLoad().Source(std::move(*dynamodb_source)).CacheRefresh(std::chrono::seconds(15))
+);
+
+auto config = config_builder.Build();
+if (!config) {
+    /* an error occurred, config is not valid */
+}
+```

--- a/snippets/validators/languages/cpp-server/Dockerfile
+++ b/snippets/validators/languages/cpp-server/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH="/usr/lib/ccache:${PATH}"
 # Pre-clone cpp-sdks. The snippet's CMakeLists references this via
 # `add_subdirectory(cpp-sdks)` from the project root, so we symlink it
 # into the project dir at build time rather than committing the tree.
-ARG CPP_SDKS_REF=launchdarkly-cpp-server-v3.10.1
+ARG CPP_SDKS_REF=launchdarkly-cpp-server-v3.13.1
 RUN git clone --depth 1 --branch "${CPP_SDKS_REF}" \
         https://github.com/launchdarkly/cpp-sdks.git /opt/cpp-sdks
 
@@ -30,6 +30,13 @@ RUN git clone --depth 1 --branch "${CPP_SDKS_REF}" \
 # fragments. Both share one CMakeLists that links the redis source library
 # only when LD_BUILD_REDIS_SUPPORT is set, so the variant is selected purely
 # by the configure-time -D flag.
+#
+# DynamoDB fragments need no third variant. The DynamoDB source library's
+# public headers are AWS-clean, and the fragment bodies live in a
+# never-instantiated template, so no DynamoDB or AWS symbols are ODR-used.
+# Both projects put the library's include dir on the compile path (see the
+# CMakeLists below) WITHOUT LD_BUILD_DYNAMODB_SUPPORT -- which would
+# otherwise FetchContent-build the (very heavy) AWS C++ SDK from source.
 RUN for proj in /opt/hello-cpp /opt/hello-cpp-redis; do \
         mkdir -p "$proj" && cd "$proj" && ln -s /opt/cpp-sdks cpp-sdks && \
         printf '%s\n' \
@@ -46,6 +53,7 @@ RUN for proj in /opt/hello-cpp /opt/hello-cpp-redis; do \
             '  set(LD_EXTRA_LIBS launchdarkly::server_redis_source)' \
             'endif()' \
             'target_link_libraries(hello PRIVATE launchdarkly::server ${LD_EXTRA_LIBS} Threads::Threads)' \
+            'target_include_directories(hello PRIVATE cpp-sdks/libs/server-sdk-dynamodb-source/include)' \
             > CMakeLists.txt && \
         printf 'int main() { return 0; }\n' > main.cpp; \
     done && \


### PR DESCRIPTION
## Summary

Adds `.snippet.md` files for the C++ (server-side) SDK's newly shipped DynamoDB persistent store and Big Segments features, for the docs site.

Six new snippets -- native C++ API and C-binding variant for each:

- DynamoDB persistent store (Lazy Load source), mirroring the existing Redis source snippets.
- Big Segments with a Redis store.
- Big Segments with a DynamoDB store.

### Validation

- All six compile end-to-end against the real cpp-sdks headers through the parse-only `cpp-server` validator.
- The DynamoDB fragments compile-check against the source library's AWS-clean public headers, so `LD_BUILD_DYNAMODB_SUPPORT` stays off and the (very heavy) AWS C++ SDK never has to build.
- Bumps the validator's cpp-sdks pin `v3.10.1 -> v3.13.1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **six** new C++ server SDK doc snippets (native and C binding) for **DynamoDB Lazy Load** persistent store, **DynamoDB Big Segments**, and **Redis Big Segments**, aligned with existing Redis Lazy Load examples.
> 
> Introduces a new **`cpp-syntax-only-dynamodb`** parse-only scaffold and extends **`cpp-syntax-only-redis`** with Big Segments store and builder headers so fragments stay verbatim while CI type-checks against real headers.
> 
> Updates the **cpp-server validator Dockerfile**: pins **cpp-sdks** from **v3.10.1** to **v3.13.1**, documents why DynamoDB needs no third CMake variant, and adds the DynamoDB source **`include/`** path on both pre-baked projects **without** `LD_BUILD_DYNAMODB_SUPPORT` so the AWS C++ SDK is never built in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c823cfbb2f100186efba5c2388db61ecc2789f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->