### PR TITLE
ci(snippets): retry toolchain downloads in shell-install validator image

### DIFF
--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -70,10 +70,8 @@ RUN corepack enable \
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
-RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 https://sh.rustup.rs \
-        -o /tmp/rustup-init.sh \
- && sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal --no-modify-path \
- && rm /tmp/rustup-init.sh
+RUN curl -fsSL https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
 
 # PHP + composer.phar for `php composer.phar require …` install snippets.
 # composer.phar lands at /opt/composer.phar; the harness symlinks it into

--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -70,8 +70,10 @@ RUN corepack enable \
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
-RUN curl -fsSL https://sh.rustup.rs \
-        | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 https://sh.rustup.rs \
+        -o /tmp/rustup-init.sh \
+ && sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal --no-modify-path \
+ && rm /tmp/rustup-init.sh
 
 # PHP + composer.phar for `php composer.phar require …` install snippets.
 # composer.phar lands at /opt/composer.phar; the harness symlinks it into

--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -71,7 +71,9 @@ ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
 RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 https://sh.rustup.rs \
-        | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+        -o /tmp/rustup-init.sh \
+ && sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal --no-modify-path \
+ && rm /tmp/rustup-init.sh
 
 # PHP + composer.phar for `php composer.phar require …` install snippets.
 # composer.phar lands at /opt/composer.phar; the harness symlinks it into

--- a/snippets/validators/languages/shell-install/Dockerfile
+++ b/snippets/validators/languages/shell-install/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update \
 # pin here self-upgrades mid-run instead of failing. Keeping the pin at or
 # above the SDK minimum avoids paying for that download on every validate.
 ENV GO_VERSION=1.25.12
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+        "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
         -o /tmp/go.tgz \
  && tar -C /usr/local -xzf /tmp/go.tgz \
  && rm /tmp/go.tgz
@@ -69,7 +70,7 @@ RUN corepack enable \
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
-RUN curl -fsSL https://sh.rustup.rs \
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
 
 # PHP + composer.phar for `php composer.phar require …` install snippets.
@@ -84,12 +85,14 @@ RUN apt-get update \
         php-mbstring \
         unzip \
  && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://getcomposer.org/download/latest-stable/composer.phar -o /opt/composer.phar \
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+        https://getcomposer.org/download/latest-stable/composer.phar -o /opt/composer.phar \
  && chmod +x /opt/composer.phar
 
 # .NET SDK for `dotnet add package` install snippets. The Microsoft apt
 # feed serves a .deb that wires up the package source for us.
-RUN curl -fsSL https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+        https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
         -o /tmp/packages-microsoft-prod.deb \
  && dpkg -i /tmp/packages-microsoft-prod.deb \
  && rm /tmp/packages-microsoft-prod.deb \
@@ -105,7 +108,8 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends openjdk-17-jdk-headless \
  && rm -rf /var/lib/apt/lists/*
 ENV GRADLE_VERSION=8.10.2
-RUN curl -fsSL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+        "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
         -o /tmp/gradle.zip \
  && unzip -q /tmp/gradle.zip -d /opt \
  && ln -s "/opt/gradle-${GRADLE_VERSION}/bin/gradle" /usr/local/bin/gradle \


### PR DESCRIPTION
## Summary

The `shell-install` validator image build fetches five toolchains with bare `curl -fsSL`, so a single transient upstream hiccup fails the whole matrix cell. Two examples within ten minutes today, both on the gradle download:

- PR #560 (`dotnet-server-sdk`): `curl: (56) Connection died, tried 5 times before giving up`
- PR #562 (`cloudflare-server-sdk (sdk-docs)`): `curl: (22) The requested URL returned error: 503`

Adds `--retry 5 --retry-all-errors --retry-delay 5` to each download (Go tarball, rustup, composer.phar, `packages-microsoft-prod.deb`, gradle zip), matching the hardening already present in `languages/android-client/Dockerfile`. `--retry-all-errors` is what covers the 503 case — plain `--retry` only retries a subset of transient failures.

Note for a possible follow-up (not changed here): when the validate step fails, its output is invisible in the job log — `snippets-validate.yml` runs it as `output=$(… | tee /tmp/validate.log)` under `bash -e`, so the shell aborts before the `echo $output` branch runs. The failure detail is only recoverable from the uploaded `result-<sdk>` artifact.


Link to Devin session: https://app.devin.ai/sessions/d295f24bf24749ed89b7e110fcedd399
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Hardens the **shell-install** validator Docker image so CI image builds survive transient upstream failures during toolchain downloads.
> 
> All five `curl -fsSL` fetches (Go tarball, rustup installer, composer.phar, Microsoft packages deb, Gradle zip) now use **`--retry 5 --retry-all-errors --retry-delay 5`**, aligned with the android-client image pattern. **`--retry-all-errors`** is the important bit for HTTP 503s that plain `--retry` would not retry.
> 
> The rustup step no longer pipes curl directly into `sh`; it downloads **`rustup-init.sh`** to `/tmp`, runs it, then deletes it—same retry behavior on that download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd942314a58e23664c92697f7d7be0a085a2c819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->