### PR TITLE
fix(snippets): Remove polling initializer recommendation from relay proxy fallback

### DIFF
--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
@@ -18,11 +18,6 @@ var relayEndpoints = Components.ServiceEndpoints().RelayProxy(relayUri);
 var config = Configuration.Builder("YOUR_SDK_KEY")
     .DataSystem(
         Components.DataSystem().Custom()
-            .Initializers(
-                DataSystemComponents.Polling()
-                    .ServiceEndpointsOverride(relayEndpoints),
-                DataSystemComponents.Polling()
-            )
             .Synchronizers(
                 DataSystemComponents.Streaming()
                     .ServiceEndpointsOverride(relayEndpoints),

--- a/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
@@ -19,10 +19,6 @@ var config ld.Config
 relayURI := "http://my-relay-proxy:8030"
 
 config.DataSystem = ldcomponents.DataSystem().Custom().
-    Initializers(
-        ldcomponents.PollingDataSourceV2().BaseURI(relayURI).AsInitializer(),
-        ldcomponents.PollingDataSourceV2().AsInitializer(),
-    ).
     Synchronizers(
         ldcomponents.StreamingDataSourceV2().BaseURI(relayURI),
         ldcomponents.StreamingDataSourceV2(),

--- a/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
@@ -20,11 +20,6 @@ ServiceEndpointsBuilder relayEndpoints = Components.serviceEndpoints().relayProx
 LDConfig config = new LDConfig.Builder()
     .dataSystem(
         Components.dataSystem().custom()
-            .initializers(
-                DataSystemComponents.pollingInitializer()
-                    .serviceEndpointsOverride(relayEndpoints),
-                DataSystemComponents.pollingInitializer()
-            )
             .synchronizers(
                 DataSystemComponents.streamingSynchronizer()
                     .serviceEndpointsOverride(relayEndpoints),

--- a/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
@@ -19,10 +19,6 @@ ldclient.set_config(
     Config(
         "YOUR_SDK_KEY",
         datasystem_config=datasystem.custom()
-            .initializers([
-                datasystem.polling_ds_builder().base_uri(relay_uri),
-                datasystem.polling_ds_builder(),
-            ])
             .synchronizers(
                 datasystem.streaming_ds_builder().base_uri(relay_uri),
                 datasystem.streaming_ds_builder(),

--- a/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
+++ b/snippets/sdks/ruby-server-sdk/snippets/sdk-docs/features/datasaving/relay-proxy-fallback.snippet.md
@@ -15,10 +15,6 @@ relay_uri = "http://my-relay-proxy:8030"
 
 config = LaunchDarkly::Config.new(
   data_system_config: LaunchDarkly::DataSystem.custom
-    .initializers([
-      LaunchDarkly::DataSystem.polling_ds_builder.base_uri(relay_uri),
-      LaunchDarkly::DataSystem.polling_ds_builder,
-    ])
     .synchronizers([
       LaunchDarkly::DataSystem.streaming_ds_builder.base_uri(relay_uri),
       LaunchDarkly::DataSystem.streaming_ds_builder,


### PR DESCRIPTION
The relay-proxy-fallback data saving snippets recommended a pair of polling
initializers alongside the streaming synchronizers. That recommendation is
removed, so these configurations rely on the synchronizers alone.

This covers all five SDKs that document a "Relay proxy with LaunchDarkly API
fallback" configuration: .NET, Go, Java, Python, and Ruby. node-server-sdk has
no relay-proxy-fallback snippet, so it is unaffected.

The remaining DataSystem().Custom().Synchronizers(...) chain stays valid in
every language. The file-bootstrap snippets keep their file initializers, which
the docs prose describes separately.

These snippets are the canonical source rendered into ld-docs-private at
fern/topics/sdk/features/data-saving-mode.mdx, so the change has to land here.
Editing that MDX directly is reverted by the daily sync-ld-docs-snippets
workflow, and nothing in the docs repo flags the drift. Rendering a pristine
copy of that page through these snippets reproduces the intended change exactly
and refreshes the five marker hashes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates the **Relay proxy with LaunchDarkly API fallback** data-saving snippets for .NET, Go, Java, Python, and Ruby so they no longer configure **polling initializers** (relay + default API). Those examples now rely only on the **synchronizer** chain: streaming against the relay, streaming against LaunchDarkly, then polling as fallback.
> 
> This is documentation-only in the snippets repo; rendered docs in `ld-docs-private` pick up the change via the normal snippet sync. **node-server-sdk** has no matching snippet and is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc35a7154ccb0eb372fb80ac297c4a06135b11e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->