### PR TITLE
fix(snippets): use withReasons in js-client-sdk v4 evaluation reasons snippet

### DIFF
--- a/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4.snippet.md
@@ -10,7 +10,7 @@ validation:
 ---
 
 ```typescript
-const options = { evaluationReasons: true };
+const options = { withReasons: true };
 const client = createClient('example-client-side-id', context, options);
 client.start();
 


### PR DESCRIPTION
## Summary

The JS client SDK v4 evaluation-reasons snippet used the v3 option name, so the documented sample silently produced no evaluation reasons.

```diff
-const options = { evaluationReasons: true };
+const options = { withReasons: true };
```

- v4 (js-core browser SDK) exposes `withReasons` on `LDOptions` (`packages/shared/sdk-client/src/api/LDOptions.ts`); `evaluationReasons` is not recognized.
- Only `evaluation-reasons-v4` changed; the v3 snippet correctly keeps `evaluationReasons`.
- Reported via #ask-sdks; picked up downstream in ld-docs-private `fern/topics/sdk/features/evaluation-reasons.mdx` by the nightly snippet sync.

<details>
<summary>Implementation details</summary>

Verified against launchdarkly/js-core `main`: `Configuration`, `validators.ts`, and the data-source query-param builders all key off `withReasons`.

Validated locally:

```
snippets validate -sdk js-client-sdk -snippet js-client-sdk/sdk-docs/features/evaluation-reasons/evaluation-reasons-v4
=> validator: ok
```

</details>


Link to Devin session: https://app.devin.ai/sessions/f458f9869508476a87caf8f18947f6d0
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates the **JS client SDK v4** evaluation-reasons doc snippet so the client options use **`withReasons: true`** instead of the v3 name **`evaluationReasons`**, which v4 does not recognize and would leave readers without evaluation reasons in `variationDetail` results.
> 
> The v3 snippet is unchanged and still documents **`evaluationReasons`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb08a40d02fe9959a9995548649f5b2dc413f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->