### PR TITLE
chore(ci): add 3 day npm quarantine window to api-js installs

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 24.x
         registry-url: 'https://registry.npmjs.org'
 
     - name: Build JS API

--- a/api-js/.npmrc
+++ b/api-js/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
Adds a 3-day supply-chain quarantine window to this repo's npm installs, matching js-core's Yarn 4 gate (`npmMinimalAgeGate: 4320`, launchdarkly/js-core#1390).

- `api-js/.npmrc` sets `min-release-age=3` (days) — npm's equivalent of the yarn gate.
- CI action's Node bumps 20.x → 24.x: `min-release-age` needs npm ≥ 11.6, and Node 20 ships npm 10, which would silently ignore it.
- `snippets/validators/*` are intentionally left ungated — they install just-published SDK versions in order to validate them.

<details>
<summary>Implementation details</summary>

npm flattens `min-release-age` into a `before` cutoff at install time; verified locally that `npm config ls -l` inside `api-js` reports `before = "<now - 3 days>"`, so any version published in the last 3 days is not installed. `min-release-age-exclude` is available if a specific package ever needs an exemption.

The gate lives in `api-js/.npmrc` rather than the repo root because `api-js` is the only first-party JS install (`cd api-js && npm install` in `.github/actions/ci/action.yml`). A root `.npmrc` would also risk leaking into the validator Docker build contexts.

Verified locally with Node 24.16 / npm 11.13 in `api-js`: `npm install` succeeded, `npm test` passed (13 tests), `npx publint` exited 0.

</details>


Link to Devin session: https://app.devin.ai/sessions/16fffbd620254ddfa3fa8e45f1f0247b
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 421b6a66460f1e3cd9235d6eb9e9258fe5ed7ace. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->