### PR TITLE
feat(snippets): Add web proxy snippets for the C++ client SDK 3.11+

### DIFF
--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-auth-cpp-c-v3-11.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-auth-cpp-c-v3-11.snippet.md
@@ -1,0 +1,17 @@
+---
+id: cpp-client-sdk/sdk-docs/features/webproxy/web-proxy-auth-cpp-c-v3-11
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Web proxy configuration with authentication for the C++ (client-side) SDK v3.11+ (C binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```c
+/* Requires an SDK build with -DLD_CURL_NETWORKING=ON. */
+LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
+LDClientConfigBuilder_HttpProperties_Proxy(
+    builder, "https://username:password@web-proxy.domain.com:8080");
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-auth-cpp-native-v3-11.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-auth-cpp-native-v3-11.snippet.md
@@ -1,0 +1,17 @@
+---
+id: cpp-client-sdk/sdk-docs/features/webproxy/web-proxy-auth-cpp-native-v3-11
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Web proxy configuration with authentication for the C++ (client-side) SDK v3.11+ (native).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```cpp
+// Requires an SDK build with -DLD_CURL_NETWORKING=ON.
+auto config_builder = client_side::ConfigBuilder("example-mobile-key");
+config_builder.HttpProperties().Proxy(
+    "https://username:password@web-proxy.domain.com:8080");
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-cpp-c-v3-11.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-cpp-c-v3-11.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cpp-client-sdk/sdk-docs/features/webproxy/web-proxy-cpp-c-v3-11
+sdk: cpp-client-sdk
+kind: reference
+lang: c
+description: Web proxy configuration for the C++ (client-side) SDK v3.11+ (C binding).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```c
+/* Requires an SDK build with -DLD_CURL_NETWORKING=ON. */
+LDClientConfigBuilder builder = LDClientConfigBuilder_New("example-mobile-key");
+LDClientConfigBuilder_HttpProperties_Proxy(builder, "https://web-proxy.domain.com:8080");
+```

--- a/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-cpp-native-v3-11.snippet.md
+++ b/snippets/sdks/cpp-client-sdk/snippets/sdk-docs/features/webproxy/web-proxy-cpp-native-v3-11.snippet.md
@@ -1,0 +1,16 @@
+---
+id: cpp-client-sdk/sdk-docs/features/webproxy/web-proxy-cpp-native-v3-11
+sdk: cpp-client-sdk
+kind: reference
+lang: cpp
+description: Web proxy configuration for the C++ (client-side) SDK v3.11+ (native).
+validation:
+  scaffold: cpp-client-sdk/scaffolds/cpp-client-syntax-only
+
+---
+
+```cpp
+// Requires an SDK build with -DLD_CURL_NETWORKING=ON.
+auto config_builder = client_side::ConfigBuilder("example-mobile-key");
+config_builder.HttpProperties().Proxy("https://web-proxy.domain.com:8080");
+```


### PR DESCRIPTION
## Summary

Adds four snippets to the `cpp-client-sdk` webproxy group: basic and authenticated proxy configuration, each in native C++ and C-binding form (`web-proxy[-auth]-cpp-{native,c}-v3-11`). The C++ client SDK supports proxy configuration from 3.11.0 when built with `-DLD_CURL_NETWORKING=ON`; until now the group only carried the EOL v2.x C SDK examples.

All four bind to the existing `cpp-client-syntax-only` scaffold, so they compile against the validator's pinned SDK (v3.11.4). The existing CI row for `cpp-client-sdk` picks them up; the full sdk-docs group was validated locally (all existing + new snippets pass).

The documented API was also validated end to end against a real SDK build with CURL networking: both surfaces route streaming through a configured local proxy, and a dead proxy blocks all traffic (no direct fallback).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **four** new reference snippets under `cpp-client-sdk` **webproxy** for **v3.11+**: basic and authenticated proxy setup, each for **native C++** (`client_side::ConfigBuilder` / `HttpProperties().Proxy`) and the **C binding** (`LDClientConfigBuilder_HttpProperties_Proxy`). Each snippet notes that proxy support requires building with `-DLD_CURL_NETWORKING=ON`.
> 
> These extend the existing webproxy group, which previously only documented **EOL v2.x** C SDK examples (`LDConfigSetProxyURI`). New snippets use the **`cpp-client-syntax-only`** scaffold (pinned v3.11.4) so existing `cpp-client-sdk` CI validation picks them up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b7d3cbb462772876946efb0b453a31ee80f345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->