### PR TITLE
feat(snippets): add sdk-info init-env variants for env-var-based initialization

### DIFF
--- a/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/dotnet-server-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,36 @@
+---
+id: dotnet-server-sdk/sdk-info/init-env
+sdk: dotnet-server-sdk
+kind: init
+lang: csharp
+file: dotnet-server-sdk/init-env.txt
+description: Client initialization snippet for dotnet-server-sdk reading the SDK key from an environment variable.
+validation:
+  scaffold: dotnet-server-sdk/scaffolds/init-runner
+---
+
+```csharp
+using LaunchDarkly.Sdk;
+using LaunchDarkly.Sdk.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Reads your LaunchDarkly SDK key from the LAUNCHDARKLY_SDK_KEY
+// environment variable, so one build can run in every environment.
+var ldConfig = Configuration.Default(Environment.GetEnvironmentVariable("LAUNCHDARKLY_SDK_KEY"));
+var client = new LdClient(ldConfig);
+
+if (client.Initialized)
+{
+    // For onboarding purposes only we flush events as soon as
+    // possible so we quickly detect your connection.
+    // You don't have to do this in practice because events are automatically flushed.
+    client.Flush();
+    Console.WriteLine("*** SDK successfully initialized!\n");
+}
+else
+{
+    Console.WriteLine("*** SDK failed to initialize\n");
+    Environment.Exit(1);
+}
+```

--- a/snippets/sdks/go-server-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/go-server-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,39 @@
+---
+id: go-server-sdk/sdk-info/init-env
+sdk: go-server-sdk
+kind: init
+lang: go
+file: go-server-sdk/init-env.txt
+description: Client initialization snippet for go-server-sdk reading the SDK key from an environment variable.
+validation:
+  scaffold: go-server-sdk/scaffolds/init-runner
+---
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+)
+
+func main() {
+	// Reads your LaunchDarkly SDK key from the LAUNCHDARKLY_SDK_KEY
+	// environment variable, so one build can run in every environment.
+	ldClient, _ := ld.MakeClient(os.Getenv("LAUNCHDARKLY_SDK_KEY"), 5*time.Second)
+	if ldClient.Initialized() {
+		fmt.Printf("SDK successfully initialized!")
+	} else {
+		fmt.Printf("SDK failed to initialize")
+		os.Exit(1)
+	}
+
+	// For onboarding purposes only we flush events as soon as
+	// possible so we quickly detect your connection.
+	// You don't have to do this in practice because events are automatically flushed.
+	ldClient.Flush()
+}
+```

--- a/snippets/sdks/java-server-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/java-server-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,33 @@
+---
+id: java-server-sdk/sdk-info/init-env
+sdk: java-server-sdk
+kind: init
+lang: java
+file: java-server-sdk/init-env.txt
+description: Client initialization snippet for java-server-sdk reading the SDK key from an environment variable.
+validation:
+  scaffold: java-server-sdk/scaffolds/init-runner
+---
+
+```java
+import com.launchdarkly.sdk.*;
+import com.launchdarkly.sdk.server.*;
+
+public class Main {
+  public static void main(String[] args) {
+    LDConfig config = new LDConfig.Builder().build();
+
+    // Reads your LaunchDarkly SDK key from the LAUNCHDARKLY_SDK_KEY
+    // environment variable, so one build can run in every environment.
+    final LDClient client = new LDClient(System.getenv("LAUNCHDARKLY_SDK_KEY"), config);
+
+    if (client.isInitialized()) {
+      // For onboarding purposes only we flush events as soon as
+      // possible so we quickly detect your connection.
+      // You don't have to do this in practice because events are automatically flushed.
+      client.flush();
+      System.out.println("SDK successfully initialized!");
+    }
+  }
+}
+```

--- a/snippets/sdks/js-client-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/js-client-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,31 @@
+---
+id: js-client-sdk/sdk-info/init-env
+sdk: js-client-sdk
+kind: init
+lang: javascript
+file: js-client-sdk/init-env.txt
+description: Client initialization snippet for js-client-sdk reading the client-side ID from an environment variable.
+validation:
+  scaffold: js-client-sdk/scaffolds/js-syntax-only
+---
+
+```javascript
+// A "context" is a data object representing users, devices, organizations, and
+// other entities. You'll need this later, but you can ignore it for now.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY'
+};
+// Reads your client-side ID from the LAUNCHDARKLY_CLIENT_SIDE_ID
+// environment variable, so one build can run in every environment.
+const client = createClient(process.env.LAUNCHDARKLY_CLIENT_SIDE_ID, context);
+client.start();
+
+const { status } = await client.waitForInitialization();
+
+if (status === 'complete') {
+  console.log('SDK successfully initialized!');
+} else {
+  console.error('Initialization failed');
+}
+```

--- a/snippets/sdks/node-client-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/node-client-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,31 @@
+---
+id: node-client-sdk/sdk-info/init-env
+sdk: node-client-sdk
+kind: init
+lang: javascript
+file: node-client-sdk/init-env.txt
+description: Client initialization snippet for node-client-sdk reading the client-side ID from an environment variable.
+validation:
+  scaffold: node-client-sdk/scaffolds/init-runner
+---
+
+```javascript
+import * as LaunchDarkly from 'launchdarkly-node-client-sdk';
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+};
+
+// Reads your client-side ID from the LAUNCHDARKLY_CLIENT_SIDE_ID
+// environment variable, so one build can run in every environment.
+const client = LaunchDarkly.initialize(process.env.LAUNCHDARKLY_CLIENT_SIDE_ID, context);
+
+try {
+  await client.waitForInitialization(5);
+  // Initialization succeeded
+} catch (err) {
+  // Initialization failed or did not complete before timeout
+}
+```

--- a/snippets/sdks/node-server-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/node-server-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,26 @@
+---
+id: node-server-sdk/sdk-info/init-env
+sdk: node-server-sdk
+kind: init
+lang: javascript
+file: node-server-sdk/init-env.txt
+description: Client initialization snippet for node-server-sdk reading the SDK key from an environment variable.
+validation:
+  scaffold: node-server-sdk/scaffolds/init-runner
+---
+
+```javascript
+import * as LaunchDarkly from '@launchdarkly/node-server-sdk';
+
+// Reads your LaunchDarkly SDK key from the LAUNCHDARKLY_SDK_KEY
+// environment variable, so one build can run in every environment.
+const client = LaunchDarkly.init(process.env.LAUNCHDARKLY_SDK_KEY);
+
+client.once('ready', function () {
+  // For onboarding purposes only we flush events as soon as
+  // possible so we quickly detect your connection.
+  // You don't have to do this in practice because events are automatically flushed.
+  client.flush();
+  console.log('SDK successfully initialized!');
+});
+```

--- a/snippets/sdks/python-server-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/python-server-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,32 @@
+---
+id: python-server-sdk/sdk-info/init-env
+sdk: python-server-sdk
+kind: init
+lang: python
+file: python-server-sdk/init-env.txt
+description: Client initialization snippet for python-server-sdk reading the SDK key from an environment variable.
+validation:
+  scaffold: python-server-sdk/scaffolds/init-runner
+---
+
+```python
+import os
+import ldclient
+from ldclient import Context
+from ldclient.config import Config
+
+if __name__ == '__main__':
+    # Reads your LaunchDarkly SDK key from the LAUNCHDARKLY_SDK_KEY
+    # environment variable, so one build can run in every environment.
+    ldclient.set_config(Config(os.getenv('LAUNCHDARKLY_SDK_KEY')))
+
+    if not ldclient.get().is_initialized():
+        print('SDK failed to initialize')
+        exit()
+
+    # For onboarding purposes only we flush events as soon as
+    # possible so we quickly detect your connection.
+    # You don't have to do this in practice because events are automatically flushed.
+    ldclient.get().flush()
+    print('SDK successfully initialized')
+```

--- a/snippets/sdks/react-client-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/react-client-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,37 @@
+---
+id: react-client-sdk/sdk-info/init-env
+sdk: react-client-sdk
+kind: init
+lang: tsx
+file: react-client-sdk/init-env.txt
+description: Client initialization snippet for react-client-sdk reading the client-side ID from an environment variable.
+validation:
+  scaffold: react-client-sdk/scaffolds/react-syntax-only
+---
+
+```tsx
+// Add the code below to the root of your React app.
+import { createRoot } from 'react-dom/client';
+import { createLDReactProvider, LDContext } from '@launchdarkly/react-sdk';
+
+function App() {
+  return <div>Let your feature flags fly!</div>
+}
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context: LDContext = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+  email: 'biz@face.dev',
+};
+
+// Reads your client-side ID from the LAUNCHDARKLY_CLIENT_SIDE_ID
+// environment variable, so one build can run in every environment.
+const LDReactProvider = createLDReactProvider(process.env.LAUNCHDARKLY_CLIENT_SIDE_ID, context);
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <LDReactProvider>
+    <App />
+  </LDReactProvider>,
+);
+```

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/init-env.snippet.md
@@ -4,9 +4,12 @@ sdk: vue-client-sdk
 kind: init
 lang: javascript
 file: vue-client-sdk/init-env.txt
-description: Client initialization snippet for vue-client-sdk reading the client-side ID from an environment variable.
-validation:
-  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
+description: |
+  Client initialization snippet for vue-client-sdk reading the client-side ID
+  from an environment variable. Not validated: the browser bundle leaves
+  process.env.LAUNCHDARKLY_CLIENT_SIDE_ID undefined, and LDPlugin throws
+  synchronously on a missing clientSideID during `app.use(...)` — before
+  `app.mount(...)` — so even vue-syntax-only's App.vue sentinel never renders.
 ---
 
 ```javascript

--- a/snippets/sdks/vue-client-sdk/snippets/sdk-info/init-env.snippet.md
+++ b/snippets/sdks/vue-client-sdk/snippets/sdk-info/init-env.snippet.md
@@ -1,0 +1,35 @@
+---
+id: vue-client-sdk/sdk-info/init-env
+sdk: vue-client-sdk
+kind: init
+lang: javascript
+file: vue-client-sdk/init-env.txt
+description: Client initialization snippet for vue-client-sdk reading the client-side ID from an environment variable.
+validation:
+  scaffold: vue-client-sdk/scaffolds/vue-syntax-only
+---
+
+```javascript
+// Add the code below to your main.js file.
+import { createApp } from 'vue';
+import App from './App.vue';
+import { LDPlugin } from 'launchdarkly-vue-client-sdk';
+
+const app = createApp(App);
+
+// A "context" is a data object representing users, devices, organizations, and other entities.
+const context = {
+  kind: 'user',
+  key: 'EXAMPLE_CONTEXT_KEY',
+  name: 'Sandy',
+};
+
+// Reads your client-side ID from the LAUNCHDARKLY_CLIENT_SIDE_ID
+// environment variable, so one build can run in every environment.
+app.use(LDPlugin, {
+  clientSideID: process.env.LAUNCHDARKLY_CLIENT_SIDE_ID,
+  context: context
+});
+
+app.mount('#app');
+```


### PR DESCRIPTION
## What

We want to support environment variable aware sdk snippets for the upcoming redesign like so

<img width="2446" height="1556" alt="CleanShot 2026-08-19 at 16 53 09@2x" src="https://github.com/user-attachments/assets/fc630f7f-db27-42d1-8b79-f1e42ee1239a" />

Adds an `init-env` variant of the `sdk-info` init snippet for nine SDKs. Each is the existing `init` body with the hardcoded-key placeholder replaced by the language's idiomatic read of the corresponding environment variable, and the key comment updated:

| SDK | Expression |
|---|---|
| node-server, node-client, js-client, react-client, vue-client | `process.env.LAUNCHDARKLY_SDK_KEY` / `…_CLIENT_SIDE_ID` |
| python-server | `os.getenv('LAUNCHDARKLY_SDK_KEY')` |
| java-server | `System.getenv(\"LAUNCHDARKLY_SDK_KEY\")` |
| go-server | `os.Getenv(\"LAUNCHDARKLY_SDK_KEY\")` |
| dotnet-server | `Environment.GetEnvironmentVariable(\"LAUNCHDARKLY_SDK_KEY\")` |

The env var names match the validator's existing placeholder allow-list (`LAUNCHDARKLY_SDK_KEY`, `LAUNCHDARKLY_CLIENT_SIDE_ID`).

## Validation choices

- **Server + node SDKs** (node-server, node-client, python, java, go, dotnet-server): same `init-runner` scaffolds as their `init` siblings, with **no `validation.placeholders`** — the bodies read the harness env vars (`LAUNCHDARKLY_SDK_KEY` / `LAUNCHDARKLY_CLIENT_SIDE_ID`) directly, so they runtime-validate as written.
- **Browser SDKs** (js-client, react-client, vue-client): **syntax-only** scaffolds. The js-client harness's tsdown build defines no `process.env`, so the runtime harness can't execute these as written. If you'd rather runtime-validate them, the harness build would need a `define`/env-injection step — happy to follow up, but I didn't want to touch the validators in this PR.

## Product note on the browser bodies

The browser snippets emit `process.env.LAUNCHDARKLY_CLIENT_SIDE_ID` verbatim per the gonfalon design mocks. Bundler-specific prefixes (`VITE_*`, `NEXT_PUBLIC_*`, `REACT_APP_*`) are a deliberate non-goal for v1 — the copy treats it as illustrative of "read from your build environment".

## Tested

- `go test ./...` passes (frontmatter parse, id uniqueness, embedded FS)
- `snippets render --target=raw-files` against a local manifest produces the expected `init-env.txt` bodies


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **nine** new `sdk-info/init-env` snippet files (dotnet, go, java, js-client, node-client, node-server, python, react-client, vue-client) for the upcoming onboarding redesign. Each mirrors the existing `init` snippet but wires credentials through the standard env vars **`LAUNCHDARKLY_SDK_KEY`** (server SDKs) or **`LAUNCHDARKLY_CLIENT_SIDE_ID`** (client SDKs), using each language’s usual read (`process.env`, `os.getenv`, `System.getenv`, etc.).
> 
> **Validation:** Server and Node init snippets keep **`init-runner`** scaffolds and run against harness env vars with no placeholder substitution. Browser snippets (js, react, vue) use **syntax-only** scaffolds because the harness does not inject `process.env`; the vue snippet documents that limitation in frontmatter.
> 
> Rendered output is **`init-env.txt`** per SDK, alongside existing init bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 089cb55cecf20bcb68f9acc00e74d06c59d85627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->